### PR TITLE
harden self injection

### DIFF
--- a/KSystemInformer/protection.c
+++ b/KSystemInformer/protection.c
@@ -578,7 +578,6 @@ VOID KphApplyObProtections(
     PKPH_PROCESS_CONTEXT process;
     PKPH_THREAD_CONTEXT actor;
     BOOLEAN releaseLock;
-    KPH_PROCESS_STATE processState;
     ACCESS_MASK allowedAccessMask;
     ACCESS_MASK desiredAccess;
     PACCESS_MASK access;
@@ -635,12 +634,6 @@ VOID KphApplyObProtections(
     releaseLock = TRUE;
 
     if (!process->Protected)
-    {
-        goto Exit;
-    }
-
-    processState = KphGetProcessState(actor->ProcessContext);
-    if ((processState & KPH_PROCESS_STATE_HIGH) == KPH_PROCESS_STATE_HIGH)
     {
         goto Exit;
     }

--- a/phlib/include/kphuser.h
+++ b/phlib/include/kphuser.h
@@ -250,6 +250,13 @@ typedef enum _KPH_LEVEL
 PHLIBAPI
 KPH_LEVEL
 NTAPI
+KphProcessLevel(
+    _In_ HANDLE ProcessHandle
+    );
+
+PHLIBAPI
+KPH_LEVEL
+NTAPI
 KphLevel(
     VOID
     );

--- a/phlib/kph.c
+++ b/phlib/kph.c
@@ -1155,8 +1155,8 @@ KPH_PROCESS_STATE KphGetCurrentProcessState(
     return KphGetProcessState(NtCurrentProcess());
 }
 
-KPH_LEVEL KphLevel(
-    VOID
+KPH_LEVEL KphProcessLevel(
+    _In_ HANDLE ProcessHandle
     )
 {
     KPH_PROCESS_STATE state;
@@ -1172,7 +1172,7 @@ KPH_LEVEL KphLevel(
     // necessary. 
     //
 
-    state = KphGetCurrentProcessState();
+    state = KphGetProcessState(ProcessHandle);
 
     if ((state & KPH_PROCESS_STATE_MAXIMUM) == KPH_PROCESS_STATE_MAXIMUM)
         return KphLevelMax;
@@ -1190,4 +1190,12 @@ KPH_LEVEL KphLevel(
         return KphLevelMin;
 
     return KphLevelNone;
+
+}
+
+KPH_LEVEL KphLevel(
+    VOID
+    )
+{
+    return KphProcessLevel(NtCurrentProcess());
 }

--- a/phlib/native.c
+++ b/phlib/native.c
@@ -1929,6 +1929,11 @@ NTSTATUS PhLoadDllProcess(
     HANDLE threadHandle = NULL;
     HANDLE powerRequestHandle = NULL;
 
+    if (KphProcessLevel(ProcessHandle) > KphLevelMed)
+    {
+        return STATUS_ACCESS_DENIED;
+    }
+
 #ifdef _WIN64
     status = PhGetProcessIsWow64(ProcessHandle, &isWow64);
 


### PR DESCRIPTION
These changes harden against self injection. This is achieved by two changes. First, the object protections are hardened to strip access from other system informer processes. The initial relaxed mitigations in this area are unnecessary. Second, we check if the target process is above medium level in `PhLoadDllProcess`. This prevents inadvertently loading a DLL into the same process and gives extra guarantee against plugins making the call. All that said, even _if_ an untrusted module is loaded into the process the process state level will immediately drop to medium or below and access to the driver will be restricted anyway. So ultimately these changes are to harden against inadvertently restricting access by poking about.