### PR TITLE
UserNotes patch for #1317

### DIFF
--- a/plugins/UserNotes/main.c
+++ b/plugins/UserNotes/main.c
@@ -126,6 +126,11 @@ NTSTATUS GetProcessAffinity(
         &groupAffinity
         );
 
+    if (status == STATUS_INVALID_PARAMETER || status == STATUS_INVALID_INFO_CLASS) // GH#1317: Required for Windows 7 (jxy-s)
+    {
+        status = PhGetProcessAffinityMask(ProcessHandle, &groupAffinity.Mask);
+    }
+
     if (NT_SUCCESS(status))
     {
         *Affinity = groupAffinity.Mask;


### PR DESCRIPTION
This should patch #1317 but is not a comprehensive fix for `UserNotes`. It it looks like, in general, `UserNotes` needs update to be group-aware.