### PR TITLE
Fix process private/shared commit statistics

### DIFF
--- a/SystemInformer/prpgstat.c
+++ b/SystemInformer/prpgstat.c
@@ -311,7 +311,7 @@ VOID PhpUpdateProcessStatistics(
         if (Context->ProcessHandle)
         {
             PH_PROCESS_WS_COUNTERS wsCounters;
-            APP_MEMORY_INFORMATION appMemoryInfo;
+            PH_APP_MEMORY_INFORMATION appMemoryInfo;
 
             if (NT_SUCCESS(PhGetProcessWsCounters(Context->ProcessHandle, &wsCounters)))
             {

--- a/SystemInformer/prpgstat.c
+++ b/SystemInformer/prpgstat.c
@@ -311,7 +311,7 @@ VOID PhpUpdateProcessStatistics(
         if (Context->ProcessHandle)
         {
             PH_PROCESS_WS_COUNTERS wsCounters;
-            PROCESS_JOB_MEMORY_INFO appMemoryInfo;
+            APP_MEMORY_INFORMATION appMemoryInfo;
 
             if (NT_SUCCESS(PhGetProcessWsCounters(Context->ProcessHandle, &wsCounters)))
             {
@@ -320,17 +320,16 @@ VOID PhpUpdateProcessStatistics(
                 PhMoveReference(&Context->SharedWs, PhFormatSize((ULONG64)wsCounters.NumberOfSharedPages * PAGE_SIZE, ULONG_MAX));
                 Context->GotWsCounters = TRUE;
             }
-
             if (NT_SUCCESS(PhGetProcessAppMemoryInformation(Context->ProcessHandle, &appMemoryInfo)))
             {
-                PhMoveReference(&Context->SharedCommitUsage, PhFormatSize(appMemoryInfo.SharedCommitUsage, ULONG_MAX));
+                PhMoveReference(&Context->SharedCommitUsage, PhFormatSize(appMemoryInfo.TotalCommitUsage - appMemoryInfo.PrivateCommitUsage, ULONG_MAX));
                 PhMoveReference(&Context->PrivateCommitUsage, PhFormatSize(appMemoryInfo.PrivateCommitUsage, ULONG_MAX));
                 PhMoveReference(&Context->PeakPrivateCommitUsage, PhFormatSize(appMemoryInfo.PeakPrivateCommitUsage, ULONG_MAX));
                 //if (appMemoryInfo.PrivateCommitLimit)
                 //    PhMoveReference(&Context->PrivateCommitLimit, PhFormatSize(appMemoryInfo.PrivateCommitLimit, ULONG_MAX));
                 //if (appMemoryInfo.TotalCommitLimit)
                 //    PhMoveReference(&Context->TotalCommitLimit, PhFormatSize(appMemoryInfo.TotalCommitLimit, ULONG_MAX));
-            }          
+            }
         }
 
         if (!Context->GotCycles)

--- a/phlib/include/phnativeinl.h
+++ b/phlib/include/phnativeinl.h
@@ -874,15 +874,23 @@ PhSetProcessBreakOnTermination(
         );
 }
 
+typedef struct _PH_APP_MEMORY_INFORMATION
+{
+    ULONG64 AvailableCommit;
+    ULONG64 PrivateCommitUsage;
+    ULONG64 PeakPrivateCommitUsage;
+    ULONG64 TotalCommitUsage;
+} PH_APP_MEMORY_INFORMATION, * PPH_APP_MEMORY_INFORMATION;
+
 FORCEINLINE
 NTSTATUS
 PhGetProcessAppMemoryInformation(
     _In_ HANDLE ProcessHandle,
-    _Out_ PAPP_MEMORY_INFORMATION AppMemoryInfo
+    _Out_ PPH_APP_MEMORY_INFORMATION AppMemoryInfo
     )
 {
     NTSTATUS status;
-    APP_MEMORY_INFORMATION appMemoryInfo = {0};
+    PH_APP_MEMORY_INFORMATION appMemoryInfo = {0};
     VM_COUNTERS_EX2 vmCounters;
 
     status = NtQueryInformationProcess(


### PR DESCRIPTION
Currently it shows the information only for processes in a job.
And actually it is not correct information at all.
Because it contains grouped commit statistics for all processes in the job.

We will use `VM_COUNTERS_EX2` to obtain correct information for process on modern systems.
And use job info as fall-back for older systems.