### PR TITLE
harden image load protections

### DIFF
--- a/KSystemInformer/include/kph.h
+++ b/KSystemInformer/include/kph.h
@@ -787,6 +787,16 @@ VOID KphCleanupHashing(
     VOID
     );
 
+_IRQL_requires_max_(APC_LEVEL)
+VOID KphReferenceHashingInfrastructure(
+    VOID
+    );
+
+_IRQL_requires_max_(APC_LEVEL)
+VOID KphDereferenceHashingInfrastructure(
+    VOID
+    );
+
 _IRQL_requires_max_(PASSIVE_LEVEL)
 _Must_inspect_result_
 NTSTATUS KphHashFile(
@@ -842,6 +852,16 @@ NTSTATUS KphInitializeSigning(
 
 _IRQL_requires_max_(PASSIVE_LEVEL)
 VOID KphCleanupSigning(
+    VOID
+    );
+
+_IRQL_requires_max_(APC_LEVEL)
+VOID KphReferenceSigningInfrastructure(
+    VOID
+    );
+
+_IRQL_requires_max_(APC_LEVEL)
+VOID KphDereferenceSigningInfrastructure(
     VOID
     );
 

--- a/KSystemInformer/include/pooltags.h
+++ b/KSystemInformer/include/pooltags.h
@@ -62,6 +62,11 @@
 
 #define KPH_TAG_HASHING_BUFFER                  '0HpK'
 #define KPH_TAG_AUTHENTICODE_SIG                '1HpK'
+#define KPH_TAG_HASHING_INFRA                   '2HpK'
+
+// sign 
+
+#define KPH_TAG_SIGNING_INFRA                   '0SpK'
 
 // informer
 

--- a/KSystemInformer/kphobject.c
+++ b/KSystemInformer/kphobject.c
@@ -18,7 +18,7 @@
 //
 
 static volatile LONG KphpObjectTypeCount = 0;
-static KPH_OBJECT_TYPE KphpObjectTypes[7];
+static KPH_OBJECT_TYPE KphpObjectTypes[9];
 
 C_ASSERT(ARRAYSIZE(KphpObjectTypes) < MAXUCHAR);
 


### PR DESCRIPTION
This hardens the image load protections by enforcing no user writable references on image loads. This mitigates against DLL masquerading techniques. Additionally, there was a bug in the image load protections in the case where and APC was queued to do signing/hashing checks. This was addressed by enabling that area to reference those parts of the infrastructure. This enables cleanup to naturally occur when the APC eventually fires.