### PR TITLE
Apply filter to newly created threads

### DIFF
--- a/SystemInformer/prpgthrd.c
+++ b/SystemInformer/prpgthrd.c
@@ -1551,6 +1551,9 @@ INT_PTR CALLBACK PhpProcessThreadsDlgProc(
 
             PhTickThreadNodes(&threadsContext->ListContext);
 
+            // Refresh the visible nodes.
+            PhApplyTreeNewFilters(&threadsContext->ListContext.TreeFilterSupport);
+
             if (count != 0)
                 TreeNew_SetRedraw(threadsContext->TreeNewHandle, TRUE);
 


### PR DESCRIPTION
Newly created threads were added to the list because a call to filter them was missing.