### PR TITLE
migrate poolmon to extendedtools

### DIFF
--- a/plugins/ExtendedTools/ExtendedTools.rc
+++ b/plugins/ExtendedTools/ExtendedTools.rc
@@ -273,6 +273,25 @@ BEGIN
     GROUPBOX        "Average display latency",IDC_GROUPFPSDISPLAYLATENCY,7,184,355,22,0,WS_EX_TRANSPARENT
 END
 
+IDD_POOL DIALOGEX 0, 0, 641, 383
+STYLE DS_SETFONT | DS_FIXEDSYS | WS_MINIMIZEBOX | WS_MAXIMIZEBOX | WS_POPUP | WS_CAPTION | WS_SYSMENU | WS_THICKFRAME
+EXSTYLE WS_EX_APPWINDOW
+CAPTION "Pool Table"
+FONT 8, "MS Shell Dlg", 400, 0, 0x1
+BEGIN
+    CONTROL         "",IDC_POOLTREE,"PhTreeNew",WS_CLIPSIBLINGS | WS_CLIPCHILDREN | WS_TABSTOP | 0xa,4,3,633,361,WS_EX_CLIENTEDGE
+    EDITTEXT        IDC_POOLSEARCH,4,366,169,14,ES_AUTOHSCROLL
+    PUSHBUTTON      "Close",IDCANCEL,587,366,50,14
+END
+
+IDD_BIGPOOL DIALOGEX 0, 0, 469, 273
+STYLE DS_SETFONT | DS_FIXEDSYS | WS_MINIMIZEBOX | WS_MAXIMIZEBOX | WS_POPUP | WS_CAPTION | WS_SYSMENU | WS_THICKFRAME
+CAPTION "Large Pool Allocations"
+FONT 8, "MS Shell Dlg", 400, 0, 0x1
+BEGIN
+    DEFPUSHBUTTON   "Close",IDCANCEL,413,252,50,14
+    CONTROL         "",IDC_BIGPOOLLIST,"SysListView32",LVS_REPORT | LVS_SINGLESEL | LVS_ALIGNLEFT | WS_BORDER | WS_TABSTOP,7,7,455,243
+END
 
 /////////////////////////////////////////////////////////////////////////////
 //
@@ -386,13 +405,49 @@ BEGIN
         TOPMARGIN, 7
         BOTTOMMARGIN, 230
     END
+
+    IDD_POOL, DIALOG
+    BEGIN
+        LEFTMARGIN, 4
+        RIGHTMARGIN, 637
+        TOPMARGIN, 3
+        BOTTOMMARGIN, 380
+    END
+
+    IDD_BIGPOOL, DIALOG
+    BEGIN
+        LEFTMARGIN, 7
+        RIGHTMARGIN, 462
+        TOPMARGIN, 7
+        BOTTOMMARGIN, 266
+    END
 END
 #endif    // APSTUDIO_INVOKED
 
+/////////////////////////////////////////////////////////////////////////////
+//
+// AFX_DIALOG_LAYOUT
+//
+
+IDD_POOL AFX_DIALOG_LAYOUT
+BEGIN
+    0
+END
+
+IDD_BIGPOOL AFX_DIALOG_LAYOUT
+BEGIN
+    0
+END
+
+/////////////////////////////////////////////////////////////////////////////
+//
+// TXT
+//
+
+IDR_TXT_POOLTAGS        TXT                     "resources\\pooltag.txt"
+
 #endif    // English (Australia) resources
 /////////////////////////////////////////////////////////////////////////////
-
-
 
 #ifndef APSTUDIO_INVOKED
 /////////////////////////////////////////////////////////////////////////////
@@ -403,4 +458,3 @@ END
 
 /////////////////////////////////////////////////////////////////////////////
 #endif    // not APSTUDIO_INVOKED
-

--- a/plugins/ExtendedTools/ExtendedTools.vcxproj
+++ b/plugins/ExtendedTools/ExtendedTools.vcxproj
@@ -122,6 +122,11 @@
     <ClCompile Include="gpusys.c" />
     <ClCompile Include="iconext.c" />
     <ClCompile Include="framemon.cpp" />
+    <ClCompile Include="pooldb.c" />
+    <ClCompile Include="pooldialog.c" />
+    <ClCompile Include="pooldialogbig.c" />
+    <ClCompile Include="pooltable.c" />
+    <ClCompile Include="pooltree.c" />
     <ClCompile Include="PresentMon\PresentMon.cpp" />
     <ClCompile Include="PresentMon\PresentMonTraceConsumer.cpp" />
     <ClCompile Include="PresentMon\TraceConsumer.cpp" />
@@ -150,6 +155,7 @@
     <ClInclude Include="gpumini.h" />
     <ClInclude Include="gpumon.h" />
     <ClInclude Include="gpusys.h" />
+    <ClInclude Include="poolmon.h" />
     <ClInclude Include="PresentMon\ETW\Microsoft_Windows_D3D9.h" />
     <ClInclude Include="PresentMon\ETW\Microsoft_Windows_Dwm_Core.h" />
     <ClInclude Include="PresentMon\ETW\Microsoft_Windows_DXGI.h" />
@@ -167,6 +173,9 @@
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="ExtendedTools.rc" />
+  </ItemGroup>
+  <ItemGroup>
+    <Text Include="resources\pooltag.txt" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/plugins/ExtendedTools/ExtendedTools.vcxproj.filters
+++ b/plugins/ExtendedTools/ExtendedTools.vcxproj.filters
@@ -123,6 +123,21 @@
     <ClCompile Include="PresentMon\TraceConsumer.cpp">
       <Filter>Source Files\PresentMon</Filter>
     </ClCompile>
+    <ClCompile Include="pooldb.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="pooldialog.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="pooldialogbig.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="pooltable.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="pooltree.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="resource.h">
@@ -185,6 +200,9 @@
     <ClInclude Include="extension\plugin.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="poolmon.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include="CHANGELOG.txt" />
@@ -193,5 +211,10 @@
     <ResourceCompile Include="ExtendedTools.rc">
       <Filter>Resource Files</Filter>
     </ResourceCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <Text Include="resources\pooltag.txt">
+      <Filter>Resource Files</Filter>
+    </Text>
   </ItemGroup>
 </Project>

--- a/plugins/ExtendedTools/exttools.h
+++ b/plugins/ExtendedTools/exttools.h
@@ -81,6 +81,10 @@ extern BOOLEAN EtPropagateCpuUsage;
 #define SETTING_NAME_FW_TREE_LIST_SORT (PLUGIN_NAME L".FwTreeSort")
 #define SETTING_NAME_FW_IGNORE_PORTSCAN (PLUGIN_NAME L".FwIgnorePortScan")
 #define SETTING_NAME_SHOWSYSINFOGRAPH (PLUGIN_NAME L".ToolbarShowSystemInfoGraph")
+#define SETTING_NAME_POOL_WINDOW_POSITION (PLUGIN_NAME L".PoolWindowPosition")
+#define SETTING_NAME_POOL_WINDOW_SIZE (PLUGIN_NAME L".PoolWindowSize")
+#define SETTING_NAME_POOL_TREE_LIST_COLUMNS (PLUGIN_NAME L".PoolTreeViewColumns")
+#define SETTING_NAME_POOL_TREE_LIST_SORT (PLUGIN_NAME L".PoolTreeViewSort")
 
 VOID EtLoadSettings(
     VOID
@@ -1122,6 +1126,12 @@ HWND NTAPI FwToolStatusGetTreeNewHandle(
 
 VOID EtProcessFramesPropertiesInitializing(
     _In_ PVOID Parameter
+    );
+
+// poolmon
+
+VOID ShowPoolMonDialog(
+    VOID
     );
 
 #endif

--- a/plugins/ExtendedTools/pooldb.c
+++ b/plugins/ExtendedTools/pooldb.c
@@ -1,0 +1,320 @@
+/*
+ * Copyright (c) 2022 Winsider Seminars & Solutions, Inc.  All rights reserved.
+ *
+ * This file is part of System Informer.
+ *
+ * Authors:
+ *
+ *     dmex    2016
+ *
+ */
+
+#include "exttools.h"
+#include "poolmon.h"
+
+PPH_STRING TrimString(
+    _In_ PPH_STRING String
+    )
+{
+    static PH_STRINGREF whitespace = PH_STRINGREF_INIT(L" \t");
+    PH_STRINGREF sr = String->sr;
+    PhTrimStringRef(&sr, &whitespace, 0);
+    return PhCreateString2(&sr);
+}
+
+PPH_STRING FindPoolTagFilePath(
+    VOID
+    )
+{
+    static struct
+    {
+        PH_STRINGREF AppendPath;
+    } locations[] =
+    {
+#ifdef _WIN64
+        { PH_STRINGREF_INIT(L"%ProgramFiles(x86)%\\Windows Kits\\10\\Debuggers\\x64\\triage\\pooltag.txt") },
+        { PH_STRINGREF_INIT(L"%ProgramFiles(x86)%\\Windows Kits\\8.1\\Debuggers\\x64\\triage\\pooltag.txt") },
+        { PH_STRINGREF_INIT(L"%ProgramFiles(x86)%\\Windows Kits\\8.0\\Debuggers\\x64\\triage\\pooltag.txt") },
+        { PH_STRINGREF_INIT(L"%ProgramFiles%\\Debugging Tools for Windows (x64)\\triage\\pooltag.txt") }
+#else
+        { PH_STRINGREF_INIT(L"%ProgramFiles%\\Windows Kits\\10\\Debuggers\\x86\\triage\\pooltag.txt") },
+        { PH_STRINGREF_INIT(L"%ProgramFiles%\\Windows Kits\\8.1\\Debuggers\\x86\\triage\\pooltag.txt") },
+        { PH_STRINGREF_INIT(L"%ProgramFiles%\\Windows Kits\\8.0\\Debuggers\\x86\\triage\\pooltag.txt") },
+        { PH_STRINGREF_INIT(L"%ProgramFiles%\\Debugging Tools for Windows (x86)\\triage\\pooltag.txt") }
+#endif
+    };
+ 
+    PPH_STRING path;
+    ULONG i;
+   
+    for (i = 0; i < RTL_NUMBER_OF(locations); i++)
+    {
+        if (path = PhExpandEnvironmentStrings(&locations[i].AppendPath))
+        {
+            if (RtlDoesFileExists_U(path->Buffer))
+                return path;
+
+            PhDereferenceObject(path);
+        }
+    }
+
+    return NULL;
+}
+
+
+BOOLEAN PmPoolTagListHashtableEqualFunction(
+    _In_ PVOID Entry1,
+    _In_ PVOID Entry2
+    )
+{
+    PPOOL_TAG_LIST_ENTRY poolTagNode1 = *(PPOOL_TAG_LIST_ENTRY *)Entry1;
+    PPOOL_TAG_LIST_ENTRY poolTagNode2 = *(PPOOL_TAG_LIST_ENTRY *)Entry2;
+
+    return poolTagNode1->TagUlong == poolTagNode2->TagUlong;
+}
+
+ULONG PmPoolTagListHashtableHashFunction(
+    _In_ PVOID Entry
+    )
+{
+    return (*(PPOOL_TAG_LIST_ENTRY*)Entry)->TagUlong;
+}
+
+PPOOL_TAG_LIST_ENTRY FindPoolTagListEntry(
+    _In_ PPOOLTAG_CONTEXT Context,
+    _In_ ULONG PoolTag
+    )
+{
+    POOL_TAG_LIST_ENTRY lookupWindowNode;
+    PPOOL_TAG_LIST_ENTRY lookupWindowNodePtr = &lookupWindowNode;
+    PPOOL_TAG_LIST_ENTRY *windowNode;
+
+    lookupWindowNode.TagUlong = PoolTag;
+
+    windowNode = (PPOOL_TAG_LIST_ENTRY*)PhFindEntryHashtable(
+        Context->PoolTagDbHashtable,
+        &lookupWindowNodePtr
+        );
+
+    if (windowNode)
+        return *windowNode;
+    else
+        return NULL;
+}
+
+VOID LoadPoolTagDatabase(
+    _In_ PPOOLTAG_CONTEXT Context
+    )
+{
+    static PH_STRINGREF skipPoolTagFileHeader = PH_STRINGREF_INIT(L"\r\n\r\n");
+    static PH_STRINGREF skipPoolTagFileLine = PH_STRINGREF_INIT(L"\r\n");
+
+    PPH_STRING poolTagFilePath;
+    HANDLE fileHandle = NULL;
+    LARGE_INTEGER fileSize;
+    ULONG stringBufferLength;
+    PSTR stringBuffer;
+    PPH_STRING utf16StringBuffer = NULL;
+    IO_STATUS_BLOCK isb;
+
+    Context->PoolTagDbList = PhCreateList(100);
+    Context->PoolTagDbHashtable = PhCreateHashtable(
+        sizeof(PPOOL_TAG_LIST_ENTRY),
+        PmPoolTagListHashtableEqualFunction,
+        PmPoolTagListHashtableHashFunction,
+        100
+        );
+
+    if (poolTagFilePath = FindPoolTagFilePath())
+    {
+        if (!NT_SUCCESS(PhCreateFileWin32(
+            &fileHandle,
+            poolTagFilePath->Buffer,
+            FILE_GENERIC_READ,
+            FILE_ATTRIBUTE_NORMAL,
+            FILE_SHARE_READ | FILE_SHARE_DELETE,
+            FILE_OPEN,
+            FILE_NON_DIRECTORY_FILE | FILE_SYNCHRONOUS_IO_NONALERT
+            )))
+        {
+            PhDereferenceObject(poolTagFilePath);
+            return;
+        }
+
+        if (!NT_SUCCESS(PhGetFileSize(fileHandle, &fileSize)))
+        {
+            NtClose(fileHandle);
+            PhDereferenceObject(poolTagFilePath);
+            return;
+        }
+
+        if (fileSize.QuadPart == 0)
+        {
+            NtClose(fileHandle);
+            PhDereferenceObject(poolTagFilePath);
+            return;
+        }
+
+        stringBufferLength = (ULONG)fileSize.QuadPart + 1;
+        stringBuffer = PhAllocate(stringBufferLength);
+        memset(stringBuffer, 0, stringBufferLength);
+
+        if (NT_SUCCESS(NtReadFile(
+            fileHandle,
+            NULL,
+            NULL,
+            NULL,
+            &isb,
+            stringBuffer,
+            (ULONG)fileSize.QuadPart,
+            NULL,
+            NULL
+            )))
+        {
+            utf16StringBuffer = PhZeroExtendToUtf16(stringBuffer);
+        }
+
+        PhFree(stringBuffer);
+        NtClose(fileHandle);
+        PhDereferenceObject(poolTagFilePath);
+    }
+    else
+    {
+        HRSRC resourceHandle;
+
+        // Find the resource
+        if (resourceHandle = FindResource(
+            PluginInstance->DllBase,
+            MAKEINTRESOURCE(IDR_TXT_POOLTAGS),
+            L"TXT")
+            )
+        {
+            ULONG resourceLength;
+            HGLOBAL resourceBuffer;
+            PSTR utf16Buffer;
+
+            // Get the resource length
+            resourceLength = SizeofResource(PluginInstance->DllBase, resourceHandle);
+
+            // Load the resource
+            if (resourceBuffer = LoadResource(PluginInstance->DllBase, resourceHandle))
+            {
+                utf16Buffer = (PSTR)LockResource(resourceBuffer);
+
+                utf16StringBuffer = PhZeroExtendToUtf16Ex(utf16Buffer, resourceLength);
+            }
+
+            FreeResource(resourceBuffer);
+        }
+    }
+
+    if (utf16StringBuffer)
+    {
+        PH_STRINGREF firstPart;
+        PH_STRINGREF remainingPart;
+        PH_STRINGREF poolTagPart;
+        PH_STRINGREF binaryNamePart;
+        PH_STRINGREF descriptionPart;
+
+        remainingPart = utf16StringBuffer->sr;
+
+        PhSplitStringRefAtString(&remainingPart, &skipPoolTagFileHeader, TRUE, &firstPart, &remainingPart);
+
+        while (remainingPart.Length != 0)
+        {
+            PhSplitStringRefAtString(&remainingPart, &skipPoolTagFileLine, TRUE, &firstPart, &remainingPart);
+
+            if (firstPart.Length != 0)
+            {
+                PPOOL_TAG_LIST_ENTRY entry;
+                PPH_STRING poolTagString;
+                PPH_STRING poolTag;
+                PPH_STRING binaryName;
+                PPH_STRING description;
+
+                if (!PhSplitStringRefAtChar(&firstPart, '-', &poolTagPart, &firstPart))
+                    continue;
+                if (!PhSplitStringRefAtChar(&firstPart, '-', &binaryNamePart, &firstPart))
+                    continue;
+                // Note: Some entries don't have descriptions
+                PhSplitStringRefAtChar(&firstPart, '-', &descriptionPart, &firstPart);
+
+                poolTag = PhCreateString2(&poolTagPart);
+                binaryName = PhCreateString2(&binaryNamePart);
+                description = PhCreateString2(&descriptionPart);
+
+                entry = PhAllocate(sizeof(POOL_TAG_LIST_ENTRY));
+                memset(entry, 0, sizeof(POOL_TAG_LIST_ENTRY));
+
+                // Strip leading/trailing space characters.
+                poolTagString = TrimString(poolTag);
+                entry->BinaryNameString = TrimString(binaryName);
+                entry->DescriptionString = TrimString(description);
+
+                // Convert the poolTagString to ULONG
+                PhConvertUtf16ToUtf8Buffer(
+                    entry->Tag,
+                    sizeof(entry->Tag),
+                    NULL,
+                    poolTagString->Buffer,
+                    poolTagString->Length
+                    );
+
+                PhAcquireQueuedLockExclusive(&Context->PoolTagListLock);
+                PhAddEntryHashtable(Context->PoolTagDbHashtable, &entry);
+                PhAddItemList(Context->PoolTagDbList, entry);
+                PhReleaseQueuedLockExclusive(&Context->PoolTagListLock);
+
+                PhDereferenceObject(description);
+                PhDereferenceObject(binaryName);
+                PhDereferenceObject(poolTag);
+                PhDereferenceObject(poolTagString);
+            }
+        }
+
+        PhDereferenceObject(utf16StringBuffer);
+    }
+}
+
+VOID FreePoolTagDatabase(
+    _In_ PPOOLTAG_CONTEXT Context
+    )
+{
+    PhAcquireQueuedLockExclusive(&Context->PoolTagListLock);
+
+    for (ULONG i = 0; i < Context->PoolTagDbList->Count; i++)
+    {
+        PPOOL_TAG_LIST_ENTRY entry = Context->PoolTagDbList->Items[i];
+
+        PhDereferenceObject(entry->DescriptionString);
+        PhDereferenceObject(entry->BinaryNameString);
+        PhFree(entry);
+    }
+ 
+    PhClearHashtable(Context->PoolTagDbHashtable);
+    PhClearList(Context->PoolTagDbList);
+
+    PhReleaseQueuedLockExclusive(&Context->PoolTagListLock);
+}
+
+VOID UpdatePoolTagBinaryName(
+    _In_ PPOOLTAG_CONTEXT Context,
+    _In_ PPOOL_ITEM PoolEntry,
+    _In_ ULONG TagUlong
+    )
+{
+    PPOOL_TAG_LIST_ENTRY client;
+
+    if (client = FindPoolTagListEntry(Context, TagUlong))
+    {
+        PoolEntry->BinaryNameString = client->BinaryNameString;
+        PoolEntry->DescriptionString = client->DescriptionString;
+
+        //if (PhStartsWithString2(PoolEntry->BinaryNameString, L"nt!", FALSE))
+        //    PoolEntry->Type = TPOOLTAG_TREE_ITEM_TYPE_OBJECT;
+
+        //if (PhEndsWithString2(PoolEntry->BinaryNameString, L".sys", FALSE))
+            //PoolEntry->Type = TPOOLTAG_TREE_ITEM_TYPE_DRIVER;
+    }
+}
+

--- a/plugins/ExtendedTools/pooldialog.c
+++ b/plugins/ExtendedTools/pooldialog.c
@@ -1,0 +1,417 @@
+/*
+ * Copyright (c) 2022 Winsider Seminars & Solutions, Inc.  All rights reserved.
+ *
+ * This file is part of System Informer.
+ *
+ * Authors:
+ *
+ *     dmex    2016
+ *
+ */
+
+#include "exttools.h"
+#include "poolmon.h"
+#include "commonutil.h"
+
+static HWND PoolTagDialogHandle = NULL;
+static HANDLE PoolTagDialogThreadHandle = NULL;
+static PH_EVENT PoolTagDialogInitializedEvent = PH_EVENT_INIT;
+
+VOID UpdatePoolTagTable(
+    _Inout_ PPOOLTAG_CONTEXT Context
+    )
+{
+    PSYSTEM_POOLTAG_INFORMATION poolTagTable;
+    ULONG i;
+    
+    if (!NT_SUCCESS(EnumPoolTagTable(&poolTagTable)))
+    {
+        PhDereferenceObject(Context);
+        return;
+    }
+    
+    for (i = 0; i < poolTagTable->Count; i++)
+    {
+        PPOOLTAG_ROOT_NODE node;
+        SYSTEM_POOLTAG poolTagInfo;
+
+        poolTagInfo = poolTagTable->TagInfo[i];
+    
+        if (node = PmFindPoolTagNode(Context, poolTagInfo.TagUlong))
+        {
+            PhUpdateDelta(&node->PoolItem->PagedAllocsDelta, poolTagInfo.PagedAllocs);
+            PhUpdateDelta(&node->PoolItem->PagedFreesDelta, poolTagInfo.PagedFrees);
+            PhUpdateDelta(&node->PoolItem->PagedCurrentDelta, poolTagInfo.PagedAllocs - poolTagInfo.PagedFrees);
+            PhUpdateDelta(&node->PoolItem->PagedTotalSizeDelta, poolTagInfo.PagedUsed);     
+            PhUpdateDelta(&node->PoolItem->NonPagedAllocsDelta, poolTagInfo.NonPagedAllocs);
+            PhUpdateDelta(&node->PoolItem->NonPagedFreesDelta, poolTagInfo.NonPagedFrees);
+            PhUpdateDelta(&node->PoolItem->NonPagedCurrentDelta, poolTagInfo.NonPagedAllocs - poolTagInfo.NonPagedFrees);
+            PhUpdateDelta(&node->PoolItem->NonPagedTotalSizeDelta, poolTagInfo.NonPagedUsed);
+
+            PmUpdatePoolTagNode(Context, node);
+        } 
+        else
+        {
+            PPOOL_ITEM entry;
+
+            entry = PhCreateAlloc(sizeof(POOL_ITEM));
+            memset(entry, 0, sizeof(POOL_ITEM));
+
+            entry->TagUlong = poolTagInfo.TagUlong;
+            PhZeroExtendToUtf16Buffer(poolTagInfo.Tag, sizeof(poolTagInfo.Tag), entry->TagString);
+         
+            PhUpdateDelta(&entry->PagedAllocsDelta, poolTagInfo.PagedAllocs);
+            PhUpdateDelta(&entry->PagedFreesDelta, poolTagInfo.PagedFrees);
+            PhUpdateDelta(&entry->PagedCurrentDelta, poolTagInfo.PagedAllocs - poolTagInfo.PagedFrees);
+            PhUpdateDelta(&entry->PagedTotalSizeDelta, poolTagInfo.PagedUsed);
+            PhUpdateDelta(&entry->NonPagedAllocsDelta, poolTagInfo.NonPagedAllocs);
+            PhUpdateDelta(&entry->NonPagedFreesDelta, poolTagInfo.NonPagedFrees);
+            PhUpdateDelta(&entry->NonPagedCurrentDelta, poolTagInfo.NonPagedAllocs - poolTagInfo.NonPagedFrees);
+            PhUpdateDelta(&entry->NonPagedTotalSizeDelta, poolTagInfo.NonPagedUsed);
+
+            UpdatePoolTagBinaryName(Context, entry, poolTagInfo.TagUlong);
+
+            PmAddPoolTagNode(Context, entry);
+        }
+    }
+
+    TreeNew_NodesStructured(Context->TreeNewHandle);
+    PhDereferenceObject(Context);
+
+    PhFree(poolTagTable);
+}
+
+BOOLEAN WordMatchStringRef(
+    _Inout_ PPOOLTAG_CONTEXT Context,
+    _In_ PPH_STRINGREF Text
+    )
+{
+    PH_STRINGREF part;
+    PH_STRINGREF remainingPart;
+
+    remainingPart = Context->SearchboxText->sr;
+
+    while (remainingPart.Length != 0)
+    {
+        PhSplitStringRefAtChar(&remainingPart, '|', &part, &remainingPart);
+
+        if (part.Length != 0)
+        {
+            if (PhFindStringInStringRef(Text, &part, TRUE) != -1)
+                return TRUE;
+        }
+    }
+
+    return FALSE;
+}
+
+BOOLEAN WordMatchStringZ(
+    _Inout_ PPOOLTAG_CONTEXT Context,
+    _In_ PWSTR Text
+    )
+{
+    PH_STRINGREF text;
+
+    PhInitializeStringRef(&text, Text);
+    return WordMatchStringRef(Context, &text);
+}
+
+BOOLEAN PoolTagTreeFilterCallback(
+    _In_ PPH_TREENEW_NODE Node,
+    _In_opt_ PVOID Context
+    )
+{
+    PPOOLTAG_CONTEXT context = Context;
+    PPOOLTAG_ROOT_NODE poolNode = (PPOOLTAG_ROOT_NODE)Node;
+
+    if (PhIsNullOrEmptyString(context->SearchboxText))
+        return TRUE;
+
+    if (poolNode->PoolItem->TagString[0] != 0)
+    {
+        if (WordMatchStringZ(context, poolNode->PoolItem->TagString))
+            return TRUE;
+    }
+
+    if (!PhIsNullOrEmptyString(poolNode->PoolItem->BinaryNameString))
+    {
+        if (WordMatchStringRef(context, &poolNode->PoolItem->BinaryNameString->sr))
+            return TRUE;
+    }
+
+    if (!PhIsNullOrEmptyString(poolNode->PoolItem->DescriptionString))
+    {
+        if (WordMatchStringRef(context, &poolNode->PoolItem->DescriptionString->sr))
+            return TRUE;
+    }
+
+    return FALSE;
+}
+
+VOID NTAPI PoolmonProcessesUpdatedCallback(
+    _In_opt_ PVOID Parameter,
+    _In_opt_ PVOID Context
+    )
+{
+    PPOOLTAG_CONTEXT context = Context;
+
+    context->ProcessesUpdatedCount++;
+
+    if (context->ProcessesUpdatedCount < 2)
+        return;
+ 
+    PhReferenceObject(context);
+    UpdatePoolTagTable(Context);
+}
+
+INT_PTR CALLBACK PoolMonDlgProc(
+    _In_ HWND hwndDlg,
+    _In_ UINT uMsg,
+    _In_ WPARAM wParam,
+    _In_ LPARAM lParam
+    )
+{
+    PPOOLTAG_CONTEXT context;
+
+    if (uMsg == WM_INITDIALOG)
+    {
+        context = PhCreateAlloc(sizeof(POOLTAG_CONTEXT));
+        memset(context, 0, sizeof(POOLTAG_CONTEXT));
+
+        PhSetWindowContext(hwndDlg, PH_WINDOW_CONTEXT_DEFAULT, context);
+    }
+    else
+    {
+        context = PhGetWindowContext(hwndDlg, PH_WINDOW_CONTEXT_DEFAULT);
+
+        if (uMsg == WM_DESTROY)
+        {
+            PhRemoveWindowContext(hwndDlg, PH_WINDOW_CONTEXT_DEFAULT);
+            PhDereferenceObject(context);
+        }
+    }
+
+    if (!context)
+        return FALSE;
+
+    switch (uMsg)
+    {
+    case WM_INITDIALOG:
+        {
+            PhSetApplicationWindowIcon(hwndDlg);
+
+            context->ParentWindowHandle = hwndDlg;
+            context->TreeNewHandle = GetDlgItem(hwndDlg, IDC_POOLTREE);
+            context->SearchboxHandle = GetDlgItem(hwndDlg, IDC_POOLSEARCH);
+
+            PhRegisterDialog(hwndDlg);
+            PhCenterWindow(hwndDlg, PhMainWndHandle);
+
+            PhCreateSearchControl(hwndDlg, context->SearchboxHandle, L"Search Pool Tags (Ctrl+K)");
+            PmInitializePoolTagTree(context);
+
+            PhInitializeLayoutManager(&context->LayoutManager, hwndDlg);
+            PhAddLayoutItem(&context->LayoutManager, context->TreeNewHandle, NULL, PH_ANCHOR_ALL);
+            PhAddLayoutItem(&context->LayoutManager, context->SearchboxHandle, NULL, PH_ANCHOR_BOTTOM | PH_ANCHOR_LEFT);         
+            PhAddLayoutItem(&context->LayoutManager, GetDlgItem(hwndDlg, IDCANCEL), NULL, PH_ANCHOR_BOTTOM | PH_ANCHOR_RIGHT);
+            PhLoadWindowPlacementFromSetting(SETTING_NAME_POOL_WINDOW_POSITION, SETTING_NAME_POOL_WINDOW_SIZE, hwndDlg);
+            
+            context->SearchboxText = PhReferenceEmptyString();
+            context->TreeFilterEntry = PhAddTreeNewFilter(
+                &context->FilterSupport,
+                PoolTagTreeFilterCallback,
+                context
+                );
+
+            LoadPoolTagDatabase(context);
+
+            PhReferenceObject(context);
+            UpdatePoolTagTable(context);
+            TreeNew_AutoSizeColumn(context->TreeNewHandle, TREE_COLUMN_ITEM_DESCRIPTION, TN_AUTOSIZE_REMAINING_SPACE);
+
+            PhRegisterCallback(
+                PhGetGeneralCallback(GeneralCallbackProcessProviderUpdatedEvent),
+                PoolmonProcessesUpdatedCallback,
+                context,
+                &context->ProcessesUpdatedCallbackRegistration
+                );          
+                
+            SendMessage(hwndDlg, WM_NEXTDLGCTL, (WPARAM)context->TreeNewHandle, TRUE);
+        }
+        break;
+    case WM_SIZE:
+        PhLayoutManagerLayout(&context->LayoutManager);
+        TreeNew_AutoSizeColumn(context->TreeNewHandle, TREE_COLUMN_ITEM_DESCRIPTION, TN_AUTOSIZE_REMAINING_SPACE);
+        break;
+    case WM_DESTROY:
+        {
+            PhUnregisterCallback(
+                PhGetGeneralCallback(GeneralCallbackProcessProviderUpdatedEvent),
+                &context->ProcessesUpdatedCallbackRegistration
+                );
+
+            PhSaveWindowPlacementToSetting(SETTING_NAME_POOL_WINDOW_POSITION, SETTING_NAME_POOL_WINDOW_SIZE, hwndDlg);
+            PmSaveSettingsTreeList(context);
+
+            PhDeleteTreeNewFilterSupport(&context->FilterSupport);
+
+            PmDeletePoolTagTree(context);
+            FreePoolTagDatabase(context);
+
+            PhDeleteLayoutManager(&context->LayoutManager);
+            PhUnregisterDialog(hwndDlg);
+
+            PostQuitMessage(0);
+        }
+        break;
+    case POOL_TABLE_SHOWDIALOG:
+        {
+            if (IsMinimized(hwndDlg))
+                ShowWindow(hwndDlg, SW_RESTORE);
+            else
+                ShowWindow(hwndDlg, SW_SHOW);
+
+            SetForegroundWindow(hwndDlg);
+        }
+        break;
+    case WM_COMMAND:
+        {
+            switch (GET_WM_COMMAND_ID(wParam, lParam))
+            {
+            case IDCANCEL:
+                DestroyWindow(hwndDlg);
+                break;
+            case IDC_POOLCLEAR:
+                {
+                    SetFocus(context->SearchboxHandle);
+                    Static_SetText(context->SearchboxHandle, L"");
+                }
+                break;
+            case IDC_POOLSEARCH:
+                {
+                    PPH_STRING newSearchboxText;
+
+                    if (GET_WM_COMMAND_CMD(wParam, lParam) != EN_CHANGE)
+                        break;
+
+                    newSearchboxText = PH_AUTO(PhGetWindowText(context->SearchboxHandle));
+
+                    if (!PhEqualString(context->SearchboxText, newSearchboxText, FALSE))
+                    {
+                        // Cache the current search text for our callback.
+                        PhSwapReference(&context->SearchboxText, newSearchboxText);
+
+                        PhApplyTreeNewFilters(&context->FilterSupport);
+                    }
+                }
+                break;
+            case POOL_TABLE_SHOWCONTEXTMENU:
+                {
+                    PPH_EMENU menu;
+                    PPOOLTAG_ROOT_NODE selectedNode;
+                    PPH_EMENU_ITEM selectedItem;
+                    PPH_TREENEW_CONTEXT_MENU contextMenuEvent = (PPH_TREENEW_CONTEXT_MENU)lParam;
+
+                    if (selectedNode = PmGetSelectedPoolTagNode(context))
+                    {
+                        menu = PhCreateEMenu();
+                        PhInsertEMenuItem(menu, PhCreateEMenuItem(0, 1, L"Show allocations", NULL, NULL), -1);
+                        PhInsertEMenuItem(menu, PhCreateEMenuSeparator(), -1);
+                        PhInsertEMenuItem(menu, PhCreateEMenuItem(0, 2, L"Edit description...", NULL, NULL), -1);
+                        
+                        selectedItem = PhShowEMenu(
+                            menu,
+                            hwndDlg,
+                            PH_EMENU_SHOW_LEFTRIGHT,
+                            PH_ALIGN_LEFT | PH_ALIGN_TOP,
+                            contextMenuEvent->Location.x,
+                            contextMenuEvent->Location.y
+                            );
+
+                        if (selectedItem && selectedItem->Id != -1)
+                        {
+                            switch (selectedItem->Id)
+                            {
+                            case 1:
+                                ShowBigPoolDialog(selectedNode->PoolItem);
+                                break;
+                            }
+                        }
+
+                        PhDestroyEMenu(menu);
+                    }
+                }
+                break;
+            }
+        }
+        break;
+    }
+
+    return FALSE;
+}
+
+NTSTATUS ShowPoolMonDialogThread(
+    _In_ PVOID Parameter
+    )
+{
+    BOOL result;
+    MSG message;
+    PH_AUTO_POOL autoPool;
+
+    PhInitializeAutoPool(&autoPool);
+
+    PoolTagDialogHandle = CreateDialog(
+        PluginInstance->DllBase,
+        MAKEINTRESOURCE(IDD_POOL),
+        NULL,
+        PoolMonDlgProc
+        );
+
+    PhSetEvent(&PoolTagDialogInitializedEvent);
+
+    PostMessage(PoolTagDialogHandle, POOL_TABLE_SHOWDIALOG, 0, 0);
+
+    while (result = GetMessage(&message, NULL, 0, 0))
+    {
+        if (result == -1)
+            break;
+
+        if (!IsDialogMessage(PoolTagDialogHandle, &message))
+        {
+            TranslateMessage(&message);
+            DispatchMessage(&message);
+        }
+
+        PhDrainAutoPool(&autoPool);
+    }
+
+    PhDeleteAutoPool(&autoPool);
+
+    if (PoolTagDialogThreadHandle)
+    {
+        NtClose(PoolTagDialogThreadHandle);
+        PoolTagDialogThreadHandle = NULL;
+    }
+
+    PhResetEvent(&PoolTagDialogInitializedEvent);
+
+    return STATUS_SUCCESS;
+}
+
+VOID ShowPoolMonDialog(
+    VOID
+    )
+{
+    if (!PoolTagDialogThreadHandle)
+    {
+        if (!NT_SUCCESS(PhCreateThreadEx(&PoolTagDialogThreadHandle, ShowPoolMonDialogThread, NULL)))
+        {
+            PhShowError(PhMainWndHandle, L"%s", L"Unable to create the pool monitor window.");
+            return;
+        }
+
+        PhWaitForEvent(&PoolTagDialogInitializedEvent, NULL);
+    }
+
+    PostMessage(PoolTagDialogHandle, POOL_TABLE_SHOWDIALOG, 0, 0);
+}

--- a/plugins/ExtendedTools/pooldialog.c
+++ b/plugins/ExtendedTools/pooldialog.c
@@ -236,6 +236,8 @@ INT_PTR CALLBACK PoolMonDlgProc(
                 &context->ProcessesUpdatedCallbackRegistration
                 );          
                 
+            PhInitializeWindowTheme(hwndDlg, !!PhGetIntegerSetting(L"EnableThemeSupport"));
+
             SendMessage(hwndDlg, WM_NEXTDLGCTL, (WPARAM)context->TreeNewHandle, TRUE);
         }
         break;

--- a/plugins/ExtendedTools/pooldialogbig.c
+++ b/plugins/ExtendedTools/pooldialogbig.c
@@ -1,0 +1,168 @@
+/*
+ * Copyright (c) 2022 Winsider Seminars & Solutions, Inc.  All rights reserved.
+ *
+ * This file is part of System Informer.
+ *
+ * Authors:
+ *
+ *     dmex    2016
+ *
+ */
+
+#include "exttools.h"
+#include "poolmon.h"
+
+VOID UpdateBigPoolTable(
+    _Inout_ PBIGPOOLTAG_CONTEXT Context
+    )
+{
+    PSYSTEM_BIGPOOL_INFORMATION bigPoolTable;
+    ULONG i;
+    
+    if (!NT_SUCCESS(EnumBigPoolTable(&bigPoolTable)))
+        return;
+    
+    for (i = 0; i < bigPoolTable->Count; i++)
+    {
+        INT itemIndex;
+        SYSTEM_BIGPOOL_ENTRY poolTagInfo;
+        WCHAR virtualAddressString[PH_PTR_STR_LEN_1] = L"";
+
+        poolTagInfo = bigPoolTable->AllocatedInfo[i];
+
+        if (poolTagInfo.TagUlong != Context->TagUlong)
+            continue;
+
+        PhPrintPointer(virtualAddressString, poolTagInfo.VirtualAddress);
+        itemIndex = PhAddListViewItem(
+            Context->ListviewHandle,
+            MAXINT,
+            virtualAddressString,
+            NULL
+            );
+
+        PhSetListViewSubItem(
+            Context->ListviewHandle,
+            itemIndex,
+            1,
+            PhaFormatSize(poolTagInfo.SizeInBytes, -1)->Buffer
+            );
+
+        if (poolTagInfo.NonPaged)
+        {
+            PhSetListViewSubItem(
+                Context->ListviewHandle,
+                itemIndex,
+                2,
+                L"Yes"
+                );
+        }
+        else
+        {
+            PhSetListViewSubItem(
+                Context->ListviewHandle,
+                itemIndex,
+                2,
+                L"No"
+                );
+        }
+    }
+
+    PhFree(bigPoolTable);
+}
+
+INT_PTR CALLBACK BigPoolMonDlgProc(
+    _In_ HWND hwndDlg,
+    _In_ UINT uMsg,
+    _In_ WPARAM wParam,
+    _In_ LPARAM lParam
+    )
+{
+    PBIGPOOLTAG_CONTEXT context;
+
+    if (uMsg == WM_INITDIALOG)
+    {
+        context = PhAllocate(sizeof(BIGPOOLTAG_CONTEXT));
+        memset(context, 0, sizeof(BIGPOOLTAG_CONTEXT));
+
+        context->TagUlong = ((PPOOL_ITEM)lParam)->TagUlong;
+        PhZeroExtendToUtf16Buffer(context->Tag, sizeof(context->Tag), context->TagString);
+
+        PhSetWindowContext(hwndDlg, PH_WINDOW_CONTEXT_DEFAULT, context);
+    }
+    else
+    {
+        context = PhGetWindowContext(hwndDlg, PH_WINDOW_CONTEXT_DEFAULT);
+
+        if (uMsg == WM_DESTROY)
+            PhRemoveWindowContext(hwndDlg, PH_WINDOW_CONTEXT_DEFAULT);
+    }
+
+    if (!context)
+        return FALSE;
+
+    switch (uMsg)
+    {
+    case WM_INITDIALOG:
+        {
+            context->WindowHandle = hwndDlg;
+            context->ListviewHandle = GetDlgItem(hwndDlg, IDC_BIGPOOLLIST);
+
+            PhCenterWindow(hwndDlg, NULL);
+
+            PhSetWindowText(hwndDlg, PhaFormatString(L"Large Allocations (%s)", context->TagString)->Buffer);
+
+            PhRegisterDialog(hwndDlg);
+            PhSetListViewStyle(context->ListviewHandle, FALSE, TRUE);
+            PhSetControlTheme(context->ListviewHandle, L"explorer");
+            PhAddListViewColumn(context->ListviewHandle, 0, 0, 0, LVCFMT_LEFT, 150, L"Address");
+            PhAddListViewColumn(context->ListviewHandle, 1, 1, 1, LVCFMT_LEFT, 100, L"Size");
+            PhAddListViewColumn(context->ListviewHandle, 2, 2, 2, LVCFMT_LEFT, 100, L"NonPaged");
+            PhSetExtendedListView(context->ListviewHandle);
+
+            PhInitializeLayoutManager(&context->LayoutManager, hwndDlg);
+            PhAddLayoutItem(&context->LayoutManager, context->ListviewHandle, NULL, PH_ANCHOR_ALL);
+            PhAddLayoutItem(&context->LayoutManager, GetDlgItem(hwndDlg, IDCANCEL), NULL, PH_ANCHOR_BOTTOM | PH_ANCHOR_RIGHT);
+            //PhLoadWindowPlacementFromSetting(SETTING_NAME_WINDOW_POSITION, SETTING_NAME_WINDOW_SIZE, hwndDlg);
+
+            UpdateBigPoolTable(context);
+        }
+        break;
+    case WM_SIZE:
+        PhLayoutManagerLayout(&context->LayoutManager);
+        break;
+    case WM_DESTROY:
+        {
+            //PhSaveWindowPlacementToSetting(SETTING_NAME_WINDOW_POSITION, SETTING_NAME_WINDOW_SIZE, hwndDlg);
+
+            PhDeleteLayoutManager(&context->LayoutManager);
+            PhUnregisterDialog(hwndDlg);
+        }
+        break;
+    case WM_COMMAND:
+        {
+            switch (GET_WM_COMMAND_ID(wParam, lParam))
+            {
+            case IDCANCEL:
+                EndDialog(hwndDlg, IDOK);
+                break;
+            }
+        }
+        break;
+    }
+
+    return FALSE;
+}
+
+VOID ShowBigPoolDialog(
+    _In_ PPOOL_ITEM PoolItem
+    )
+{
+    DialogBoxParam(
+        PluginInstance->DllBase,
+        MAKEINTRESOURCE(IDD_BIGPOOL),
+        NULL,
+        BigPoolMonDlgProc,
+        (LPARAM)PoolItem
+        );
+}

--- a/plugins/ExtendedTools/poolmon.h
+++ b/plugins/ExtendedTools/poolmon.h
@@ -1,0 +1,216 @@
+/*
+ * Copyright (c) 2022 Winsider Seminars & Solutions, Inc.  All rights reserved.
+ *
+ * This file is part of System Informer.
+ *
+ * Authors:
+ *
+ *     jxy-s   2022
+ *
+ */
+
+#pragma once
+
+#define CINTERFACE
+#define COBJMACROS
+#include <phdk.h>
+#include <phappresource.h>
+#include <settings.h>
+#include <shlobj.h>
+#include <symprv.h>
+#include <windowsx.h>
+#include <workqueue.h>
+
+#include "resource.h"
+
+#define POOL_TABLE_SHOWDIALOG  (WM_APP + 1)
+#define POOL_TABLE_SHOWCONTEXTMENU (WM_APP + 2)
+
+typedef enum _POOLTAG_TREE_ITEM_TYPE
+{
+    TPOOLTAG_TREE_ITEM_TYPE_NONE,
+    TPOOLTAG_TREE_ITEM_TYPE_OBJECT,
+    TPOOLTAG_TREE_ITEM_TYPE_DRIVER,
+} POOLTAG_TREE_ITEM_TYPE;
+
+typedef struct _POOL_TAG_LIST_ENTRY
+{
+    LIST_ENTRY ListEntry;
+
+    union
+    {
+        UCHAR Tag[4];
+        ULONG TagUlong;
+    };
+
+    PPH_STRING BinaryNameString;
+    PPH_STRING DescriptionString;
+} POOL_TAG_LIST_ENTRY, *PPOOL_TAG_LIST_ENTRY;
+
+typedef struct _POOL_ITEM
+{
+    ULONG TagUlong;
+    WCHAR TagString[5];
+
+    PPH_STRING BinaryNameString;
+    PPH_STRING DescriptionString;
+    POOLTAG_TREE_ITEM_TYPE Type;
+
+    PH_UINT64_DELTA PagedAllocsDelta;
+    PH_UINT64_DELTA PagedFreesDelta;
+    PH_UINT64_DELTA PagedCurrentDelta;
+    PH_UINT64_DELTA PagedTotalSizeDelta;
+    PH_UINT64_DELTA NonPagedAllocsDelta;
+    PH_UINT64_DELTA NonPagedFreesDelta;
+    PH_UINT64_DELTA NonPagedCurrentDelta;
+    PH_UINT64_DELTA NonPagedTotalSizeDelta;
+} POOL_ITEM, *PPOOL_ITEM;
+
+typedef enum _POOLTAG_TREE_COLUMN_ITEM_NAME
+{
+    TREE_COLUMN_ITEM_TAG,
+    TREE_COLUMN_ITEM_DRIVER,
+    TREE_COLUMN_ITEM_DESCRIPTION,
+    TREE_COLUMN_ITEM_PAGEDALLOC,
+    TREE_COLUMN_ITEM_PAGEDFREE,
+    TREE_COLUMN_ITEM_PAGEDCURRENT,
+    TREE_COLUMN_ITEM_PAGEDTOTAL,
+    TREE_COLUMN_ITEM_NONPAGEDALLOC,
+    TREE_COLUMN_ITEM_NONPAGEDFREE,
+    TREE_COLUMN_ITEM_NONPAGEDCURRENT,
+    TREE_COLUMN_ITEM_NONPAGEDTOTAL,
+    TREE_COLUMN_ITEM_MAXIMUM
+} POOLTAG_TREE_COLUMN_ITEM_NAME;
+
+typedef struct _POOLTAG_ROOT_NODE
+{
+    PH_TREENEW_NODE Node;
+    PH_STRINGREF TextCache[TREE_COLUMN_ITEM_MAXIMUM];
+
+    ULONG TagUlong; 
+    PPOOL_ITEM PoolItem;
+
+    PPH_STRING PagedAllocsDeltaString;
+    PPH_STRING PagedFreesDeltaString;
+    PPH_STRING PagedLiveDeltaString;
+    PPH_STRING PagedCurrentDeltaString;
+    PPH_STRING PagedTotalSizeDeltaString;
+    PPH_STRING NonPagedAllocsDeltaString;
+    PPH_STRING NonPagedFreesDeltaString;
+    PPH_STRING NonPagedLiveDeltaString;
+    PPH_STRING NonPagedCurrentDeltaString;
+    PPH_STRING NonPagedTotalSizeDeltaString;
+} POOLTAG_ROOT_NODE, *PPOOLTAG_ROOT_NODE;
+
+typedef struct _POOLTAG_CONTEXT
+{
+    HWND ParentWindowHandle;
+    HWND SearchboxHandle;
+    HWND TreeNewHandle;
+    PH_LAYOUT_MANAGER LayoutManager;
+    ULONG ProcessesUpdatedCount;
+    PH_CALLBACK_REGISTRATION ProcessesUpdatedCallbackRegistration;
+
+    PPH_STRING SearchboxText;
+    PH_TN_FILTER_SUPPORT FilterSupport;
+    PPH_TN_FILTER_ENTRY TreeFilterEntry;
+
+    PH_QUEUED_LOCK PoolTagListLock;
+    PPH_LIST PoolTagDbList;
+    PPH_HASHTABLE PoolTagDbHashtable;  
+
+    ULONG TreeNewSortColumn;
+    PH_SORT_ORDER TreeNewSortOrder;
+    PPH_HASHTABLE NodeHashtable;
+    PPH_LIST NodeList;
+    PPH_LIST NodeRootList;
+} POOLTAG_CONTEXT, *PPOOLTAG_CONTEXT;
+
+// pooldialog.c
+
+typedef struct _BIGPOOLTAG_CONTEXT
+{
+    HWND WindowHandle;
+    HWND ListviewHandle;
+    PH_LAYOUT_MANAGER LayoutManager;
+
+    union
+    {
+        UCHAR Tag[4];
+        ULONG TagUlong;
+    };
+    WCHAR TagString[5];
+
+} BIGPOOLTAG_CONTEXT, *PBIGPOOLTAG_CONTEXT;
+
+VOID ShowBigPoolDialog(
+    _In_ PPOOL_ITEM PoolItem
+    );
+
+VOID PmLoadSettingsTreeList(
+    _Inout_ PPOOLTAG_CONTEXT Context
+    );
+
+VOID PmSaveSettingsTreeList(
+    _Inout_ PPOOLTAG_CONTEXT Context
+    );
+
+VOID PmInitializePoolTagTree(
+    _Inout_ PPOOLTAG_CONTEXT Context
+    );
+
+VOID PmDeletePoolTagTree(
+    _In_ PPOOLTAG_CONTEXT Context
+    );
+
+PPOOLTAG_ROOT_NODE PmFindPoolTagNode(
+    _In_ PPOOLTAG_CONTEXT Context,
+    _In_ ULONG PoolTag
+    );
+
+PPOOLTAG_ROOT_NODE PmAddPoolTagNode(
+    _Inout_ PPOOLTAG_CONTEXT Context,
+    _In_ PPOOL_ITEM PoolItem
+    );
+
+VOID PmUpdatePoolTagNode(
+    _In_ PPOOLTAG_CONTEXT Context,
+    _In_ PPOOLTAG_ROOT_NODE WindowNode
+    );
+
+struct _PH_TN_FILTER_SUPPORT*
+NTAPI
+PmGetFilterSupportTreeList(
+    VOID
+    );
+
+PPOOLTAG_ROOT_NODE PmGetSelectedPoolTagNode(
+    _In_ PPOOLTAG_CONTEXT Context
+    );
+
+// pooltable.c
+
+NTSTATUS EnumPoolTagTable(
+    _Out_ PVOID* Buffer
+    );
+
+NTSTATUS EnumBigPoolTable(
+    _Out_ PVOID* Buffer
+    );
+
+
+// pooldb.c
+
+VOID LoadPoolTagDatabase(
+    _In_ PPOOLTAG_CONTEXT Context
+    );
+
+VOID FreePoolTagDatabase(
+    _In_ PPOOLTAG_CONTEXT Context
+    );
+
+VOID UpdatePoolTagBinaryName(
+    _In_ PPOOLTAG_CONTEXT Context,
+    _In_ PPOOL_ITEM PoolEntry,
+    _In_ ULONG TagUlong
+    );

--- a/plugins/ExtendedTools/pooltable.c
+++ b/plugins/ExtendedTools/pooltable.c
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2022 Winsider Seminars & Solutions, Inc.  All rights reserved.
+ *
+ * This file is part of System Informer.
+ *
+ * Authors:
+ *
+ *     dmex    2016
+ *
+ */
+
+#include "exttools.h"
+#include "poolmon.h"
+
+NTSTATUS EnumPoolTagTable(
+    _Out_ PVOID* Buffer
+    )
+{
+    NTSTATUS status;
+    PVOID buffer;
+    ULONG bufferSize;
+    ULONG attempts;
+
+    bufferSize = 0x100;
+    buffer = PhAllocate(bufferSize);
+
+    status = NtQuerySystemInformation(
+        SystemPoolTagInformation,
+        buffer,
+        bufferSize,
+        &bufferSize
+        );
+    attempts = 0;
+
+    while (status == STATUS_INFO_LENGTH_MISMATCH && attempts < 8)
+    {
+        PhFree(buffer);
+        buffer = PhAllocate(bufferSize);
+
+        status = NtQuerySystemInformation(
+            SystemPoolTagInformation,
+            buffer,
+            bufferSize,
+            &bufferSize
+            );
+        attempts++;
+    }
+
+    if (NT_SUCCESS(status))
+        *Buffer = buffer;
+    else
+        PhFree(buffer);
+
+    return status;
+}
+
+NTSTATUS EnumBigPoolTable(
+    _Out_ PVOID* Buffer
+    )
+{
+    NTSTATUS status;
+    PVOID buffer;
+    ULONG bufferSize;
+    ULONG attempts;
+
+    bufferSize = 0x100;
+    buffer = PhAllocate(bufferSize);
+
+    status = NtQuerySystemInformation(
+        SystemBigPoolInformation,
+        buffer,
+        bufferSize,
+        &bufferSize
+        );
+    attempts = 0;
+
+    while (status == STATUS_INFO_LENGTH_MISMATCH && attempts < 8)
+    {
+        PhFree(buffer);
+        buffer = PhAllocate(bufferSize);
+
+        status = NtQuerySystemInformation(
+            SystemBigPoolInformation,
+            buffer,
+            bufferSize,
+            &bufferSize
+            );
+        attempts++;
+    }
+
+    if (NT_SUCCESS(status))
+        *Buffer = buffer;
+    else
+        PhFree(buffer);
+
+    return status;
+}
+

--- a/plugins/ExtendedTools/pooltree.c
+++ b/plugins/ExtendedTools/pooltree.c
@@ -1,0 +1,579 @@
+/*
+ * Copyright (c) 2022 Winsider Seminars & Solutions, Inc.  All rights reserved.
+ *
+ * This file is part of System Informer.
+ *
+ * Authors:
+ *
+ *     dmex    2016
+ *
+ */
+
+#include "exttools.h"
+#include "poolmon.h"
+
+#define SORT_FUNCTION(Column) PmPoolTreeNewCompare##Column
+#define BEGIN_SORT_FUNCTION(Column) static int __cdecl PmPoolTreeNewCompare##Column( \
+    _In_ void *_context, \
+    _In_ const void *_elem1, \
+    _In_ const void *_elem2 \
+    ) \
+{ \
+    PPOOLTAG_ROOT_NODE node1 = *(PPOOLTAG_ROOT_NODE*)_elem1; \
+    PPOOLTAG_ROOT_NODE node2 = *(PPOOLTAG_ROOT_NODE*)_elem2; \
+    PPOOL_ITEM poolItem1 = node1->PoolItem; \
+    PPOOL_ITEM poolItem2 = node2->PoolItem; \
+    int sortResult = 0;
+
+#define END_SORT_FUNCTION \
+    if (sortResult == 0) \
+        sortResult = uintptrcmp((ULONG_PTR)poolItem1->TagUlong, (ULONG_PTR)poolItem2->TagUlong); \
+    \
+    return PhModifySort(sortResult, ((PPOOLTAG_CONTEXT)_context)->TreeNewSortOrder); \
+}
+
+VOID PmLoadSettingsTreeList(
+    _Inout_ PPOOLTAG_CONTEXT Context
+    )
+{
+    PPH_STRING settings;
+    PH_INTEGER_PAIR sortSettings;
+
+    settings = PhGetStringSetting(SETTING_NAME_POOL_TREE_LIST_COLUMNS);
+    PhCmLoadSettings(Context->TreeNewHandle, &settings->sr);
+    PhDereferenceObject(settings);
+
+    sortSettings = PhGetIntegerPairSetting(SETTING_NAME_POOL_TREE_LIST_SORT);
+    TreeNew_SetSort(Context->TreeNewHandle, (ULONG)sortSettings.X, (PH_SORT_ORDER)sortSettings.Y);
+}
+
+VOID PmSaveSettingsTreeList(
+    _Inout_ PPOOLTAG_CONTEXT Context
+    )
+{
+    PPH_STRING settings;
+    PH_INTEGER_PAIR sortSettings;
+    ULONG sortColumn;
+    PH_SORT_ORDER sortOrder;
+        
+    settings = PhCmSaveSettings(Context->TreeNewHandle);
+    PhSetStringSetting2(SETTING_NAME_POOL_TREE_LIST_COLUMNS, &settings->sr);
+    PhDereferenceObject(settings);
+
+    TreeNew_GetSort(Context->TreeNewHandle, &sortColumn, &sortOrder);
+    sortSettings.X = sortColumn;
+    sortSettings.Y = sortOrder;
+    PhSetIntegerPairSetting(SETTING_NAME_POOL_TREE_LIST_SORT, sortSettings);
+}
+
+BOOLEAN PmPoolTagNodeHashtableEqualFunction(
+    _In_ PVOID Entry1,
+    _In_ PVOID Entry2
+    )
+{
+    PPOOLTAG_ROOT_NODE poolTagNode1 = *(PPOOLTAG_ROOT_NODE *)Entry1;
+    PPOOLTAG_ROOT_NODE poolTagNode2 = *(PPOOLTAG_ROOT_NODE *)Entry2;
+
+    return poolTagNode1->TagUlong == poolTagNode2->TagUlong;
+}
+
+ULONG PmPoolTagNodeHashtableHashFunction(
+    _In_ PVOID Entry
+    )
+{
+    return (*(PPOOLTAG_ROOT_NODE*)Entry)->TagUlong;
+}
+
+VOID PmDestroyPoolTagNode(
+    _In_ PPOOLTAG_ROOT_NODE PoolTagNode
+    )
+{
+   PhClearReference(&PoolTagNode->PagedAllocsDeltaString);
+   PhClearReference(&PoolTagNode->PagedFreesDeltaString);
+   PhClearReference(&PoolTagNode->PagedCurrentDeltaString);
+   PhClearReference(&PoolTagNode->PagedTotalSizeDeltaString);
+   PhClearReference(&PoolTagNode->NonPagedAllocsDeltaString);
+   PhClearReference(&PoolTagNode->NonPagedFreesDeltaString);
+   PhClearReference(&PoolTagNode->NonPagedCurrentDeltaString);
+   PhClearReference(&PoolTagNode->NonPagedTotalSizeDeltaString);
+
+   PhFree(PoolTagNode);
+}
+
+PPOOLTAG_ROOT_NODE PmAddPoolTagNode(
+    _Inout_ PPOOLTAG_CONTEXT Context,
+    _In_ PPOOL_ITEM PoolItem
+    )
+{
+    PPOOLTAG_ROOT_NODE poolTagNode;
+
+    poolTagNode = PhAllocate(sizeof(POOLTAG_ROOT_NODE));
+    memset(poolTagNode, 0, sizeof(POOLTAG_ROOT_NODE));
+    PhInitializeTreeNewNode(&poolTagNode->Node);
+
+    poolTagNode->PoolItem = PoolItem;
+    poolTagNode->TagUlong = PoolItem->TagUlong;
+
+    memset(poolTagNode->TextCache, 0, sizeof(PH_STRINGREF) * TREE_COLUMN_ITEM_MAXIMUM);
+    poolTagNode->Node.TextCache = poolTagNode->TextCache;
+    poolTagNode->Node.TextCacheSize = TREE_COLUMN_ITEM_MAXIMUM;
+
+    PhAddEntryHashtable(Context->NodeHashtable, &poolTagNode);
+    PhAddItemList(Context->NodeList, poolTagNode);
+
+    if (Context->FilterSupport.FilterList)
+        poolTagNode->Node.Visible = PhApplyTreeNewFiltersToNode(&Context->FilterSupport, &poolTagNode->Node);
+
+    return poolTagNode;
+}
+
+PPOOLTAG_ROOT_NODE PmFindPoolTagNode(
+    _In_ PPOOLTAG_CONTEXT Context,
+    _In_ ULONG PoolTag
+    )
+{
+    POOLTAG_ROOT_NODE lookupWindowNode;
+    PPOOLTAG_ROOT_NODE lookupWindowNodePtr = &lookupWindowNode;
+    PPOOLTAG_ROOT_NODE *windowNode;
+
+    lookupWindowNode.TagUlong = PoolTag;
+
+    windowNode = (PPOOLTAG_ROOT_NODE*)PhFindEntryHashtable(
+        Context->NodeHashtable,
+        &lookupWindowNodePtr
+        );
+
+    if (windowNode)
+        return *windowNode;
+    else
+        return NULL;
+}
+
+VOID PmRemovePoolTagNode(
+    _In_ PPOOLTAG_CONTEXT Context,
+    _In_ PPOOLTAG_ROOT_NODE PoolTagNode
+    )
+{
+    ULONG index = 0;
+
+    // Remove from hashtable/list and cleanup.
+    PhRemoveEntryHashtable(Context->NodeHashtable, &PoolTagNode);
+
+    if ((index = PhFindItemList(Context->NodeList, PoolTagNode)) != -1)
+    {
+        PhRemoveItemList(Context->NodeList, index);
+    }
+
+    PmDestroyPoolTagNode(PoolTagNode);
+
+    //TreeNew_NodesStructured(Context->TreeNewHandle);
+}
+
+VOID PmUpdatePoolTagNode(
+    _In_ PPOOLTAG_CONTEXT Context,
+    _In_ PPOOLTAG_ROOT_NODE PoolTagNode
+    )
+{
+    memset(PoolTagNode->TextCache, 0, sizeof(PH_STRINGREF) * TREE_COLUMN_ITEM_MAXIMUM);
+
+    PhInvalidateTreeNewNode(&PoolTagNode->Node, TN_CACHE_COLOR);
+    //TreeNew_NodesStructured(Context->TreeNewHandle);
+}
+
+BEGIN_SORT_FUNCTION(Name)
+{
+    sortResult = PhCompareStringZ(poolItem1->TagString, poolItem2->TagString, FALSE);
+}
+END_SORT_FUNCTION
+
+BEGIN_SORT_FUNCTION(Type)
+{
+    sortResult = PhCompareStringWithNull(poolItem1->BinaryNameString, poolItem2->BinaryNameString, FALSE);
+}
+END_SORT_FUNCTION
+
+BEGIN_SORT_FUNCTION(Description)
+{
+    sortResult = PhCompareStringWithNull(poolItem1->DescriptionString, poolItem2->DescriptionString, TRUE);
+}
+END_SORT_FUNCTION
+
+BEGIN_SORT_FUNCTION(PagedAlloc)
+{
+    sortResult = uint64cmp(poolItem1->PagedAllocsDelta.Value, poolItem2->PagedAllocsDelta.Value);
+}
+END_SORT_FUNCTION
+
+BEGIN_SORT_FUNCTION(PagedFree)
+{
+    sortResult = uint64cmp(poolItem1->PagedFreesDelta.Value, poolItem2->PagedFreesDelta.Value);
+}
+END_SORT_FUNCTION
+
+BEGIN_SORT_FUNCTION(PagedCurrent)
+{
+    sortResult = uint64cmp(poolItem1->PagedCurrentDelta.Value, poolItem2->PagedCurrentDelta.Value);
+}
+END_SORT_FUNCTION
+
+BEGIN_SORT_FUNCTION(PagedTotal)
+{
+    sortResult = uint64cmp(poolItem1->PagedTotalSizeDelta.Value, poolItem2->PagedTotalSizeDelta.Value);
+}
+END_SORT_FUNCTION
+
+BEGIN_SORT_FUNCTION(NonPagedAlloc)
+{
+    sortResult = uint64cmp(poolItem1->NonPagedAllocsDelta.Value, poolItem2->NonPagedAllocsDelta.Value);
+}
+END_SORT_FUNCTION
+
+BEGIN_SORT_FUNCTION(NonPagedFree)
+{
+    sortResult = uint64cmp(poolItem1->NonPagedFreesDelta.Value, poolItem2->NonPagedFreesDelta.Value);
+}
+END_SORT_FUNCTION
+
+BEGIN_SORT_FUNCTION(NonPagedCurrent)
+{
+    sortResult = uint64cmp(poolItem1->NonPagedCurrentDelta.Value, poolItem2->NonPagedCurrentDelta.Value);
+}
+END_SORT_FUNCTION
+
+BEGIN_SORT_FUNCTION(NonPagedTotal)
+{
+    sortResult = uint64cmp(poolItem1->NonPagedTotalSizeDelta.Value, poolItem2->NonPagedTotalSizeDelta.Value);
+}
+END_SORT_FUNCTION
+
+BOOLEAN NTAPI PmPoolTagTreeNewCallback(
+    _In_ HWND hwnd,
+    _In_ PH_TREENEW_MESSAGE Message,
+    _In_opt_ PVOID Parameter1,
+    _In_opt_ PVOID Parameter2,
+    _In_opt_ PVOID Context
+    )
+{
+    PPOOLTAG_CONTEXT context;
+    PPOOLTAG_ROOT_NODE node;
+
+    context = Context;
+
+    switch (Message)
+    {
+    case TreeNewGetChildren:
+        {
+            PPH_TREENEW_GET_CHILDREN getChildren = Parameter1;
+
+            node = (PPOOLTAG_ROOT_NODE)getChildren->Node;
+
+            if (!getChildren->Node)
+            {
+                static PVOID sortFunctions[] =
+                {
+                    SORT_FUNCTION(Name),
+                    SORT_FUNCTION(Type),
+                    SORT_FUNCTION(Description),
+                    SORT_FUNCTION(PagedAlloc),
+                    SORT_FUNCTION(PagedFree),
+                    SORT_FUNCTION(PagedCurrent),
+                    SORT_FUNCTION(PagedTotal),
+                    SORT_FUNCTION(NonPagedAlloc),
+                    SORT_FUNCTION(NonPagedFree),
+                    SORT_FUNCTION(NonPagedCurrent),
+                    SORT_FUNCTION(NonPagedTotal),
+                };
+                int (__cdecl *sortFunction)(void *, const void *, const void *);
+
+                if (context->TreeNewSortColumn < TREE_COLUMN_ITEM_MAXIMUM)
+                    sortFunction = sortFunctions[context->TreeNewSortColumn];
+                else
+                    sortFunction = NULL;
+
+                if (sortFunction)
+                {
+                    qsort_s(context->NodeList->Items, context->NodeList->Count, sizeof(PVOID), sortFunction, context);
+                }
+
+                getChildren->Children = (PPH_TREENEW_NODE *)context->NodeList->Items;
+                getChildren->NumberOfChildren = context->NodeList->Count;
+            }
+        }
+        return TRUE;
+    case TreeNewIsLeaf:
+        {
+            PPH_TREENEW_IS_LEAF isLeaf = (PPH_TREENEW_IS_LEAF)Parameter1;
+
+            node = (PPOOLTAG_ROOT_NODE)isLeaf->Node;
+
+            isLeaf->IsLeaf = TRUE;
+        }
+        return TRUE;
+    case TreeNewGetCellText:
+        {
+            PPH_TREENEW_GET_CELL_TEXT getCellText = (PPH_TREENEW_GET_CELL_TEXT)Parameter1;
+            PPOOL_ITEM poolItem;
+
+            node = (PPOOLTAG_ROOT_NODE)getCellText->Node;
+            poolItem = node->PoolItem;
+
+            switch (getCellText->Id)
+            {
+            case TREE_COLUMN_ITEM_TAG:    
+                PhInitializeStringRefLongHint(&getCellText->Text, poolItem->TagString);
+                break;
+            case TREE_COLUMN_ITEM_DRIVER:
+                PhInitializeStringRefLongHint(&getCellText->Text, PhGetStringOrEmpty(poolItem->BinaryNameString));
+                break;
+            case TREE_COLUMN_ITEM_DESCRIPTION:
+                PhInitializeStringRefLongHint(&getCellText->Text, PhGetStringOrEmpty(poolItem->DescriptionString));
+                break;
+            case TREE_COLUMN_ITEM_PAGEDALLOC:
+                {
+                    if (poolItem->PagedAllocsDelta.Value != 0)
+                    {
+                        PhMoveReference(&node->PagedAllocsDeltaString, PhFormatUInt64(poolItem->PagedAllocsDelta.Value, TRUE));
+                        getCellText->Text = node->PagedAllocsDeltaString->sr;
+                    }
+                }
+                break;
+            case TREE_COLUMN_ITEM_PAGEDFREE:
+                {
+                    if (poolItem->PagedFreesDelta.Value != 0)
+                    {
+                        PhMoveReference(&node->PagedFreesDeltaString, PhFormatUInt64(poolItem->PagedFreesDelta.Value, TRUE));
+                        getCellText->Text = node->PagedFreesDeltaString->sr;
+                    }
+                }
+                break;
+            case TREE_COLUMN_ITEM_PAGEDCURRENT:
+                {
+                    if (poolItem->PagedCurrentDelta.Value != 0)
+                    {
+                        PhMoveReference(&node->PagedCurrentDeltaString, PhFormatUInt64(poolItem->PagedCurrentDelta.Value, TRUE));
+                        getCellText->Text = node->PagedCurrentDeltaString->sr;
+                    }
+                }
+                break;
+            case TREE_COLUMN_ITEM_PAGEDTOTAL:
+                {
+                    if (poolItem->PagedTotalSizeDelta.Value != 0)
+                    {
+                        PhMoveReference(&node->PagedTotalSizeDeltaString, PhFormatSize(poolItem->PagedTotalSizeDelta.Value, -1));
+                        getCellText->Text = node->PagedTotalSizeDeltaString->sr;
+                    }
+                }
+                break;
+            case TREE_COLUMN_ITEM_NONPAGEDALLOC:
+                {
+                    if (poolItem->NonPagedAllocsDelta.Value != 0)
+                    {
+                        PhMoveReference(&node->NonPagedAllocsDeltaString, PhFormatUInt64(poolItem->NonPagedAllocsDelta.Value, TRUE));
+                        getCellText->Text = node->NonPagedAllocsDeltaString->sr;
+                    }
+                }
+                break;
+            case TREE_COLUMN_ITEM_NONPAGEDFREE:
+                {
+                    if (poolItem->NonPagedFreesDelta.Value != 0)
+                    {
+                        PhMoveReference(&node->NonPagedFreesDeltaString, PhFormatUInt64(poolItem->NonPagedFreesDelta.Value, TRUE));
+                        getCellText->Text = node->NonPagedFreesDeltaString->sr;
+                    }
+                }
+                break;
+            case TREE_COLUMN_ITEM_NONPAGEDCURRENT:
+                {
+                    if (poolItem->NonPagedCurrentDelta.Value != 0)
+                    {
+                        PhMoveReference(&node->NonPagedCurrentDeltaString, PhFormatUInt64(poolItem->NonPagedCurrentDelta.Value, TRUE));
+                        getCellText->Text = node->NonPagedCurrentDeltaString->sr;
+                    }
+                }
+                break;
+            case TREE_COLUMN_ITEM_NONPAGEDTOTAL:
+                {
+                    if (poolItem->NonPagedTotalSizeDelta.Value != 0)
+                    {
+                        PhMoveReference(&node->NonPagedTotalSizeDeltaString, PhFormatSize(poolItem->NonPagedTotalSizeDelta.Value, -1));
+                        getCellText->Text = node->NonPagedTotalSizeDeltaString->sr;
+                    }
+                }
+                break;
+            default:
+                return FALSE;
+            }
+
+            getCellText->Flags = TN_CACHE;
+        }
+        return TRUE;
+    case TreeNewGetNodeColor:
+        {
+            //PPH_TREENEW_GET_NODE_COLOR getNodeColor = (PPH_TREENEW_GET_NODE_COLOR)Parameter1;
+            //node = (PPOOLTAG_ROOT_NODE)getNodeColor->Node;
+
+            //switch (node->PoolItem->Type)
+            //{
+            //case TPOOLTAG_TREE_ITEM_TYPE_OBJECT:
+            //    getNodeColor->BackColor = RGB(255, 192, 203); //RGB(204, 255, 255);
+            //    break;
+            //case TPOOLTAG_TREE_ITEM_TYPE_DRIVER:
+            //    getNodeColor->BackColor = RGB(170, 204, 255);
+            //    break; 
+            //}
+
+            //getNodeColor->Flags = TN_CACHE | TN_AUTO_FORECOLOR;
+        }
+        return TRUE;
+    case TreeNewSortChanged:
+        {
+            TreeNew_GetSort(hwnd, &context->TreeNewSortColumn, &context->TreeNewSortOrder);
+            // Force a rebuild to sort the items.
+            TreeNew_NodesStructured(hwnd);
+        }
+        return TRUE;
+    case TreeNewContextMenu:
+        {
+            PPH_TREENEW_CONTEXT_MENU contextMenuEvent = Parameter1;
+
+            SendMessage(
+                context->ParentWindowHandle, 
+                WM_COMMAND, 
+                POOL_TABLE_SHOWCONTEXTMENU, 
+                (LPARAM)contextMenuEvent
+                );
+        }
+        return TRUE;
+    case TreeNewHeaderRightClick:
+        {
+            PH_TN_COLUMN_MENU_DATA data;
+
+            data.TreeNewHandle = hwnd;
+            data.MouseEvent = Parameter1;
+            data.DefaultSortColumn = 0;
+            data.DefaultSortOrder = AscendingSortOrder;
+            PhInitializeTreeNewColumnMenu(&data);
+
+            data.Selection = PhShowEMenu(data.Menu, hwnd, PH_EMENU_SHOW_LEFTRIGHT,
+                PH_ALIGN_LEFT | PH_ALIGN_TOP, data.MouseEvent->ScreenLocation.x, data.MouseEvent->ScreenLocation.y);
+            PhHandleTreeNewColumnMenu(&data);
+            PhDeleteTreeNewColumnMenu(&data);
+        }
+        return TRUE;
+    }
+
+    return FALSE;
+}
+
+VOID PmClearPoolTagTree(
+    _In_ PPOOLTAG_CONTEXT Context
+    )
+{
+    ULONG i;
+
+    for (i = 0; i < Context->NodeList->Count; i++)
+        PmDestroyPoolTagNode(Context->NodeList->Items[i]);
+
+    PhClearHashtable(Context->NodeHashtable);
+    PhClearList(Context->NodeList);
+}
+
+PPOOLTAG_ROOT_NODE PmGetSelectedPoolTagNode(
+    _In_ PPOOLTAG_CONTEXT Context
+    )
+{
+    PPOOLTAG_ROOT_NODE windowNode = NULL;
+    ULONG i;
+
+    for (i = 0; i < Context->NodeList->Count; i++)
+    {
+        windowNode = Context->NodeList->Items[i];
+
+        if (windowNode->Node.Selected)
+            return windowNode;
+    }
+
+    return NULL;
+}
+
+VOID PmGetSelectedPoolTagNodes(
+    _In_ PPOOLTAG_CONTEXT Context,
+    _Out_ PPOOLTAG_ROOT_NODE **PoolTags,
+    _Out_ PULONG NumberOfPoolTags
+    )
+{
+    PPH_LIST list;
+    ULONG i;
+
+    list = PhCreateList(2);
+
+    for (i = 0; i < Context->NodeList->Count; i++)
+    {
+        PPOOLTAG_ROOT_NODE node = (PPOOLTAG_ROOT_NODE)Context->NodeList->Items[i];
+
+        if (node->Node.Selected)
+        {
+            PhAddItemList(list, node);
+        }
+    }
+
+    *PoolTags = PhAllocateCopy(list->Items, sizeof(PVOID) * list->Count);
+    *NumberOfPoolTags = list->Count;
+
+    PhDereferenceObject(list);
+}
+
+VOID PmInitializePoolTagTree(
+    _Inout_ PPOOLTAG_CONTEXT Context
+    )
+{
+    Context->NodeList = PhCreateList(100);
+    Context->NodeHashtable = PhCreateHashtable(
+        sizeof(PPOOLTAG_ROOT_NODE),
+        PmPoolTagNodeHashtableEqualFunction,
+        PmPoolTagNodeHashtableHashFunction,
+        100
+        );
+
+    PhSetControlTheme(Context->TreeNewHandle, L"explorer");
+
+    TreeNew_SetCallback(Context->TreeNewHandle, PmPoolTagTreeNewCallback, Context);
+
+    PhAddTreeNewColumn(Context->TreeNewHandle, TREE_COLUMN_ITEM_TAG, TRUE, L"Tag Name", 50, PH_ALIGN_LEFT, -2, 0);
+    PhAddTreeNewColumn(Context->TreeNewHandle, TREE_COLUMN_ITEM_DRIVER, TRUE, L"Driver", 82, PH_ALIGN_LEFT, 0, 0);
+    PhAddTreeNewColumn(Context->TreeNewHandle, TREE_COLUMN_ITEM_DESCRIPTION, TRUE, L"Description", 140, PH_ALIGN_LEFT, 1, 0);
+    PhAddTreeNewColumn(Context->TreeNewHandle, TREE_COLUMN_ITEM_PAGEDALLOC, TRUE, L"Paged Allocations", 80, PH_ALIGN_RIGHT, 2, DT_RIGHT);
+    PhAddTreeNewColumn(Context->TreeNewHandle, TREE_COLUMN_ITEM_PAGEDFREE, TRUE, L"Paged Frees", 80, PH_ALIGN_RIGHT, 3, DT_RIGHT);
+    PhAddTreeNewColumn(Context->TreeNewHandle, TREE_COLUMN_ITEM_PAGEDCURRENT, TRUE, L"Paged Current", 80, PH_ALIGN_RIGHT, 4, DT_RIGHT);
+    PhAddTreeNewColumn(Context->TreeNewHandle, TREE_COLUMN_ITEM_PAGEDTOTAL, TRUE, L"Paged Bytes Total", 80, PH_ALIGN_LEFT, 5, 0);
+    PhAddTreeNewColumn(Context->TreeNewHandle, TREE_COLUMN_ITEM_NONPAGEDALLOC, TRUE, L"Non-paged Allocations", 80, PH_ALIGN_RIGHT, 6, DT_RIGHT);
+    PhAddTreeNewColumn(Context->TreeNewHandle, TREE_COLUMN_ITEM_NONPAGEDFREE, TRUE, L"Non-paged Frees", 80, PH_ALIGN_RIGHT, 7, DT_RIGHT);
+    PhAddTreeNewColumn(Context->TreeNewHandle, TREE_COLUMN_ITEM_NONPAGEDCURRENT, TRUE, L"Non-paged Current", 80, PH_ALIGN_RIGHT, 8, DT_RIGHT);
+    PhAddTreeNewColumn(Context->TreeNewHandle, TREE_COLUMN_ITEM_NONPAGEDTOTAL, TRUE, L"Non-paged Bytes Total", 80, PH_ALIGN_LEFT, 9, 0);
+
+    TreeNew_SetTriState(Context->TreeNewHandle, TRUE);
+    TreeNew_SetSort(Context->TreeNewHandle, TREE_COLUMN_ITEM_NONPAGEDTOTAL, DescendingSortOrder);
+
+    PmLoadSettingsTreeList(Context);
+
+    PhInitializeTreeNewFilterSupport(&Context->FilterSupport, Context->TreeNewHandle, Context->NodeList);
+}
+
+VOID PmDeletePoolTagTree(
+    _In_ PPOOLTAG_CONTEXT Context
+    )
+{
+    PPH_STRING settings;
+
+    settings = PhCmSaveSettings(Context->TreeNewHandle);
+    PhSetStringSetting2(SETTING_NAME_POOL_TREE_LIST_COLUMNS, &settings->sr);
+    PhDereferenceObject(settings);
+
+    for (ULONG i = 0; i < Context->NodeList->Count; i++)
+    {
+        PmDestroyPoolTagNode(Context->NodeList->Items[i]);
+    }
+
+    PhDereferenceObject(Context->NodeHashtable);
+    PhDereferenceObject(Context->NodeList);
+}

--- a/plugins/ExtendedTools/resource.h
+++ b/plugins/ExtendedTools/resource.h
@@ -96,6 +96,15 @@
 #define ID_DISK_OPENFILELOCATION        40008
 #define ID_DISK_INSPECT                 40009
 
+#define ID_POOL_TABLE                   50000
+#define IDD_POOL                        50001
+#define IDR_TXT_POOLTAGS                50002
+#define IDD_BIGPOOL                     50003
+#define IDC_POOLTREE                    50004
+#define IDC_POOLSEARCH                  50005
+#define IDC_POOLCLEAR                   50006
+#define IDC_BIGPOOLLIST                 50007
+
 // Next default values for new objects
 // 
 #ifdef APSTUDIO_INVOKED

--- a/plugins/ExtendedTools/resources/pooltag.txt
+++ b/plugins/ExtendedTools/resources/pooltag.txt
@@ -1,0 +1,4345 @@
+//
+//    Copyright (C) Microsoft.  All rights reserved.
+//
+rem
+rem    Pooltag.txt
+rem
+rem    This file lists the tags used for pool allocations by kernel mode components
+rem    and drivers.
+rem
+rem    The file has the following format:
+rem       <PoolTag> - <binary-name> - <Description>
+rem
+rem    Pooltag.txt is installed with Debugging Tools for Windows (in %windbg%\triage)
+rem    and with the Windows DDK (in %winddk%\tools\other\platform\poolmon, where
+rem    platform is amd64, i386, or arm).
+rem
+
+@GMM - <unknown>    - (Intel video driver) Memory manager
+@KCH - <unknown>    - (Intel video driver) Chipset specific service
+@MP  - <unknown>    - (Intel video driver) Miniport related memory
+@SB  - <unknown>    - (Intel video driver) Soft BIOS
+
+_ATI - <unknown>    - ATI video driver
+
+_LCD - monitor.sys  - Monitor PDO name buffer
+
+8042 - i8042prt.sys - PS/2 keyboard and mouse
+
+AdSv - vmsrvc.sys   - Virtual Machines Additions Service
+ARPC - atmarpc.sys  - ATM ARP Client
+ATMU - atmuni.sys   - ATM UNI Call Manager
+Atom - <unknown>    - Atom Tables
+Abos - <unknown>    - Abiosdsk
+AcdM - <unknown>    - TDI AcdObjectInfoG
+AcdN - <unknown>    - TDI AcdObjectInfoG
+AcpA - acpi.sys     - ACPI arbiter data
+AcpB - acpi.sys     - ACPI buffer data
+AcpD - acpi.sys     - ACPI device data
+AcpE - acpi.sys     - ACPI embedded controller data
+AcpF - acpi.sys     - ACPI interface data
+Acpg - acpi.sys     - ACPI GPE data
+Acpi - acpi.sys     - ACPI generic data
+AcpI - acpi.sys     - ACPI irp data
+AcpL - acpi.sys     - ACPI lock data
+AcpM - acpi.sys     - ACPI miscellaneous data
+AcpO - acpi.sys     - ACPI object data
+AcpP - acpi.sys     - ACPI power data
+AcpR - acpi.sys     - ACPI resource data
+AcpS - acpi.sys     - ACPI string data
+Acpt - acpi.sys     - ACPI table data
+AcpT - acpi.sys     - ACPI thermal data
+AcpX - acpi.sys     - ACPI translation data
+Adap - <unknown>    - Adapter objects
+Adbe - <unknown>    - Adobe's font driver
+ADPT - acpipagr.sys - Processor Aggregator Driver
+AECi - <unknown>    - filter object interface for MS acoustic echo canceller
+Afd? - afd.sys      - AFD objects
+AfdA - afd.sys      -     Afd EA buffer
+AfdB - afd.sys      -     Afd data buffer
+AfdC - afd.sys      -     Afd connection structure
+AfdD - afd.sys      -     Afd debug data
+AfdE - afd.sys      -     Afd endpoint structure
+AfdF - afd.sys      -     Afd TransmitFile info
+AfdG - afd.sys      -     Afd group table
+AfdI - afd.sys      -     Afd TDI data
+AfdL - afd.sys      -     Afd local address buffer
+AfdP - afd.sys      -     Afd poll info
+AfdQ - afd.sys      -     Afd work queue item
+AfdR - afd.sys      -     Afd remote address buffer
+AfdS - afd.sys      -     Afd security info
+AfdT - afd.sys      -     Afd transport info
+AfdW - afd.sys      -     Afd work item
+AfdX - afd.sys      -     Afd context buffer
+Afda - afd.sys      -     Afd APC buffer (NT 3.51 only)
+Afdc - afd.sys      -     Afd connect data buffer
+Afdd - afd.sys      -     Afd disconnect data buffer
+Afdf - afd.sys      -     Afd TransmitFile debug data
+Afdh - afd.sys      -     Afd address list change buffer
+Afdi - afd.sys      -     Afd "set inline mode" buffer
+Afdl - afd.sys      -     Afd lookaside lists buffer
+Afdp - afd.sys      -     Afd transport IRP buffer
+Afdq - afd.sys      -     Afd routing query buffer
+Afdr - afd.sys      -     Afd ERESOURCE buffer
+Afdt - afd.sys      -     Afd transport address buffer
+Ahca - ahcache.sys  -     Appcompat kernel cache pool tag
+
+AleD - tcpip.sys    -     ALE remote endpoint
+Ala4 - tcpip.sys    -     ALE remote endpoint IPv4 address
+Ala6 - tcpip.sys    -     ALE remote endpoint IPv6 address
+Alei - tcpip.sys    -     ALE arrival/nexthop interface cache
+AleU - tcpip.sys    -     ALE pend context
+AleE - tcpip.sys    -     ALE endpoint context
+AlLl - tcpip.sys    -     ALE remote endpoint LRU
+AlCi - tcpip.sys    -     ALE credential info
+AlSP - tcpip.sys    -     ALE secure socket policy
+AlPU - tcpip.sys    -     ALE secure socket policy update
+AlPi - tcpip.sys    -     ALE peer info
+AlP4 - tcpip.sys    -     ALE peer IPv4 address
+AlP6 - tcpip.sys    -     ALE peer IPv6 address
+AlPT - tcpip.sys    -     ALE peer target
+Alep - tcpip.sys    -     ALE process info
+AleS - tcpip.sys    -     ALE token info
+AleP - tcpip.sys    -     ALE process image path
+AleK - tcpip.sys    -     ALE audit
+AleA - tcpip.sys    -     ALE connection abort context
+AlDN - tcpip.sys    -     ALE endpoint delete notify
+AleW - tcpip.sys    -     ALE enum filter array
+AleN - tcpip.sys    -     ALE notify context
+AlSs - tcpip.sys    -     ALE socket security context
+AlPF - tcpip.sys    -     ALE policy filters
+AleL - tcpip.sys    -     ALE LRU
+AleI - tcpip.sys    -     ALE token ID
+AlP5 - tcpip.sys    -     ALE 5-tuple state
+AlE5 - tcpip.sys    -     ALE 5-tuple temp entry
+
+Aric - tcpip.sys    -     ALE route inspection context
+Adnc - tcpip.sys    -     ALE endpoint deactivation notification context
+Acrc - tcpip.sys    -     ALE connect request inspection context
+Acrl - tcpip.sys    -     ALE connect redirect layer data
+Abrc - tcpip.sys    -     ALE bind request inspection context
+Abrl - tcpip.sys    -     ALE bind redirect layer data
+AlSm - tcpip.sys    -     ALE Secondary App Meta Data
+
+Afp  - <unknown>    - SFM File server
+AlCI - nt!alpc      - ALPC communication info
+AlEv - nt!alpc      - ALPC eventlog queue
+AlIn - nt!alpc      - ALPC Internal allocation
+AlHa - nt!alpc      - ALPC port handle table
+AlMs - nt!alpc      - ALPC message
+ALPC - nt!alpc      - ALPC port objects
+AlRe - nt!alpc      - ALPC section region
+AlRr - nt!Alpc      - ALPC resource reserves
+AlSc - nt!alpc      - ALPC section
+AlSe - nt!alpc      - ALPC client security
+AlVi - nt!alpc      - ALPC view
+ATmp - AppTag mount point
+ATon - AppTag object name
+ATub - AppTag user buffer
+ATgb - AppTag guid buffer
+ATac - AppTag ATR command buffer
+ATdi - AppTag cliendata index buffer
+ATdt - AppTag cliendata temp buffer
+ATFb - AppTag file id buffer
+
+Aml* - <unknown>    - ACPI AMLI Pooltags
+APIC - pnpapic.sys  - I/O APIC Driver
+ArbA - nt!arb       - ARBITER_ALLOCATION_STATE_TAG
+ArbL - nt!arb       - ARBITER_ORDERING_LIST_TAG
+ArbM - nt!arb       - ARBITER_MISC_TAG
+ArbR - nt!arb       - ARBITER_RANGE_LIST_TAG
+Arp? - <unknown>    - ATM ARP server objects, atmarps.sys
+ArpA - <unknown>    -     AtmArpS address
+ArpB - <unknown>    -     AtmArpS buffer space
+ArpI - <unknown>    -     AtmArpS Interface structure
+ArpK - <unknown>    -     AtmArpS ARP block
+ArpM - <unknown>    -     AtmArpS MARS structure
+ArpR - <unknown>    -     AtmArpS NDIS request
+ArpS - <unknown>    -     AtmArpS SAP structure
+Asy1 - <unknown>    - ndis / ASYNC_IOCTX_TAG
+Asy2 - <unknown>    - ndis / ASYNC_INFO_TAG
+Asy3 - <unknown>    - ndis / ASYNC_ADAPTER_TAG
+Asy4 - <unknown>    - ndis / ASYNC_FRAME_TAG
+AtC  - <unknown>    - IDE disk configuration
+AtD  - <unknown>    - atdisk.c
+ATIX - <unknown>    - WDM mini drivers for ATI tuner, xbar, etc.
+Atk  - <unknown>    - Appletalk transport
+AtmA - <unknown>    - Atoms
+AtmT - <unknown>    - Atom tables
+AtvE - cea_km.lib   - Event broker aggregation library.
+AuxL - <unknown>    - EXIFS Auxlist
+
+AzAp - HDAudio.sys  - HD Audio Class Driver (Datastore: audio path)
+AzAd - HDAudio.sys  - HD Audio Class Driver (AzPcAudDev)
+AzCd - HDAudio.sys  - HD Audio Class Driver (CodecVendor)
+AzCE - HDAudio.sys  - HD Audio Class Driver (CEAAudioRender)
+AzCm - HDAudio.sys  - HD Audio Class Driver (AzCommon)
+AzFg - HDAudio.sys  - HD Audio Class Driver (Audio Function Group)
+Azfg - HDAudio.sys  - HD Audio Class Driver (datastore: function group)
+AzJd - HDAudio.sys  - HD Audio Class Driver (JackDetector)
+AzMa - HDAudio.sys  - HD Audio Class Driver (Main)
+AzMi - HDAudio.sys  - HD Audio Class Driver (micin, MixedCapture)
+AzMu - HDAudio.sys  - HD Audio Class Driver (MuxedCapture)
+AzMx - HDAudio.sys  - HD Audio Class Driver (AzMixerport)
+AzLd - HDAudio.sys  - HD Audio Class Driver (Datastore: logical device)
+AzLi - HDAudio.sys  - HD Audio Class Driver (CDIn,AUXIn, linein)
+AzLg - HDAudio.sys  - HD Audio Class Driver (debug)
+AzLs - HDAudio.sys  - HD Audio Class Driver (DLTest)
+AzPd - HDAudio.sys  - HD Audio Class Driver (AzDma)
+AzPx - HDAudio.sys  - HD Audio Class Driver (AzPower)
+AzRr - HDAudio.sys  - HD Audio Class Driver (RedirectedRender)
+AzRR - HDAudio.sys  - HD Audio Class Driver (SpdifEmbeddedRender, SpdifOut, Headphone, HBDAout)
+AzSd - HDAudio.sys  - HD Audio Class Driver (subdevicegraph)
+AzSi - HDAudio.sys  - HD Audio Class Driver (SpdifIn)
+AzSt - HDAudio.sys  - HD Audio Class Driver (AzWaveCyclicStream, HdaWaveRTstream)
+AzTs - HDAudio.sys  - HD Audio Class Driver (TestSet1000, TestSet1001)
+AzUT - HDAudio.sys  - HD Audio Class Driver (TestSet0004)
+AzWd - HDAudio.sys  - HD Audio Class Driver (AzWidget)
+AzWp - HDAudio.sys  - HD Audio Class Driver (AzWaveport, HdaWaveRTminiport)
+
+Bat? - <unknown>    - Battery Class drivers
+BatC - <unknown>    -     Composite battery driver
+BatM - <unknown>    -     Control method battery driver
+BatS - <unknown>    -     Smart battery driver
+Batt - <unknown>    -     Battery class driver
+BCSP - bthbcsp.sys  - Bluetooth BCSP minidriver
+BCDK - nt!init      - Kernel boot configuration data.
+BDD  - BasicDisplay.sys - Microsoft Basic Display Driver
+BIG  - nt!mm        - Large session pool allocations (ntos\ex\pool.c)
+BlCc - blkcache.sys - Block Cache Driver
+Bmfd - <unknown>    - Font related stuff
+BT3C - bt3c.sys     - Bluetooth 3COM minidriver
+BT8x - <unknown>    - WDM mini drivers for Brooktree 848,829, etc.
+BTHP - bthport.sys  - Bluetooth port driver (generic)
+BthS - bthport.sys  - Bluetooth port driver (security)
+BTME - bthenum.sys  - Bluetooth enumerator
+BTMO - bthmodem.sys - Bluetooth modem
+BTPT - <unknown>    - Bluetooth transport protocol library
+BTSR - bthser.sys   - Bluetooth serial minidriver
+BTUR - bthuart.sys  - Bluetooth UART minidriver
+WPAD - BasicRender.sys - Basic Render Adapter
+WPDV - BasicRender.sys - Basic Render DX Device
+WPCT - BasicRender.sys - Basic Render DX Context
+WPAL - BasicRender.sys - Basic Render Allocation
+WPAO - BasicRender.sys - Basic Render Opened Allocation
+WPRC - BasicRender.sys - Basic Render Rectangles (for Present)
+Bu*  - <unknown>    - burneng.sys from adaptec
+
+BvHI - netiobvt.sys - BVT HT Items
+BvHT - netiobvt.sys - BVT HT Tables
+
+Call - nt!ex        - kernel callback object signature
+call - <unknown>    - debugging call tables
+CBRe - <unknown>    - CallbackRegistration
+CBSI - cbsi.sys     - Common Block Store
+Cc   - nt!cc        - Cache Manager allocations (catch-all)
+CcAs - nt!cc        - Cache Manager Async cached read structure
+CcBc - nt!cc        - Cache Manager Bcb from pool
+CcBm - nt!cc        - Cache Manager Bitmap
+CcBn - nt!cc        - Cache Manager Bcb trim notification entry
+CcBr - nt!cc        - Cache Manager Bitmap range
+CcBz - nt!cc        - Cache Manager Bcb Zone
+CcDw - nt!cc        - Cache Manager Deferred Write
+CcEv - nt!cc        - Cache Manager Event
+CcFn - nt!cc        - Cache Manager File name for popups
+CCFF - CCFFilter.sys - Cluster Client Failover Filter
+CcMb - nt!cc        - Cache Manager Mbcb
+CcOb - nt!cc        - Cache Manager Overlap Bcb
+CcPB - nt!ccpf      - Prefetcher trace buffer
+CcPC - nt!ccpf      - Prefetcher context
+CcPD - nt!ccpf      - Prefetcher trace dump
+CcPF - nt!ccpf      - Prefetcher file name
+CcPI - nt!ccpf      - Prefetcher intermediate table
+CcPL - nt!ccpf      - Prefetcher read list
+CcPM - nt!ccpf      - Prefetcher metadata
+CcPS - nt!ccpf      - Prefetcher scenario
+CcPT - nt!ccpf      - Prefetcher trace
+CcPV - nt!ccpf      - Prefetcher queried volumes
+CcPW - nt!ccpf      - Prefetcher workers
+CcPa - nt!ccpf      - Prefetcher async context
+CcPc - nt!cc        - Cache Manager Private Cache Map
+CcPf - nt!ccpf      - Prefetcher
+CcPh - nt!ccpf      - Prefetcher header preallocation
+CcPn - nt!ccpf      - Prefetcher name info
+CcPp - nt!ccpf      - Prefetcher instructions
+CcPq - nt!ccpf      - Prefetcher query buffer
+CcPs - nt!ccpf      - Prefetcher section table
+CcPv - nt!ccpf      - Prefetcher volume info
+CcPw - nt!ccpf      - Prefetcher enable worker
+CcSc - nt!cc        - Cache Manager Shared Cache Map
+CcVa - nt!cc        - Cache Manager Initial array of Vacbs
+CcVl - nt!cc        - Cache Manager Vacb Level structures (large streams)
+CcVp - nt!cc        - Cache Manager Array of Vacb pointers for a cached stream
+CctX - <unknown>    - EXIFX FCB Commit CTX
+CcWq - nt!cc        - Cache Manager Work Queue Item
+CcWK - nt!cc        - Kernel Cache Manager lookaside list
+CcWk - nt!cc        - Kernel Cache Manager lookaside list
+CcZe - nt!cc        - Cache Manager Buffer of Zeros
+CDmp - crashdmp.sys - Crashdump driver
+CdA  - <unknown>    - CdAudio filter driver
+Cdcc - cdfs.sys     - CDFS Ccb
+Cddn - cdfs.sys     - CDFS CdName in dirent
+Cdee - cdfs.sys     - CDFS Search expression for enumeration
+Cdfd - cdfs.sys     - CDFS Data Fcb
+Cdfi - cdfs.sys     - CDFS Index Fcb
+Cdfl - cdfs.sys     - CDFS Filelock
+CdFn - cdfs.sys     - CDFS Filename buffer
+Cdfn - cdfs.sys     - CDFS Nonpaged Fcb
+Cdfs - cdfs.sys     - CDFS General Allocation
+Cdft - cdfs.sys     - CDFS Fcb Table entry
+Cdgs - cdfs.sys     - CDFS Generated short name
+Cdic - cdfs.sys     - CDFS Irp Context
+Cdil - cdfs.sys     - CDFS Irp Context lite
+Cdio - cdfs.sys     - CDFS Io context for async reads
+Cdma - cdfs.sys     - CDFS Mcb array
+Cdpe - cdfs.sys     - CDFS Prefix Entry
+CdPn - cdfs.sys     - CDFS CdName in path entry
+Cdpn - cdfs.sys     - CDFS Prefix Entry name
+Cdsp - cdfs.sys     - CDFS Buffer for spanning path table
+Cdtc - cdfs.sys     - CDFS TOC
+Cdun - cdfs.sys     - CDFS Buffer for upcased name
+Cdvd - cdfs.sys     - CDFS Buffer for volume descriptor
+Cdvp - cdfs.sys     - CDFS Vpb allocated in filesystem
+CIcr - ci.dll       - Code Integrity allocations for image integrity checking
+CIsc - ci.dll       - Code Integrity core dll
+CIha - ci.dll       - Code Integrity hashes
+CKRT - <multiple>   - Cluster Kernel RTL library
+CLb* - clusbflt.sys - Cluster block storage target driver
+CLB* - clusbflt.sys - Cluster block storage target driver
+CLd* - clusdflt.sys - Cluster disk filter driver
+ClfA - clfs.sys     - CLFS Log container lookaside list
+ClfB - clfs.sys     - CLFS Log base file lookaside list
+ClfC - clfs.sys     - CLFS Log physical FCB lookaside list
+ClfD - clfs.sys     - CLFS Log virtual FCB lookaside list
+ClfE - clfs.sys     - CLFS Log CCB lookaside list
+ClfF - clfs.sys     - CLFS Log flush element lookaside list
+ClfG - clfs.sys     - CLFS Log I/O Request lookaside list
+ClfH - clfs.sys     - CLFS Log I/O control block lookaside list
+ClfI - clfs.sys     - CLFS Log marshal buffer lookaside list
+ClfJ - clfs.sys     - CLFS Log MDL reference
+ClfK - clfs.sys     - CLFS Log read completion element
+ClfL - clfs.sys     - CLFS Log base file image (obsolete)
+ClfN - clfs.sys     - CLFS Log base file lock
+ClfO - clfs.sys     - CLFS Log zero page
+ClfP - clfs.sys     - CLFS Log request state
+ClfS - clfs.sys     - CLFS Log base file snapshot
+Clfs - clfs.sys     - CLFS General buffer, or owner page lookaside list
+ClNt - netft.sys    - NetFt
+ClNw - netft.sys    - NetFt work items
+CM   - nt!cm        - Configuration Manager (registry)
+CmcD - hal.dll      - HAL CMC Driver Log
+CmcK - hal.dll      - HAL CMC Kernel Log
+CmcT - hal.dll      - HAL CMC temporary Log
+CMCa - nt!cm        - Configuration Manager Cache (registry)
+CMDc - nt!cm        - Configuration Manager Cache (registry)
+CMkb - nt!cm        - registry key control blocks
+CMpb - nt!cm        - registry post blocks
+CMnb - nt!cm        - registry notify blocks
+CMpe - nt!cm        - registry post events
+CMpa - nt!cm        - registry post apcs
+CMsb - nt!cm        - registry stash buffer
+CmVn - nt!cm        - captured value name
+CMVw - nt!cm        - registry mapped view of file
+CMVa - nt!cm        - value cache value tag
+CMVI - nt!cm        - value index cache tag
+CMSc - nt!cm        - security cache pooltag
+CMSb - nt!cm        - internal stash buffer pool tag
+CMNb - nt!cm        - Configuration Manager Name Tag
+CMIn - nt!cm        - Configuration Manager  Index Hint Tag
+CMDa - nt!cm        - value data cache pool tag
+CMAl - nt!cm        - internal registry memory allocator pool tag
+CMA1 - nt!cm        - Configuration Manager Audit Tag 1
+CMA2 - nt!cm        - Configuration Manager Audit Tag 2
+CMA3 - nt!cm        - Configuration Manager Audit Tag 3
+CMA4 - nt!cm        - Configuration Manager Audit Tag 4
+CMIx - nt!cm        - Configuration Manager Intent Lock Tag
+CMUw - nt!cm        - Configuration Manager Unit of Work Tag
+CMTr - nt!cm        - Configuration Manager Transaction Tag
+CMRm - nt!cm        - Configuration Manager Resource Manager Tag
+CM?? - nt!cm        - Internal Configuration manager allocations
+Cngb - ksecdd.sys   - CNG kmode crypto pool tag
+COMX - serial.sys   - serial driver allocations
+Cont - <unknown>    - Contiguous physical memory allocations for device drivers
+CopW - <unknown>    - EXIFS CopyOnWrite
+Covr - nt!cov       - Code Coverage pool tag
+CpeD - hal.dll      - HAL CPE Driver Log
+CpeK - hal.dll      - HAL CMC Kernel Log
+CpeT - hal.dll      - HAL CPE temporary Log
+CPnp - classpnp.sys - ClassPnP transfer packets
+Crsp - ksecdd.sys   - CredSSP kernel mode client allocations
+CrtH - <unknown>    - EXIFS Create Header
+Cryp - ksecdd.sys   - Crypto allocations
+CSdk - <unknown>    - Cluster Disk Filter driver
+CSnt - <unknown>    - Cluster Network driver
+CTE  - <unknown>    - Common transport environment (ntos\inc\cxport.h, used by tdi)
+Cvli - <unknown>    - EXIFS Cached Volume Info
+
+D2d  - <unknown>    - Device Object to DosName rtns (ntos\rtl\dev2dos.c)
+D3Dd - <unknown>    - DX D3D driver (embedded in a display driver like s3mvirge.dll)
+D851 - <unknown>    - 8514a video driver
+Dacl - <unknown>    - Temp allocations for object DACLs
+DamK - dam.sys      - Desktop Activity Moderator
+Dati - <unknown>    - ati video driver
+DbCb - nt!dbg       - Debug Print Callbacks
+DbLo - <unknown>    - Debug logging
+dcam - <unknown>    - WDM mini driver for IEEE 1394 digital camera
+
+DcbA - msdcb.sys    - DCB application priority
+DcbC - msdcb.sys    - DCB NMR provider context
+DcbD - msdcb.sys    - DCB NDIS_QOS_CONFIGURATION
+DcbG - msdcb.sys    - DCB string data
+DcbI - msdcb.sys    - DCB interface context
+DcbL - msdcb.sys    - DCB LLDP buffer
+DcbP - msdcb.sys    - DCB NDIS port information
+DcbR - msdcb.sys    - DCB store change record
+DcbS - msdcb.sys    - DCB security object
+DcbU - msdcb.sys    - DCB UQOS_POLICY_DESCRIPTOR
+DcbX - msdcb.sys    - DCB general
+
+Dcdd - cdd.dll      - Canonical display driver
+Dcl  - <unknown>    - cirrus video driver
+Ddk  - <unknown>    - Default for driver allocated memory (user's of ntddk.h)
+Devi - <unknown>    - Device objects
+
+DEag - devolume.sys - Drive extender disk set array: DEVolume!DEDiskSet *
+DEbo - devolume.sys - Drive extender bus opener context: DEVolume!DEBusOpenerContext
+DEbe - devolume.sys - Drive extender extends buffer
+DEbg - devolume.sys - Drive extender bus opener context global: DEVolume!DEBusOpenerContextGlobal
+DEbm - devolume.sys - Drive extender bitmap
+DEbu - devolume.sys - Drive extender generic buffer
+DEcl - devolume.sys - Drive extender delayed cleaner: DEVolume!DelayedCleaner
+DEct - devolume.sys - Drive extender chunk table
+DEda - devolume.sys - Drive extender disk array: DEVolume!DEDisk *
+DEdb - devolume.sys - Drive extender disk directory information
+DEdc - devolume.sys - Drive extender disk chunk: DEVolume!DiskChunk
+DEdg - devolume.sys - Drive extender disk globals: DEVolume!DEDiskGlobals
+DEdi - devolume.sys - Drive extender disk: DEVolume!DEDisk
+DEdm - devolume.sys - Drive extender disk mini chunk: DEVolume!DiskMiniChunk
+DEdn - devolume.sys - Drive extender disk identification info: DEVolume!DiskIdentificationInfo
+DEdr - devolume.sys - Drive extender device relations
+DEds - devolume.sys - Drive extender disk set: DEVolume!DEDiskSet
+DEdt - devolume.sys - Drive extender disk message: DEVolume!DE_DISK_MESSAGE
+DEdu - devolume.sys - Drive extender disk set message: DEVolume!DE_DISK_SET_MESSAGE
+DEdv - devolume.sys - Drive extender driver object: DEVolume!DEDriver
+DEea - devolume.sys - Drive extender expanding array: DEVolume!ExpandingAutoPointerArray<T>
+DEec - devolume.sys - Drive extender ECC Page: DEVolume!DeEccPage
+DEfg - devolume.sys - Drive extender filter: DEVolume!DEFilter
+DEga - devolume.sys - Drive extender guild array
+DEic - devolume.sys - Drive extender filter instance context
+DEip - devolume.sys - Drive extender IRP based logical to physical request: DEVolume!IrpBasedLogicalToPhysicalRequest
+DEir - devolume.sys - Drive extender IRP based read request: DEVolume!IrpBasedReadRequest
+DEiw - devolume.sys - Drive extender IRP based write request: DEVolume!IrpBasedWriteRequest
+DEla - devolume.sys - Drive extender log mini chunk array
+DElb - devolume.sys - Drive extender log buffer
+DEli - devolume.sys - Drive extender disk set id record: DEVolume!DiskSetIdentificationRecord
+DElm - devolume.sys - Drive extender log manager: DEVolume!LogManager
+DElp - devolume.sys - Drive extender logical to physical request: DEVolume!LogicalToPhysicalRequest
+DElr - devolume.sys - Drive extender log reader: DEVolume!LogReader
+DElv - devolume.sys - Drive extender disk set volume id record: DEVolume!VolumeIdentificationRecord
+DElw - devolume.sys - Drive extender log writer buffer: DEVolume!LogWriterBuffer
+DEmc - devolume.sys - Drive extender volume chunk init mapping manager: DEVolume!VolumeChunkInitializationMappingManager
+DEml - devolume.sys - Drive extender log mapping manager: DEVolume!LogMappingManager
+DEms - devolume.sys - Drive extender superblock mapping manager: DEVolume!SuperBlockMappingManager
+DEmv - devolume.sys - Drive extender volume mapping manager: DEVolume!VolumeMappingManager
+DEog - devolume.sys - Drive extender old GUID array
+DEpe - devolume.sys - Drive extender pingable event: DEVolume!PingableEvent
+DEpg - devolume.sys - Drive extender pingable object globals: DEVolume!PingableObjectGlobals
+DEpm - devolume.sys - Drive extender physical map: DEVolume!PhysicalMap
+DEqm - devolume.sys - Drive extender queued message: DEVolume!QueuedMessage
+DEra - devolume.sys - Drive extender disk event request
+DErb - devolume.sys - Drive extender become dirty request: DEVolume!VolumeChunk::BecomeDirtyRequest
+DErc - devolume.sys - Drive extender commit request: DEVolume!VolumeChunk::CommitRequest
+DErd - devolume.sys - Drive extender decommit request: DEVolume!VolumeChunk::DecommitRequest
+DEre - devolume.sys - Drive extender decommit all request: DEVolume!DiskSetVolume::DecommitAllRequest
+DErg - devolume.sys - Drive extender registry: DEVolume!DERegistry
+DErh - devolume.sys - Drive extender replicate chunk: DEVolume!ReplicateChunk
+DErl - devolume.sys - Drive extender long and notify request: DEVolume!DiskSetVolume::LogAndNotifyRequest
+DErm - devolume.sys - Drive extender range lock manager: DEVolume!RangeLockManager
+DErn - devolume.sys - Drive extender new epoch request: DEVolume!DEDiskSet::NewEpochRequest
+DEro - devolume.sys - Drive extender become out of date request: DEVolume!VolumeChunk::BecomeOutOfDateRequest
+DErp - devolume.sys - Drive extender replicator: DEVolume!Replicator
+DErr - devolume.sys - Drive extender read request: DEVolume!ReadRequest
+DErs - devolume.sys - Drive extender delete or shutdown request: DEVolume!DiskSetVolume::DeleteOrShutdownRequest
+DErt - devolume.sys - Drive extender start request: DEVolume!DEDiskSet::StartRequest
+DEru - devolume.sys - Drive extender shutdown request: DEVolume!DEDiskSet::ShutdownRequest
+DErv - devolume.sys - Drive extender repair volume request: DEVolume!DiskSetVolume::RepairVolumeDamageRequest
+DErw - devolume.sys - Drive extender read write target: DEVolume!ReadWriteTarget
+DErx - devolume.sys - Drive extender shutdown system request: DEVolume!DiskSetVolume::ShutdownRequest
+DEry - devolume.sys - Drive extender start or create request: DEVolume!DiskSetVolume::StartOrCreateRequest
+DErz - devolume.sys - Drive extender write super blocks request: DEVolume!DEDiskSet::WriteSuperBlocksRequest
+DEsb - devolume.sys - Drive extender super block buffer
+DEsd - devolume.sys - Drive extender disk set disk: DEVolume!DiskSetDisk
+DEsg - devolume.sys - Drive extender disk set globals: DEVolume!DEDiskSetGlobals
+DEsh - devolume.sys - Drive extender space holder operation: DEVolume!SpaceHolderOperation
+DEte - devolume.sys - Drive extender data error message: DEVolume!DE_DATA_ERROR_MESSAGE
+DEtr - devolume.sys - Drive extender trace message
+DEtn - devolume.sys - Drive extender range lock test node
+DEtx - devolume.sys - Drive extender range lock test
+DEts - devolume.sys - Drive extender splay tree test
+DEtw - devolume.sys - Drive extender trim worker pauser: DEVolume!AutoPauseTrimWorker
+DEub - devolume.sys - Drive extender unaligned EccPage temp buffer: DEVolume!DeEccPage
+DEus - devolume.sys - Drive extender unicode string
+DEva - devolume.sys - Drive extender volume chunk array: DEVolume!AutoVolumeChunkPtr *
+DEvc - devolume.sys - Drive extender volume chunk: DEVolume!VolumeChunk
+DEvg - devolume.sys - Drive extender volume globals: DEVolume!DEVolumeGlobals
+DEvh - devolume.sys - Drive extender volume device globals: DEVolume!DEVolumeDeviceGlobals
+DEvm - devolume.sys - Drive extender volume message: DEVolume!DE_VOLUME_MESSAGE
+DEvo - devolume.sys - Drive extender volume message: DEVolume!DEVolume
+DEvs - devolume.sys - Drive extender disk set volume: DEVolume!DiskSetVolume
+DEwi - devolume.sys - Drive extender work item: DEVolume!AutoWorkItem
+DEze - devolume.sys - Drive extender cluster of zeros
+
+Dh 0 - <unknown>    - DirectDraw/3D default object
+Dh 1 - <unknown>    - DirectDraw/3D DirectDraw object
+Dh 2 - <unknown>    - DirectDraw/3D Surface object
+Dh 3 - <unknown>    - DirectDraw/3D Direct3D context object
+Dh 4 - <unknown>    - DirectDraw/3D VideoPort object
+Dh 5 - <unknown>    - DirectDraw/3D MotionComp object
+
+Dfb  - <unknown>    - framebuf video driver
+DfC? - dfsc.sys     - DFS Client allocations
+DfCa - dfsc.sys     - DFS Client PERUSERTABLE
+DfCb - dfsc.sys     - DFS Client REFCONTEXT
+DfCc - dfsc.sys     - DFS Client CONNECTION
+DfCd - dfsc.sys     - DFS Client CURRENTDC
+DfCe - dfsc.sys     - DFS Client CSCEA
+DfCf - dfsc.sys     - DFS Client FILENAME
+DfCg - dfsc.sys     - DFS Client PREFIXCACHE
+DfCh - dfsc.sys     - DFS Client HASH
+DfCi - dfsc.sys     - DFS Client INPUTBUFFER
+DfCj - dfsc.sys     - DFS Client REFERRALNAME
+DfCj - dfsc.sys     - DFS Client REWRITTENNAME
+DfCl - dfsc.sys     - DFS Client DCLIST
+DfCm - dfsc.sys     - DFS Client CMCONTEXT
+DfCn - dfsc.sys     - DFS Client DOMAINNAME
+DfCp - dfsc.sys     - DFS Client PATH
+DfCq - dfsc.sys     - DFS Client REGSTRING
+DfCr - dfsc.sys     - DFS Client REFERRAL
+DfCs - dfsc.sys     - DFS Client SHARENAME
+DfCt - dfsc.sys     - DFS Client TREECONNECT
+DfCu - dfsc.sys     - DFS Client USETABLE
+DfCv - dfsc.sys     - DFS Client SERVERNAME
+DfCw - dfsc.sys     - DFS Client TARGETINFO
+DfCx - dfsc.sys     - DFS Client CREDENTIALS
+DfCy - dfsc.sys     - DFS Client REMOTEENTRY
+DfCz - dfsc.sys     - DFS Client DOMAINREFERRAL
+Dfs  - <unknown>    - Distributed File System
+dfsr - <unknown>    - RDBSS IRP allocation
+Dfsm - <unknown>    - Eng event allocation (ENG_KEVENTALLOC,ENG_ALLOC) in ntgdi\gre
+dFVE - dumpfve.sys  - Full Volume Encryption crash dump filter (Bitlocker Drive Encryption)
+Dict - storport.sys - StorCreateDictionary storport!_STOR_DICTIONARY.Entries
+Dire - <unknown>    - Directory objects
+Dlck - <unknown>    - deadlock verifier (part of driver verifier) structures
+Dlmp - <unknown>    - Video utility library for Vista display drivers
+Dmga - <unknown>    - mga (matrox) video driver
+DmH? - <unknown>    - DirectMusic hardware synthesizer
+DmpS - dumpsvc.sys  - Crashdump Service Driver
+DmS? - <unknown>    - DirectMusic kernel software synthesizer
+Dndt - <unknown>    - Device node
+Dnod - <unknown>    - Device node structure
+DOPE - <unknown>    - Device Object Power Extension (po component)
+DpDc - FsDepends.sys - FsDepends Dependency Context Block
+DpDl - FsDepends.sys - FsDepends Dependency List Block
+DpPl - FsDepends.sys - FsDepends Parent Link Block
+DPrf - <unknown>    - Disk performance filter driver
+DPwr - nt!pnp       - PnP power management
+Dprt - dxgkrnl.sys  - Video port for Vista display drivers
+Dps5 - <unknown>    - NT5 PostScript printer driver
+Dpsh - <unknown>    - Postcript driver heap memory
+Dpsi - <unknown>    - psidisp video driver
+Dpsm - <unknown>    - Postcript driver memory
+Dqv  - <unknown>    - qv (qvision) video driver
+DpVc - FsDepends.sys - FsDepends Volume Context Block
+DrDr - rdpdr.sys    - Global object
+DrEx - rdpdr.sys    - Exchange object
+DrIC - rdpdr.sys    - I/O context object
+Driv - <unknown>    - Driver objects
+Drsd - <unknown>    - Rasdd Printer Driver Pool Tag.
+Dtga - <unknown>    - tga video driver
+Dump - <unknown>    - Bugcheck dump allocations
+Dun5 - <unknown>    - NT5 Universal printer driver
+DUQD - mpsdrv.sys   - MPSDRV upcall user request
+DV?? - <unknown>    - RDR2 DAV MiniRedir Tags
+DVCx - <unknown>    - AsyncEngineContext, DAV MiniRedir
+DVEx - <unknown>    - Exchange, DAV MiniRedir
+DVFi - <unknown>    - FileInfo, DAV MiniRedir
+DVFn - <unknown>    - FileName, DAV MiniRedir
+DVRw - <unknown>    - ReadWrite, DAV MiniRedir
+DVSc - <unknown>    - SrvCall, DAV MiniRedir
+DVSh - <unknown>    - SharedHeap, DAV MiniRedir
+
+Dvga - <unknown>    - vga 16 color video driver
+Dvg2 - <unknown>    - vga 256 color video driver
+Dvg6 - <unknown>    - vga 64K color video driver
+Dvgr - <unknown>    - vga for risc video driver
+DW32 - <unknown>    - W32 video driver
+Dwd  - <unknown>    - wd90c24a video driver
+Dwp9 - <unknown>    - weitekp9 video driver
+Dxga - <unknown>    - XGA video driver
+
+DxgK - dxgkrnl.sys  - Vista display driver support
+
+Efsm - <unknown>    - EFS driver
+Efsc - <unknown>    - EFS driver
+
+Efst - <unknown>    -  EXIFS FS Statistics
+
+Envr - <unknown>    - Environment strings
+
+EQAn - tcpip.sys    - EQoS application name
+EQCc - tcpip.sys    - EQoS counters
+EQHb - tcpip.sys    - EQoS HKE binding
+EQHp - tcpip.sys    - EQoS HKE parameters
+EQOw - tcpip.sys    - EQoS policy owner
+EQPn - tcpip.sys    - EQoS policy net entry
+EQPp - tcpip.sys    - EQoS policy profile entry
+EQPs - tcpip.sys    - EQoS policy scratch data
+EQPt - tcpip.sys    - EQoS policy table
+EQQu - tcpip.sys    - EQoS flow unit
+EQSc - tcpip.sys    - EQoS pacer client
+EQSe - tcpip.sys    - EQoS QIM endpoint
+EQSp - tcpip.sys    - EQoS generic policy data
+EQSt - tcpip.sys    - EQoS policy trim scratch
+EQSx - tcpip.sys    - EQoS security object
+EQSy - tcpip.sys    - EQoS proxy data
+EQUn - tcpip.sys    - EQoS uQoS NPI client data
+EQUr - tcpip.sys    - EQoS URL string
+EQUp - tcpip.sys    - EQoS URL policy section
+EQUQ - tcpip.sys    - UQoS generic allocation
+
+Err  - <unknown>    - Error strings
+
+EtwA - nt!etw       - Etw APC
+EtwG - nt!etw       - Etw Guid
+EtwD - nt!etw       - Etw DataBlock
+EtwS - nt!etw       - Etw DataSource
+EtwR - nt!etw       - Etw Registration
+EtwC - nt!etw       - Etw Realtime Consumer
+EtwB - nt!etw       - Etw Buffer
+EtwP - nt!etw       - Etw Pool
+EtwQ - nt!etw       - Etw Queue
+Etwb - nt!etw       - Etw binary tracking
+Etwq - nt!etw       - Etw ReplyQueue
+Etwr - nt!etw       - Etw ReplyQueue Entry
+EtwL - nt!etw       - ETW_LOGGER_CONTEXT
+Etwp - nt!etw       - ETW per-processor block
+EtwW - nt!etw       - ETW work item
+Etwm - nt!etw       - ETW stack tracing bit-map
+EtwF - nt!etw       - ETW schematized filter
+
+Evel - <unknown>    - EFS file system filter driver lookaside list
+Even - <unknown>    - Event objects
+Evid - <unknown>    - Rtl Event ID's
+ExWl - <unknown>    - Executive worker list entry
+
+Fat  - fastfat.sys  - Fat File System allocations
+FatB - fastfat.sys  - Fat allocation bitmaps
+FatC - fastfat.sys  - Fat Ccbs
+FatD - fastfat.sys  - Fat pool dirents
+FatE - fastfat.sys  - Fat EResources
+FatF - fastfat.sys  - Fat Fcbs
+FatI - fastfat.sys  - Fat IrpContexts
+FatL - fastfat.sys  - Fat FAT entry lookup buffer on verify
+FatN - fastfat.sys  - Fat Nonpaged Fcbs
+FatO - fastfat.sys  - Fat I/O buffer
+FatP - fastfat.sys  - Fat output for query retrieval pointers (caller frees)
+FatQ - fastfat.sys  - Fat buffered user buffer
+FatR - fastfat.sys  - Fat repinned Bcb
+FatS - fastfat.sys  - Fat stashed Bpb
+FatT - fastfat.sys  - Fat directory allocation bitmaps
+FatV - fastfat.sys  - Fat Vcb stat bucket
+Fatv - fastfat.sys  - Fat events
+FatW - fastfat.sys  - Fat FAT windowing structure
+FatX - fastfat.sys  - Fat IO contexts
+Fatb - fastfat.sys  - Fat Bcb arrays
+Fatd - fastfat.sys  - Fat EA data
+Fate - fastfat.sys  - Fat EA set headers
+Fatf - fastfat.sys  - Fat deferred flush contexts
+Fati - fastfat.sys  - Fat IO run descriptor
+Fatn - fastfat.sys  - Fat filename buffer
+Fatr - fastfat.sys  - Fat verification-time rootdir snapshot
+Fats - fastfat.sys  - Fat verification-time boot sector
+Fatv - fastfat.sys  - Fat backpocket Vpb
+Fatx - fastfat.sys  - Fat delayed close contexts
+
+Fcbl - <unknown>    - EXIFS FCBlock
+fboX - <unknown>    - EXIFS FOBXVF List
+
+Feiv - netio.sys    - WFP filter engine incoming values
+Fecc - netio.sys    - WFP filter engine classify context
+Fecf - netio.sys    - WFP filter engine callout context
+
+File - <unknown>    - File objects
+FIcn - fileinfo.sys - FileInfo FS-filter Create Retry Path
+FIcp - fileinfo.sys - FileInfo FS-filter Extra Create Parameter
+FIcs - fileinfo.sys - FileInfo FS-filter Stream Context
+FIcv - fileinfo.sys - FileInfo FS-filter Volume Context
+FIOc - fileinfo.sys - FileInfo FS-filter Prefetch Open Context
+FIou - fileinfo.sys - FileInfo FS-filter User Open Context
+FIof - fileinfo.sys - FileInfo FS-filter File Object Context
+FIPc - fileinfo.sys - FileInfo FS-filter Prefetch Context
+FIvn - fileinfo.sys - FileInfo FS-filter Volume Name
+FIvp - fileinfo.sys - FileInfo FS-filter Volume Properties
+
+FlmC - tcpip.sys    - Framing Layer Client Contexts
+FlmP - tcpip.sys    - Framing Layer Provider Contexts
+Flng - tcpip.sys    - Framing Layer Generic Buffers (Tunnel/Port change notifications, ACLs)
+FlpC - tcpip.sys    - Framing Layer Client Contexts
+FlpI - tcpip.sys    - Framing Layer Interfaces
+FlpL - tcpip.sys    - Framing Layer Client Interface Contexts
+FlpM - tcpip.sys    - Framing Layer Multicast Groups
+FlpS - tcpip.sys    - Framing Layer Serialized Requests
+Fl6D - tcpip.sys    - FL6t DataLink Addresses
+Fl4D - tcpip.sys    - FL4t DataLink Addresses
+FlSB - tcpip.sys    - Framing Layer Stack Block
+
+Flop - <unknown>    - floppy driver
+
+Flst - <unknown>    - EXIFS Freelist
+
+Fltt - nt!Vf        - Log of Driver Verifier fault injection stack traces.
+
+FLex - <unknown>    - exclusive file lock
+FLfl - <unknown>    - exported (non-private) file lock
+FLli - <unknown>    - per-file lock information
+FLln - <unknown>    - shared lock tree node
+FLsh - <unknown>    - shared file lock
+FLwl - <unknown>    - waiting lock
+
+FM?? - fltmgr.sys   - Unrecognized FltMgr tag (update pooltag.w)
+FMac - fltmgr.sys   -       ASCII String buffers
+FMas - fltmgr.sys   -       ASYNC_IO_COMPLETION_CONTEXT structure
+FMcb - fltmgr.sys   -       FLT_CCB structure
+FMcn - fltmgr.sys   -       Non paged context extension structures
+FMcp - fltmgr.sys   -       Client port wrapper structure
+FMcr - fltmgr.sys   -       Context registration structures
+FMct - fltmgr.sys   -       TRACK_COMPLETION_NODES structure
+FMdh - fltmgr.sys   -       Paged ECP context for targeted create reparse
+FMdl - fltmgr.sys   -       Array of DEVICE_OBJECT pointers
+FMea - fltmgr.sys   -       EA buffer for create
+FMfc - fltmgr.sys   -       FLTMGR_FILE_OBJECT_CONTEXT structure
+FMfi - fltmgr.sys   -       Fast IO dispatch table
+FMfk - fltmgr.sys   -       Byte Range Lock structure
+FMfl - fltmgr.sys   -       FLT_FILTER structure
+FMfn - fltmgr.sys   -       NAME_CACHE_NODE structure
+FMfr - fltmgr.sys   -       FLT_FRAME structure
+FMfz - fltmgr.sys   -       FILE_LIST_CTRL structure
+FMib - fltmgr.sys   -       Irp SYSTEM buffers
+FMic - fltmgr.sys   -       IRP_CTRL structure
+FMil - fltmgr.sys   -       IRP_CTRL completion node stack
+FMin - fltmgr.sys   -       FLT_INSTANCE name
+FMis - fltmgr.sys   -       FLT_INSTANCE structure
+FMla - fltmgr.sys   -       Per-processor IRPCTRL lookaside lists
+FMlp - fltmgr.sys   -       Paged stream list control entry structures
+FMnc - fltmgr.sys   -       NAME_CACHE_CREATE_CTRL structure
+FMng - fltmgr.sys   -       NAME_GENERATION_CONTEXT structure
+FMol - fltmgr.sys   -       OPLOCK_CONTEXT structure
+FMos - fltmgr.sys   -       Operation status ctrl structure
+FMpl - fltmgr.sys   -       Cache aware pushLock
+FMpr - fltmgr.sys   -       FLT_PRCB structure
+FMrl - fltmgr.sys   -       FLT_OBJECT rundown logs
+FMrp - fltmgr.sys   -       Reparse point data buffer
+FMrr - fltmgr.sys   -       Per-processor Cache-aware rundown ref structure
+FMrs - fltmgr.sys   -       Registry string
+FMrw - fltmgr.sys   -       FLT_REGISTRY_WATCH_CONTEXT structure
+FMsc - fltmgr.sys   -       SECTION_CONTEXT structure
+FMsd - fltmgr.sys   -       Security descriptors
+FMsl - fltmgr.sys   -       STREAM_LIST_CTRL structure
+FMtb - fltmgr.sys   -       TXN_PARAMETER_BLOCK structure
+FMtn - fltmgr.sys   -       Temporary file names
+FMtp - fltmgr.sys   -       Non Paged TxVol context structures
+FMtr - fltmgr.sys   -       Temporary Registry information
+FMts - fltmgr.sys   -       Tree Stack
+FMus - fltmgr.sys   -       Unicode string
+FMvf - fltmgr.sys   -       FLT_VERIFIER_EXTENSION structure
+FMvj - fltmgr.sys   -       FLT_VERIFIER_OBJECT structure
+FMvl - fltmgr.sys   -       Array of FLT_VERIFIER_OBJECT structures
+FMvo - fltmgr.sys   -       FLT_VOLUME structure
+FMwi - fltmgr.sys   -       Work item structures
+
+Fsb -  netio.sys    - Fixed-Size Block pool
+
+Fsrc - fsrec.sys    - Filesystem recognizer (fsrec.sys)
+
+Fstb - <unknown>    - ntos\fstub
+FstB - <unknown>    - ntos\fstub
+
+FsVg - fsvga.sys    - International VGA support
+
+flnk - <unknown>    - font link tag used in ntgdi\gre
+
+fpct - wof.sys      - Compressed file chunk table
+fpcx - wof.sys      - Compressed file IO context
+fpdw - wof.sys      - Compressed file decompression workspace
+fpgn - wof.sys      - Compressed file general
+fppm - wof.sys      - Compressed file IO parameters
+fprd - wof.sys      - Compressed file small read buffer
+fpRD - wof.sys      - Compressed file large read buffer
+fpwi - wof.sys      - Compressed file work item
+fpxp - wof.sys      - Compressed file xpress context
+
+FS?? - nt!fsrtl     - Unrecoginzed File System Run Time allocations (update pooltag.w)
+FSeh - nt!fsrtl     - File System Run Time Extra Create Parameter Entry
+FSel - nt!fsrtl     - File System Run Time Extra Create Parameter List
+FSfm - nt!fsrtl     - File System Run Time Fast Mutex Lookaside List
+FSim - nt!fsrtl     - File System Run Time Mcb Initial Mapping Lookaside List
+FSrt - nt!fsrtl     - File System Run Time allocations (DO NOT USE!)
+FSmg - nt!fsrtl     - File System Run Time
+FSrd - nt!fsrtl     - File System Run Time
+FSrm - nt!fsrtl     - File System Run Time
+FSrn - nt!fsrtl     - File System Run Time
+FSrN - nt!fsrtl     - File System Run Time
+FSro - nt!fsrtl     - File System Run Time
+FSrs - nt!fsrtl     - File System Run Time Work Item for low-stack posting
+FSun - nt!fsrtl     - File System Run Time
+FOCX - nt!fsrtl     - File System Run Time File Object Context structure
+
+FTrc - <unknown>    - Fault tolerance Slist tag.
+FtC  - <unknown>    - Fault tolerance driver
+FtM  - <unknown>    - Fault tolerance driver
+FtS  - <unknown>    - Fault tolerance driver
+FtT  - <unknown>    - Fault tolerance driver
+FtU  - <unknown>    - Fault tolerance driver
+FtV  - <unknown>    - Fault tolerance driver
+       <unknown>
+
+FtpA - mpsdrv.sys   - MPSDRV FTP protocol analyzer
+FwfD - mpsdrv.sys   - MPSDRV driver buffer for flattening NET_BUFFFER
+
+FwSD - tcpip.sys    - WFP security descriptor
+
+FVE? - fvevol.sys   - Full Volume Encryption Filter Driver (Bitlocker Drive Encryption)
+FVE0 - fvevol.sys   - General allocations
+FVEc - fvevol.sys   - Cryptographic allocations
+FVEl - fvevol.sys   - FVELIB allocations
+FVEp - fvevol.sys   - Write buffers
+FVEr - fvevol.sys   - Reserved mapping addresses
+FVEv - fvevol.sys   - Conversion allocations
+FVEw - fvevol.sys   - Worker threads
+FVEx - fvevol.sys   - Read/write control structures
+
+FxDr - wdf01000.sys - KMDF driver globals/generic pool allocation tag. Fallback tag in case driver tag is unusable.
+FxLg - wdf01000.sys - KMDF IFR log tag
+FxL? - wdfldr.sys   - KMDF Loader Pool allocation
+
+Fwpp - fwpkclnt.sys - Windows Filtering Platform export driver.
+Fwpn - fwpkclnt.sys - WFP NBL info
+Fwpi - fwpkclnt.sys - WFP injector info
+Fwpx - fwpkclnt.sys - WFP NBL tagged context
+Fwpd - fwpkclnt.sys - WFP delayed injection context
+Fwpc - fwpkclnt.sys - WFP injection call context
+
+G??? - <unknown>    - Gdi Objects
+G    - <unknown>    -     Gdi Generic allocations
+Gcac - <unknown>    -     Gdi glyph cache
+Gcap - <unknown>    -     Gdi capture buffer
+Gcsl - <unknown>    -     Gdi string resource script names
+Gdbr - <unknown>    -     Gdi driver brush realization
+Gdd  - <unknown>    -     Gdi ddraw PKEY_VALUE_FULL_INFORMATION
+Gdda - <unknown>    -     Gdi ddraw attach list
+GddD - <unknown>    -     Gdi ddraw dummy page
+Gdde - <unknown>    -     Gdi ddraw event
+Gddf - <unknown>    -     Gdi ddraw driver heaps
+Gddp - <unknown>    -     Gdi ddraw driver caps
+Gddv - <unknown>    -     Gdi ddraw driver video memory list
+Gdxd - <unknown>    -     Gdi ddraw VPE directdraw object
+Gdxs - <unknown>    -     Gdi ddraw VPE surface, videoport, capture object
+Gdxx - <unknown>    -     Gdi ddraw VPE DXAPI object
+Gdev - <unknown>    -     Gdi GDITAG_DEVMODE
+GDev - <unknown>    -     Gdi pdev
+Gdrs - <unknown>    -     Gdi GDITAG_DRVSUP
+Gebr - <unknown>    -     Gdi ENGBRUSH
+gEdg - <unknown>    -     Gdi gradient fill triangle
+Gffv - <unknown>    -     Gdi FONTFILEVIEW
+gFil - <unknown>    -     Gdi FILEVIEW
+GFil - <unknown>    -     Gdi engine descriptor list
+Gfsb - <unknown>    -     Gdi font sustitution list
+Gfsm - <unknown>    -     Gdi Fast mutex
+Ggdv - <unknown>    -     Gdi GDITAG_GDEVICE
+Gglb - <unknown>    -     Gdi temp buffer
+Ggls - <unknown>    -     Gdi glyphset
+Ggb  - <unknown>    -     Gdi glyph bits
+Ggbl - <unknown>    -     Gdi look aside buffers
+Ghmg - <unknown>    -     Gdi handle manager objects
+Gini - <unknown>    -     Gdi fast mutex
+Gldv - <unknown>    -     Gdi Ldev
+Glnk - <unknown>    -     Gdi PFELINK
+Gmap - <unknown>    -     Gdi font map signature table
+Gpff - <unknown>    -     Gdi physical font file
+Gpft - <unknown>    -     Gdi font table
+Gsem - <unknown>    -     Gdi Semaphores
+Gsp  - <unknown>    -     Gdi sprite
+Gspr - <unknown>    -     Gdi sprite grow range
+Gtmp - <unknown>    -     Gdi temporary allocations
+Gtmw - <unknown>    -     Gdi TMW_INTERNAL
+Gxlt - <unknown>    -     Gdi Xlate
+
+Gfcb - <unknown>    - EXIFS Grow FCB
+
+
+Hal  - hal.dll      - Hardware Abstraction Layer
+HalV - ntoskrnl.exe - Driver Verifier DMA checking
+Hpfs - <unknown>    - Pinball (aka Hpfs) allocations
+HisC - <unknown>    - histogram filter driver
+Hist - <unknown>    - histogram filter driver
+HidP - hidparse.sys - HID Parser
+HidC - hidclass.sys - HID Class driver
+HdCl - <unknown>    - HID Client Sample Driver
+HpMM - pnpmem.sys   - HotPlug Memory Driver
+
+HCID - bthport.sys  - Bluetooth port driver HCI debug
+HCIT - bthport.sys  - Bluetooth port driver (HCI)
+
+HcRs - hcaport.sys - HCAPORT_TAG_RESOURCE_LIST
+HcEv - hcaport.sys - HCAPORT_TAG_EVENT
+HcdI - hcaport.sys - HCAPORT_TAG_HWID
+HcEn - hcaport.sys - HCAPORT_TAG_ENUM
+HcMc - hcaport.sys - HCAPORT_TAG_MISC
+HcDr - hcaport.sys - HCAPORT_TAG_DEVICE_RELATIONS
+HcBm - hcaport.sys - HCAPORT_TAG_BITMAP
+HcOb - hcaport.sys - HCAPORT_TAG_OBJECT
+HcCq - hcaport.sys - HCAPORT_TAG_CQUEUE
+HcPr - hcaport.sys - HCAPORT_TAG_PROTD
+HPmi - hcaport.sys - HCAPORT_TAG_PMI_EXTENSION
+HcMa - hcaport.sys - HCAPORT_TAG_MAD
+HcMp - hcaport.sys - HCAPORT_TAG_MINIPORT
+HcCm - hcaport.sys - HCAPORT_TAG_CM
+HcUc - hcaport.sys - HCAPORT_TAG_UCONTEXT
+HcMr - hcaport.sys - HCAPORT_TAG_REMOVE_LOCK
+Hmgo - hcaport.sys - HCAPORT_TAG_WQ_MG_INFO
+Hioc - hcaport.sys - HCAPORT_TAG_IOC_SERVICE_TABLE
+
+hSVD - mrxdav.sys - Shared Heap Tag
+
+HTab - <unknown>    - Hash Table pool
+
+HT01 - <unknown>    - GDI Halftone AddCachedDCI() for CurCDCIData
+HT02 - <unknown>    - GDI Halftone GetCachedDCI() for Threshold
+HT03 - <unknown>    - GDI Halftone FindCachedSMP() for CurCSMPData
+HT04 - <unknown>    - GDI Halftone FindCachedSMP() for CurCSMPBmp
+HT05 - <unknown>    - GDI Halftone HT_CreateDeviceHalftoneInfo() for HT_DHI
+HT06 - <unknown>    - GDI Halftone pDCIAdjClr() for DEVCLRADJ
+HT07 - <unknown>    - GDI Halftone ComputeRGB555LUT() for RGBLUT
+HT08 - <unknown>    - GDI Halftone ColorTriadSrcToDev() for RGB-XYZ
+HT09 - <unknown>    - GDI Halftone ColorTriadSrcToDev() for CRTX-FD6XYZ Cache
+HT10 - <unknown>    - GDI Halftone CreateDyesColorMappingTable() for DevPrims
+HT11 - <unknown>    - GDI Halftone CreateDyesColorMappingTable() for DyeMappingTable
+HT12 - <unknown>    - GDI Halftone ThresholdsFromYData() for pYData
+HT13 - <unknown>    - GDI Halftone ComputeHTCellRegress() for pThresholds
+HT14 - <unknown>    - GDI Halftone CalculateStretch() for InputSI/pSrcMaskLine
+HT15 - <unknown>    - GDI Halftone CalculateStretch() for PrimColorInfo
+
+Hvlm - nt!Hvl       - Temporary MDL for the Hvl component.
+HvlP - nt!Hvl       - Hypercall marshalling pages for the Hvl component.
+
+IBCM - wibcm.sys - CM_INSTANCE_TAG Windows Infiniband Communications Manager
+CEP  - wibcm.sys - CEP_INSTANCE_TAG
+CMSH - wibcm.sys - WIBCM_SHARED_TAG
+CMWK - wibcm.sys - WIBCM_WORK_TAG
+CMWT - wibcm.sys - WIBCM_TIMER_TAG
+
+IBm* - wibms.sys - Windows Infiniband Management Server pool tags
+
+IbPm - wibpm.sys - WIBPM_TAG Windows Infiniband Performance Manager
+IbPS - wibpm.sys - WIBPM_SENT_TAG
+IbPI - wibpm.sys - WIBPM_ITEM_TAG
+IbPA - wibpm.sys - WIBPM_SAMPLE_TAG
+
+IbW0 - wibwmi.sys - WIBWMI0_TAG Windows Infiniband WMI Manager
+IbW1 - wibwmi.sys - WIBWMI1_TAG
+IbW2 - wibwmi.sys - WIBWMI2_TAG
+
+Ic4c - tcpip.sys    - ICMP IPv4 Control data
+Ic4h - tcpip.sys    - ICMP IPv4 Headers
+Ic6c - tcpip.sys    - ICMP IPv6 Control data
+Ic6h - tcpip.sys    - ICMP IPv6 Headers
+IBbf - tcpip.sys    - IP BVT Buffers
+Ilom - tcpip.sys    - IPsec LBFO offload map
+Ilog - tcpip.sys    - IPsec LBFO offload general
+InAD - tcpip.sys    - Inet Ancillary Data
+InCo - tcpip.sys    - Inet Compartment
+InCS - tcpip.sys    - Inet Compartment Set
+IneI - tcpip.sys    - Inet Inspects
+InF0 - tcpip.sys    - Inet Generic Fixed Size Block pool 0
+InF1 - tcpip.sys    - Inet Generic Fixed Size Block pool 1
+InF2 - tcpip.sys    - Inet Generic Fixed Size Block pool 2
+InIS - tcpip.sys    - Inet Inspect Streams
+InNA - <unknown>    - Inet Na Clients
+InNP - tcpip.sys    - Inet Nsi Providers
+InPA - tcpip.sys    - Inet Port Assignment Arrays
+InPa - tcpip.sys    - Inet Port Assignments
+InPE - tcpip.sys    - Inet Port Exclusions
+InPP - tcpip.sys    - Inet Port pool
+InSB - tcpip.sys    - Inet stack block
+InSC - tcpip.sys    - Inet Queued Send Contexts
+InWP - tcpip.sys    - Inet Wake Port Record
+Ipas - tcpip.sys    - IP Buffers for Address Sort
+Ipcr - tcpip.sys    - IP Cache-aware Reference Counters
+IPbw - tcpip.sys    - IP Path Bandwidth information
+IPdc - tcpip.sys    - IP Destination Cache
+IPfg - tcpip.sys    - IP Fragment Groups
+IPfp - tcpip.sys    - IP PreValidated Receives
+IPif - tcpip.sys    - IP Interfaces
+IPlo - tcpip.sys    - IP Loopback buffers
+IPmf - tcpip.sys    - IP Multicast Forwarding Entry pool
+IPpo - tcpip.sys    - IP Offload buffers
+IPpa - tcpip.sys    - IP Path information
+IPrq - tcpip.sys    - IP Request Control data
+IPss - tcpip.sys    - IP Session State
+IPsi - tcpip.sys    - IP SubInterfaces
+Ipng - tcpip.sys    - IP Generic buffers (Address, Interface, Packetize, Route allocations)
+IpOl - tcpip.sys    - IP Offload Log data
+Ippp - tcpip.sys    - IP Prefix Policy information
+IPre - tcpip.sys    - IP Reassembly buffers
+Iptt - tcpip.sys    - IP Timer Tables
+Iptc - tcpip.sys    - IP Transaction Context information
+Ipur - tcpip.sys    - IP Unicast Routes
+Ipwi - tcpip.sys    - IP Work Item allocations
+I4ai - tcpip.sys    - IPv4 Local Address Identifiers
+I4ba - tcpip.sys    - IPv4 Local Broadcast Addresses
+I4bf - tcpip.sys    - IPv4 Generic Buffers (Source Address List allocations)
+I4e -  tcpip.sys    - IPv4 Echo data
+I4ma - tcpip.sys    - IPv4 Local Multicast Addresses
+I4nb - tcpip.sys    - IPv4 Neighbors
+I4rd - tcpip.sys    - IPv4 Receive Datagrams Arguments
+I4ua - tcpip.sys    - IPv4 Local Unicast Addresses
+I6ai - tcpip.sys    - IPv6 Local Address Identifiers
+I6aa - tcpip.sys    - IPv6 Local Anycast Addresses
+I6bf - tcpip.sys    - IPv6 Generic Buffers (Source Address List allocations)
+I6e -  tcpip.sys    - IPv6 Echo data
+I6ma - tcpip.sys    - IPv6 Local Multicast Addresses
+I6nb - tcpip.sys    - IPv6 Neighbors
+I6rd - tcpip.sys    - IPv6 Receive Datagrams Arguments
+I6ua - tcpip.sys    - IPv6 Local Unicast Addresses
+
+IPX  - <unknown>    - Nwlnkipx transport
+Icp  - <unknown>    - I/O completion packets queue on a completion ports
+IcpP - <unknown>    - NPAGED_LOOKASIDE_LIST I/O completion per processor lookaside pointers
+IdeP - <unknown>    - atapi IDE
+IdeX - <unknown>    - PCI IDE
+idle - <unknown>    - Power Manager idle handler
+Ifs  - <unknown>    - Default file system allocations (user's of ntifs.h)
+Info - <unknown>    - general system information allocations
+Io   - nt!io        - general IO allocations
+IoBo - nt!io        - Io boot disk information
+IoCc - nt!io        - Io completion context
+IoDn - nt!io        - Io device name info
+IoEa - nt!io        - Io extended attributes
+IoEr - nt!io        - Io error log packets
+IoFc - nt!io        - Io name transmogrify operation
+IoFs - nt!io        - Io shutdown packet
+IoFu - nt!pnp       - Io file utils
+Ioin - <unknown>    - Io interrupts
+IoKB - nt!io        - Registry basic key block (temp allocation)
+IoNm - nt!io        - Io parsing names
+IoOp - nt!io        - I/O subsystem open packet
+IoRb - nt!io        - Io remote boot related
+IoRi - nt!io        - I/O SubSystem Driver Reinitialization Callback Packet
+IoRN - nt!io        - Registry key name (temp allocation)
+IoSD - nt!io        - Io system device buffer
+IoSe - nt!io        - Io security related
+IoSh - nt!io        - Io shutdown packet
+IoSi - nt!io        - Io Symbolic Links
+IoSn - nt!io        - Io Session Notifications
+IoSt - nt!io        - Io Stream Identifier Context
+IoTi - nt!io        - Io timers
+IoTt - nt!vf        - I/O verifier IRP tracking table
+IoUs - nt!io        - I/O SubSystem completion Context Allocation
+Irp  - <unknown>    - Io, IRP packets
+Irp+ - nt!vf        - I/O verifier allocated IRP packets
+IrpB - nt!vf        - I/O verifier direct I/O double buffer allocation
+Irpd - nt!vf        - I/O verifier deferred completion context
+Irps - nt!vf        - I/O verifier per-IRP session tracking data
+Irpt - nt!vf        - I/O verifier per-IRP tracking data
+IrpC - nt!vf        - I/O verifier stack contexts
+Irpl - nt!io        - system large IRP lookaside list
+Irps - nt!io        - system small IRP lookaside list
+IrpX - nt!io        - IRP Extension
+Isap - <unknown>    - Pnp Isa bus extender
+II?? - <unknown>    - IP in IP tunneling
+IIrf - <unknown>    - Free memory
+IIdt - <unknown>    - Data
+IITn - <unknown>    - Tunnel
+IIhd - <unknown>    - Header
+IIpk - <unknown>    - Packet
+IIsc - <unknown>    - Send Context
+IIts - <unknown>    - Transfer Context
+IIwc - <unknown>    - Work Context
+
+Im*  - <unknown>    - Imapi.sys from adaptec
+
+INTC - <unknown>    - Intel video driver
+
+IPm? - <unknown>    - IP Multicasting
+IPmg - <unknown>    - Group
+IPms - <unknown>    - Source
+IPmo - <unknown>    - Outgoing Interface
+IPmm - <unknown>    - Message
+IPmf - <unknown>    - Free memory (only in checked builds)
+
+Ip?? - ipsec.sys    - IP Security (IPsec)
+IpSI - ipsec.sys    -  initial allocations
+IpAT - ipsec.sys    -  AH headers in transport mode
+IpAU - ipsec.sys    -  AH headers in tunnel mode
+IpET - ipsec.sys    -  ESP headers in transport mode
+IpEU - ipsec.sys    -  ESP headers in tunnel mode
+IpHT - ipsec.sys    -  HUGHES headers in transport mode
+IpHU - ipsec.sys    -  HUGHES headers in tunnel mode
+IpAX - ipsec.sys    -  key acquire contexts
+IpFI - ipsec.sys    -  filter blocks
+IpSA - ipsec.sys    -  security associations (SA)
+IpKE - ipsec.sys    -  keys
+IpTI - ipsec.sys    -  timers
+IpSQ - ipsec.sys    -  stall queues
+IpLA - ipsec.sys    -  lookaside lists
+IpBP - ipsec.sys    -  buffer pools
+IpSC - ipsec.sys    -  send complete context
+IpEQ - ipsec.sys    -  event queue
+IpHW - ipsec.sys    -  hardware accleration items
+IpCO - ipsec.sys    -  IP compression
+
+ItoM - tcpip.sys    - IPsec task offload interface
+ItoD - tcpip.sys    - IPsec task offload delete SA
+ItoS - tcpip.sys    - IPsec task offload add SA
+ItoC - tcpip.sys    - IPsec task offload context
+ItoO - tcpip.sys    - IPsec task offload paramters
+
+Itht - tcpip.sys    - IPsec hashtable
+ISLe - tcpip.sys    - IPsec SA list entry
+IsRc - tcpip.sys    - IPsec rebalance context
+Ikmb - tcpip.sys    - IPsec key module blob
+Ithp - tcpip.sys    - IPsec throttle parameter
+Ipfl - tcpip.sys    - IPsec flow handle
+Ipap - tcpip.sys    - IPsec pend context
+Inlc - tcpip.sys    - IPsec NL complete context
+Iprc - tcpip.sys    - IPsec RPC context
+Ipis - tcpip.sys    - IPsec inbound sequence info
+Itok - tcpip.sys    - IPsec token
+Iser - tcpip.sys    - IPsec inbound sequence range
+IKeO - tcpip.sys    - IPsec key object
+I4sa - tcpip.sys    - IPsec SADB v4
+I4s6 - tcpip.sys    - IPsec SADB v6
+IHaO - tcpip.sys    - IPsec hash object
+Ipnc - tcpip.sys    - IPsec negotiation context
+Icse - tcpip.sys    - IPsec NS connection state
+Itro - tcpip.sys    - IPsec outbound session security context
+Itri - tcpip.sys    - IPsec inbound packet security context
+Ituo - tcpip.sys    - IPsec outbound tunnel session security context
+Itui - tcpip.sys    - IPsec inbound packet tunnel security context
+Ipft - tcpip.sys    - IPsec filter
+Ipwi - tcpip.sys    - IPsec work item
+
+Idqf - tcpip.sys    - IPsec DoS Protection QoS flow
+Idpc - tcpip.sys    - IPsec DoS Protection pacer create
+Idst - tcpip.sys    - IPsec DoS Protection state entry
+Ifws - tcpip.sys    - IPsec forward state
+
+ImPl - ndisimplatform.sys - NDIS IM (LBFO) Platform
+
+IpFl - mpsdrv.sys   - MPSDRV IP Flow
+
+IrD? - <unknown>    - IrDA TDI and RAS drivers
+
+IU?? - <unknown>    - IIS Utility Driver
+IUDl - <unknown>    -     Lookaside list allocations
+IUcp - <unknown>    -     completion port minipackets
+
+KAPC - nt!io              - I/O SubSystem HardError APC
+KbdC - kbdclass.sys - Keyboard Class Driver
+KbdH - kbdhid.sys   - Keyboard HID mapper Driver
+KCfe - <unknown>    - Kernel COM factory entry
+KDN_ - kdnic.sys    - Network Kernel Debug Adapter
+KDNT - kdnic.sys    - Network Kernel Debug Adapter TCB
+KDNR - kdnic.sys    - Network Kernel Debug Adapter RCB
+KDNr - kdnic.sys    - Network Kernel Debug Adapter RECV-NBL
+KDNF - kdnic.sys    - Network Kernel Debug Adapter FRAME
+Ke   - <unknown>    - Kernel data structures
+KeIC - <unknown>    - Kernel Interrupt Object Chain
+Key  - <unknown>    - Key objects
+KMIX - <unknown>    - Kmixer (wdm audio)
+KNMI - <unknown>    - Kernel NMI Callback object
+KrbC - ksecdd.sys   - Kerberos Client package
+krpc - nt           - NTOS midl_user_allocate
+KSah - <unknown>    - Ks auxiliary stream headers
+KSAI - <unknown>    -    allocator instance
+KSai - <unknown>    -    default allocator instance header
+KSbi - <unknown>    -    event buffered item
+KSCI - <unknown>    -    clock instance
+KSce - <unknown>    -    create item entry
+KSch - <unknown>    -    create handler entry
+KSci - <unknown>    -    default clock instance header
+KScp - <unknown>    -    object creation parameters auxiliary copy
+KSda - <unknown>    -    default allocator
+KSdc - <unknown>    -    default clock
+KSdh - <unknown>    -    device header
+Kse0 - ksecdd.sys   - Security driver allocs for sec package 0
+Kse1 - ksecdd.sys   - Security driver allocs for sec package 1
+Kse2 - ksecdd.sys   - Security driver allocs for sec package 2
+Kse3 - ksecdd.sys   - Security driver allocs for sec package 3
+Kse4 - ksecdd.sys   - Security driver allocs for sec package 4
+Kse5 - ksecdd.sys   - Security driver allocs for sec package 5
+Kse6 - ksecdd.sys   - Security driver allocs for sec package 6
+Kse7 - ksecdd.sys   - Security driver allocs for sec package 7
+Kse8 - ksecdd.sys   - Security driver allocs for sec package 8
+Kse9 - ksecdd.sys   - Security driver allocs for sec package 9
+Ksec - ksecdd.sys   - Security device driver
+KSed - <unknown>    -    event dpc item
+KSee - <unknown>    -    event entry
+KSed - <unknown>    -    oneshot event deletion dpc
+KSep - <unknown>    -    irp system buffer event parameter
+KseS - ksecdd.sys   - Security driver allocs for LSA proper
+KSew - <unknown>    -    oneshot event deletion workitem
+KseZ - ksecdd.sys   - Security driver allocs for default sec package
+KSqr - <unknown>    -    QM quality report
+KSer - <unknown>    -    QM error report
+KSfd - <unknown>    -    filter cache data (MSKSSRV)
+KsFI - <unknown>    -    filter instance
+KSns - <unknown>    -    null security object
+KSnv - <unknown>    -    registry name value
+KSoh - <unknown>    -    object header
+KSop - <unknown>    -    object creation parameters
+KSpc - <unknown>    -    port driver instance FsContext
+KSPI - <unknown>    -    pin instance
+KSpp - <unknown>    -    irp system buffer property/method/event parameter
+KSpt - <unknown>    -    pin type list (MSKSSRV)
+KSqf - <unknown>    -    query information file buffer
+KSsc - <unknown>    -    port driver stream FsContext
+KSsf - <unknown>    -    set information file buffer
+KSsh - <unknown>    -    stream headers
+KSsi - <unknown>    -    software bus interface
+KSsl - <unknown>    -    symbolic link buffer (MSKSSRV)
+KSsp - <unknown>    -    serialized property set
+KsoO - <unknown>    -    WDM audio stuff
+L2CA - bthport.sys  - Bluetooth port driver (L2CAP)
+L2T0 - <unknown>    -    ndis\l2tp / MTAG_FREED
+L2T1 - <unknown>    -    ndis\l2tp / MTAG_ADAPTERCB
+L2T2 - <unknown>    -    ndis\l2tp / MTAG_TUNNELCB
+L2T3 - <unknown>    -    ndis\l2tp / MTAG_VCCB
+L2T4 - <unknown>    -    ndis\l2tp / MTAG_VCTABLE
+L2T5 - <unknown>    -    ndis\l2tp / MTAG_WORKITEM
+L2T6 - <unknown>    -    ndis\l2tp / MTAG_TIMERQ
+L2T7 - <unknown>    -    ndis\l2tp / MTAG_TIMERQITEM
+L2T8 - <unknown>    -    ndis\l2tp / MTAG_PACKETPOOL
+L2T9 - <unknown>    -    ndis\l2tp / MTAG_FBUFPOOL
+L2Ta - <unknown>    -    ndis\l2tp / MTAG_HBUFPOOL
+L2Tb - <unknown>    -    ndis\l2tp / MTAG_TDIXRDG
+L2Tc - <unknown>    -    ndis\l2tp / MTAG_TDIXSDG
+L2Td - <unknown>    -    ndis\l2tp / MTAG_CTRLRECD
+L2Te - <unknown>    -    ndis\l2tp / MTAG_CTRLSENT
+L2Tf - <unknown>    -    ndis\l2tp / MTAG_PAYLRECD
+L2Tg - <unknown>    -    ndis\l2tp / MTAG_PAYLSENT
+L2Th - <unknown>    -    ndis\l2tp / MTAG_INCALL
+L2Ti - <unknown>    -    ndis\l2tp / MTAG_UTIL
+L2Tj - <unknown>    -    ndis\l2tp / MTAG_ROUTEQUERY
+L2Tk - <unknown>    -    ndis\l2tp / MTAG_ROUTESET
+L2Tl - <unknown>    -    ndis\l2tp / MTAG_L2TPPARAMS
+L2Tm - <unknown>    -    ndis\l2tp / MTAG_TUNNELWORK
+L2Tn - <unknown>    -    ndis\l2tp / MTAG_TDIXROUTE
+LANE - atmlane.sys  - LAN Emulation Client for ATM
+LB?? - <unknown>    - LM Datagram receiver allocations
+LBan - <unknown>    -     Server announcement
+LBvb - <unknown>    -     View buffer
+LBma - <unknown>    -     Master announce context
+LBxp - <unknown>    -     Transport
+LBxn - <unknown>    -     TransportName
+LBxm - <unknown>    -     Master name
+LBtn - <unknown>    -     Transport name
+LBea - <unknown>    -     Ea buffer
+LBdi - <unknown>    -     POOL_DOMAIN_INFO
+LBds - <unknown>    -     Send datagram context
+LBci - <unknown>    -     Connection info
+LBmh - <unknown>    -     Mailslot header
+LBbl - <unknown>    -     Backup List
+LBsl - <unknown>    -     Browser server list
+LBbs - <unknown>    -     Browser server
+LBgb - <unknown>    -     GetBackupList request
+LBbr - <unknown>    -     GetBackupList response
+LBmb - <unknown>    -     Mailslot Buffer
+LBid - <unknown>    -     Illegal datagram context
+LBbn - <unknown>    -     Name
+LBnn - <unknown>    -     Name name
+LBic - <unknown>    -     IRP context
+LBwi - <unknown>    -     Work item
+LBel - <unknown>    -     Election context
+LBbb - <unknown>    -     Become backup context
+LBbr - <unknown>    -     Become backup request
+LBpn - <unknown>    -     Paged Name
+LBpt - <unknown>    -     Paged transport
+LBse - <unknown>    -     Browser security
+
+Lbuf - <unknown>    - EXIFS Large Buffer
+
+Ldmp - nt!io        -     Live Dump Buffers. Note, these buffers will not be present in the resulting live dump file.
+
+LeGe - tcpip.sys    - Legacy Registry Mapping Module Buffers
+
+LeoC - <unknown>    -     Symantec/Norton AntiVirus filter driver
+List - <unknown>    -     kernel utilities list allocation
+LCam - <unknown>    - WDM mini video capture driver for Logitech camera
+Lfs  - <unknown>    - Lfs allocations
+LfsI - <unknown>    - Lfs allocations
+LLDP - mslldp.sys   - LLDP protocol driver allocations
+LogA - clfsapimp.sys - CLFS Kernel API test driver
+LpcZ - <unknown>    - LPC Zone
+LpcM - <unknown>    - Local procedure call message blocks
+Lr?? - <unknown>    - LM redirector allocations
+Lr   - <unknown>    -     Generic allocations
+Lrcx - <unknown>    -     Context blocks of various types
+Lrcl - <unknown>    -     ConnectListEntries
+Lrsl - <unknown>    -     ServerListEntries
+Lrse - <unknown>    -     Security entry
+Lrsc - <unknown>    -     Search Control Blocks
+Lrea - <unknown>    -     EA related allocations
+Lric - <unknown>    -     Instance Control Blocks
+Lrfc - <unknown>    -     File Control Blocks
+Lrfl - <unknown>    -     Fcb Locks
+Lrfp - <unknown>    -     Fcb Paging locks
+Lrcn - <unknown>    -     Computer Name
+Lrdn - <unknown>    -     Domain Name
+Lr?? - <unknown>    -     Buffers used for FsControlFile APIs
+Lrlc - <unknown>    -     Lock Control Blocks
+Lrlb - <unknown>    -     Lock Control Block buffers
+Lrnf - <unknown>    -     Non paged FCB
+Lrnt - <unknown>    -     Non paged transport
+Lrps - <unknown>    -     Paged security entry
+Lrte - <unknown>    -     Transport event.
+Lrxx - <unknown>    -     Transceive context blocks
+Lr!! - <unknown>    -     Cancel request context blocks
+Lrmt - <unknown>    -     MPX table
+Lrme - <unknown>    -     MPX table entries
+Lrsx - <unknown>    -     Send contexts
+Lraw - <unknown>    -     Async write context
+Lrwb - <unknown>    -     Write behind buffer header
+Lrbb - <unknown>    -     Write behind buffer
+Lrwq - <unknown>    -     Work queue item
+Lrac - <unknown>    -     ACL for redirector
+Lrds - <unknown>    -     Security Descriptor for redirector
+Lrsm - <unknown>    -     SMB buffer
+Lrds - <unknown>    -     Duplicated ansi string
+Lrdu - <unknown>    -     Duplicated unicode string
+Lxpt - <unknown>    -     Transport
+Lrtc - <unknown>    -     Transport connection
+Lrna - <unknown>    -     Netbios Addresses
+Lrca - <unknown>    -     Temporary storage used in name canonicalization
+Lr2x - <unknown>    -     Transact SMB context
+Lrpt - <unknown>    -     Primary transport server list
+Lrso - <unknown>    -     Operating system name
+Lref - <unknown>    -     Reference history (debug only)
+LS?? - <unknown>    - LM server allocations
+LSac - srv.sys      -     SMB1 BlockTypeAdminCheck
+LSas - srv.sys      -     SMB1 BlockTypeAdapterStatus
+LSbf - srvnet.sys   -     SMB1 buffer descriptor or srvnet allocation
+LScd - srv.sys      -     SMB1 comm device
+LScn - srv.sys      -     SMB1 connection
+LSdb - srv.sys      -     SMB1 data buffer
+LSdc - srv.sys      -     SMB1 BlockTypeDirCache
+LSdi - srv.sys      -     SMB1 BlockTypeDirectoryInfo
+LSep - srv.sys      -     SMB1 endpoint
+LSfn - srv.sys      -     SMB1 BlockTypeFSName
+LSfR - srv2.sys     -     SMB2 rfssequence table and rfs64table
+LShs - srv2.sys     -     SMB2 lease hash table
+LSlb - srv2.sys     -     SRVLIB security descriptor/registry buffer
+LSlf - srv.sys      -     SMB1 LFCB
+LSlr - srv.sys      -     SMB1 BlockTypeLargeReadX
+LSmf - srv.sys      -     SMB1 MFCB
+LSmi - srv.sys      -     SMB1 BlockTypeMisc
+LSnh - srv.sys      -     SMB1 nonpaged block header
+LSni - srv.sys      -     SMB1 BlockTypeNameInfo
+LSnn - srv2.sys     -     SMB2 netname
+LSop - srv.sys      -     SMB1 oplock break wait
+LSpc - srv.sys      -     SMB1 paged connection
+LSpm - srv.sys      -     SMB1 paged MFCB
+LSpr - srv.sys      -     SMB1 paged RFCB
+LSrf - srv.sys      -     SMB1 RFCB
+LSrp - srvnet.sys   -     srvnet RPC allocation
+LSRp - srv2.sys     -     SRVLIB reparse point
+LSsc - srv.sys      -     SMB1 search(core)
+LSsd - srv.sys      -     SMB1 BlockTypeShareSecurityDescriptor
+LSsf - srv.sys      -     SMB1 BlockTypeDfs
+LSsh - srv.sys      -     SMB1 share
+LSSL - srv2.sys     -     SMBLIB allocation
+LSsp - srv.sys      -     SMB1 search(core complete)
+LSsr - srv.sys      -     SMB1 search
+LSss - srv.sys      -     SMB1 session
+LStb - srv.sys      -     SMB1 table
+LStc - srv.sys      -     SMB1 tree connect
+LSti - srv.sys      -     SMB1 timer
+LStr - srv.sys      -     SMB1 transaction
+LSvi - srv.sys      -     SMB1 BlockTypeVolumeInformation
+LSwi - srv.sys      -     SMB1 initial work context
+LSwn - srv.sys      -     SMB1 normal work context
+LSwq - srv.sys      -     SMB1 BlockTypeWorkQueue
+LSwr - srv.sys      -     SMB1 raw work context
+LSws - srv.sys      -     SMB1 BlockTypeWorkContextSpecial
+LS2b - srv2.sys     -     SMB2 buffer
+LS2c - srv2.sys     -     SMB2 connection
+LS2e - srv2.sys     -     SMB2 endpoint
+LS2f - srv2.sys     -     SMB2 file
+LS2h - srv2.sys     -     SMB2 share
+LS2i - srv2.sys     -     SMB2 client
+LS2l - srv2.sys     -     SMB2 lease
+LS2n - srv2.sys     -     SMB2 channel
+LS2o - srv2.sys     -     SMB2 oplock break
+LS2p - srv2.sys     -     SMB2 provider
+LS2q - srv2.sys     -     SMB2 queue
+LS2s - srv2.sys     -     SMB2 session
+LS2t - srv2.sys     -     SMB2 treeconnect
+LS2W - srv2.sys     -     SMB2 special workitem
+LS2w - srv2.sys     -     SMB2 workitem
+LS2x - srv2.sys     -     SMB2 security context
+LS$S - srv2.sys     -     SMB2 ecp
+LS2$ - srv2.sys     -     SMB2 misc. allocation
+LS00 - srvnet.sys   -     SRVNET LookasideList level 0 allocation 256 Bytes
+LS01 - srvnet.sys   -     SRVNET LookasideList level 1 allocation 512 Bytes
+LS02 - srvnet.sys   -     SRVNET LookasideList level 2 allocation 1K Bytes
+LS03 - srvnet.sys   -     SRVNET LookasideList level 3 allocation 2K Bytes
+LS04 - srvnet.sys   -     SRVNET LookasideList level 4 allocation 4K Bytes
+LS05 - srvnet.sys   -     SRVNET LookasideList level 5 allocation 8K Bytes
+LS06 - srvnet.sys   -     SRVNET LookasideList level 6 allocation 16K Bytes
+LS07 - srvnet.sys   -     SRVNET LookasideList level 7 allocation 32K Bytes
+LS08 - srvnet.sys   -     SRVNET LookasideList level 8 allocation 64K Bytes
+LS09 - srvnet.sys   -     SRVNET LookasideList level 9 allocation 128K Bytes
+LS10 - srvnet.sys   -     SRVNET LookasideList level 10 allocation 192K Bytes
+LS11 - srvnet.sys   -     SRVNET LookasideList level 11 allocation 256K Bytes
+LS12 - srvnet.sys   -     SRVNET LookasideList level 12 allocation 320K Bytes
+LS13 - srvnet.sys   -     SRVNET LookasideList level 13 allocation 384K Bytes
+LS14 - srvnet.sys   -     SRVNET LookasideList level 14 allocation 448K Bytes
+LS15 - srvnet.sys   -     SRVNET LookasideList level 15 allocation 512K Bytes
+LS16 - srvnet.sys   -     SRVNET LookasideList level 16 allocation 576K Bytes
+LS17 - srvnet.sys   -     SRVNET LookasideList level 17 allocation 640K Bytes
+LS18 - srvnet.sys   -     SRVNET LookasideList level 18 allocation 704K Bytes
+LS19 - srvnet.sys   -     SRVNET LookasideList level 19 allocation 768K Bytes
+LS20 - srvnet.sys   -     SRVNET LookasideList level 20 allocation 832K Bytes
+LSnd - <unknown>    - WDM mini sound driver for Logitech video camera
+Luaf - luafv.sys    - LUA File Virtualization
+LXMK - <unknown>    - kernel mixer line driver (KMXL - looks like they got their tag backwards)
+
+MXF  - <unknown>    - DirectMusic (MIDI Transform Filter)
+
+MapP - <unknown>    - PNP map
+Mapr - <unknown>    - arc firmware registry routines
+
+McaC - hal.dll      - HAL MCA corrected Log
+McaD - hal.dll      - HAL MCA Driver Log
+McaK - hal.dll      - HAL MCA Kernel Log
+McaP - hal.dll      - HAL MCA Log from previous boot
+McaT - hal.dll      - HAL MCA temporary Log
+
+Mdp -  netio.sys    - Memory Descriptor Lists
+
+MCAM - <unknown>    - WDM mini driver for Intel USB camera
+MCDx - <unknown>    - OpenGL MCD server (mcdsrv32.dll) allocations
+MCDd - <unknown>    - OpenGL MCD driver (embedded in a display driver like s3mvirge.dll)
+Mdl  - <unknown>    - Io, Mdls
+MdlP - <unknown>    - MDL per processor lookaside list pointers
+MePr - <unknown>    - In-memory print buffer
+MiCf - nt!mm        - Mm compressed Control Flow Guard valid target RVA list
+mkup - mpsdrv.sys   - MPSDRV upcall request
+Mm   - nt!mm        - general Mm Allocations
+MmAc - nt!mm        - Mm access log buffers
+MmBk - nt!mm        - Mm banked sections
+MmCa - nt!mm        - Mm control areas for mapped files
+MmCd - nt!mm        - Mm fork clone descriptors
+MmCh - nt!mm        - Mm fork clone headers
+MmCi - nt!mm        - Mm control areas for images
+MmCl - nt!mm        - Mm fork clone prototype PTEs
+MmCm - nt!mm        - Calls made to MmAllocateContiguousMemory
+MmCr - nt!mm        - Mm fork clone roots
+MmCt - nt!mm        - Mm debug tracing
+MmDb - nt!mm        - NtMapViewOfSection service
+MmDT - nt!mm        - Mm debug
+MmEx - nt!mm        - Mm events
+MmHi - nt!mm        - Mm image entry - allocated per session
+MmHn - nt!mm        - Mm sessionwide address name string entry
+MmHv - nt!mm        - Mm sessionwide address entry
+MmIn - nt!mm        - Mm inpaged io structures
+MmLd - nt!mm        - Mm load module database
+MmPd - nt!mm        - Mm page table commitment bitmaps
+MmPg - nt!mm        - Mm page table pages at init time
+MmRp - nt!mm        - Mm repurpose logging
+MmRw - nt!mm        - Mm read write virtual memory buffers
+MmSb - nt!mm        - Mm subsections
+MmSe - nt!mm        - Mm secured VAD allocation
+MmSg - nt!mm        - Mm segments
+MmSt - nt!mm        - Mm section object prototype ptes
+MmSy - nt!mm        - Mm PTE and IO tracking logs
+Mmdl - nt!mm        - Mm Mdls for flushes
+Mmpp - nt!mm        - Mm prototype PTEs for pool
+Mmpr - nt!mm        - Mm physical VAD roots
+MmVd - nt!mm        - Mm virtual address descriptors for mapped views
+MmVs - nt!mm        - Mm virtual address descriptors short form (private views)
+Mmxx - nt!mm        - Mm temporary allocations
+MmCx - nt!mm        - info for dynamic section extension
+MmDm - nt!mm        - deferred MmUnlock entries
+MmHt - nt!mm        - session space PTE data
+MmLn - nt!mm        - temporary name buffer for driver loads
+MmMl - nt!mm        - physical memory range information
+MmPa - nt!mm        - pagefile space deletion slist entries
+MmRl - nt!mm        - temporary readlists for file prefetch
+MmSP - nt!mm        - SLIST entries for system PTE NB queues
+MmSi - nt!mm        - Control area security image stubs
+MmSc - nt!mm        - subsections used to map data files
+MmSd - nt!mm        - extended subsections used to map data files
+MmSm - nt!mm        - segments used to map data files
+MmWe - nt!mm        - Work entries for writing out modified filesystem pages.
+MmWw - nt!mm        - Write watch VAD info
+Mmpv - nt!mm        - Physical view VAD info
+Mmww - nt!mm        - Write watch bitmap VAD info
+MmSW - nt!mm        - Store write support
+MmSw - nt!mm        - Store write support when prefetching
+MmCS - nt!mm        - Pagefile CRC verification buffer
+MmCp - nt!mm        - Colored page counts for physical memory allocations
+Mmdi - nt!mm        - MDLs for physical memory allocations
+MmDp - nt!mm        - Lost delayed write context
+MmFl - nt!mm        - MDLs for large clusters for flushes
+MmFr - nt!mm        - ASLR fixup records
+MmId - nt!mm        - PFN identity buffer for setting PFN priorities
+MmIh - nt!mm        - Image header allocation for Se validation
+MmIm - nt!mm        - IO space MDL trackers
+MmIo - nt!mm        - IO space mapping trackers
+Mmlk - nt!mm        - ProbeAndLock MDL tracker
+MmLl - nt!mm        - Large page memory run allocation for finding large pages
+MmNo - nt!mm        - Inernal physical memory nodes
+MmPh - nt!mm        - Physical memory nodes for querying memory ranges
+MmRe - nt!mm        - ASLR relocation blocks
+MmWs - nt!mm        - PTE flush list for working set operations
+MmWS - nt!mm        - Working set swap support
+MmZw - nt!mm        - Work items for zeroing pages and pagefiles
+MmSa - nt!mm        - Subsection AVL tree allocations
+MmVt - nt!mm        - Verifier thunk allocations
+MmLa - nt!mm        - Memory list locks
+MmTp - nt!mm        - Store eviction thread params
+MmPb - nt!mm        - Paging file bitmaps
+
+Mn01 - monitor.sys  - ACPI method evaluation output buffer
+Mn02 - monitor.sys  - Unused
+Mn03 - monitor.sys  - Raw E-EDID v.1.x byte stream including base block + extension blocks (if any)
+Mn04 - monitor.sys  - Cached monitor ID WMI data block
+Mn05 - monitor.sys  - Cached monitor basic display parameters WMI data block
+Mn06 - monitor.sys  - Cached monitor analog video input parameters WMI data block
+Mn07 - monitor.sys  - Cached monitor digitial video input parameters WMI data block
+Mn08 - monitor.sys  - Cached monitor color characteristics WMI data block
+Mn09 - monitor.sys  - Cached supported monitor source modes WMI data block
+Mn0A - monitor.sys  - Registry subkey info buffer
+Mn0B - monitor.sys  - Registry value buffer
+Mn0C - monitor.sys  - Cached supported monitor frequency ranges WMI data block (overrides from registry)
+Mn0D - monitor.sys  - Cached supported monitor frequency ranges WMI data block (from E-EDID v.1.x base block)
+Mn0E - monitor.sys  - Buffer for E-EDID v.1.x base block, if any, populated by miniport
+Mn0F - monitor.sys  - Buffer for E-EDID v.1.x extension block(s), if any, populated by miniport
+
+MNFf - msnfsflt.sys - NFS FS Filter, filename buffer
+MNFi - msnfsflt.sys - NFS FS Filter, instance name buffer
+MNFr - msnfsflt.sys - NFS FS Filter, registry access buffer
+MNFs - msnfsflt.sys - NFS FS Filter, general string buffer
+MNFv - msnfsflt.sys - NFS FS Filter, volume name buffer
+MNFC - msnfsflt.sys - NFS FS Filter, callback context
+MNFF - msnfsflt.sys - NFS FS Filter, file context
+MNFI - msnfsflt.sys - NFS FS Filter, instance context
+MNFS - msnfsflt.sys - NFS FS Filter, stream context
+MNFT - msnfsflt.sys - NFS FS Filter, thread array
+
+MQAA - mqac.sys     - MSMQ driver, AVL allocations
+MQAB - mqac.sys     - MSMQ driver, CCursor allocations
+MQAC - mqac.sys     - MSMQ driver, generic allocations
+MQAD - mqac.sys     - MSMQ driver, CDistribution allocations
+MQAG - mqac.sys     - MSMQ driver, CGroup allocations
+MQAH - mqac.sys     - MSMQ driver, Heap allocations
+MQAP - mqac.sys     - MSMQ driver, CPacket allocations
+MQAQ - mqac.sys     - MSMQ driver, CQueue allocations
+MQAT - mqac.sys     - MSMQ driver, CTransaction allocations
+
+MRXx - <unknown>    - Client side caching for SMB
+
+REM Minstore (an ReFS component) allocations
+MSag - refs.sys     - Minstore unspecified AVL entries (too big for lookasides; filtered AVL)
+MSah - refs.sys     - Minstore allocator history
+MSal - refs.sys     - Minstore allocator block
+MSav - refs.sys     - Minstore AVL table
+MSb+ - refs.sys     - Minstor B+ table
+MSca - refs.sys     - Minstore read cache object
+MScc - refs.sys     - Minstore tx checksum context
+MScd - refs.sys     - Minstore read cache dirty page array
+MSch - refs.sys     - Minstore read cache hash table
+MSci - refs.sys     - Minstore metadata cache instance
+MScl - refs.sys     - Minstore read cache line
+MScm - refs.sys     - Minstore composite
+MScn - refs.sys     - Minstore container
+MScp - refs.sys     - Minstore cached pin
+MScs - refs.sys     - Minstore read cache sync set
+MScu - refs.sys     - Minstore cursor
+MScw - refs.sys     - Minstore read cache write range
+MSdd - refs.sys     - Minstore director row data
+MSde - refs.sys     - Minstore dirty table tracking
+MSdg - refs.sys     - Minstore debug 
+MSds - refs.sys     - Minstore debug stack logs
+Msdv - <unknown>    - WDM mini driver for IEEE 1394 DV Camera and VCR
+MSeb - refs.sys     - Minstore embedded factory (B+ and associated)
+MSeg - nt!mm        - segments used to support image files
+MSfa - refs.sys     - Minstore filtered AVL
+MSha - refs.sys     - Minstore hash table (incl. page tables)
+MSho - refs.sys     - Minstore hash table overflow (incl. page tables)
+MSht - refs.sys     - Minstore stack hash table
+MSkb - refs.sys     - Minstore keys buffer
+MSkr - refs.sys     - Minstore CmsKeyRules object
+MSls - refs.sys     - Minstore logged stack
+MSPi - refs.sys     - Minstore generic/untagged allocation
+MSpa - refs.sys     - Minstore hash table entries (incl. and primarily SmsPage)
+MSrc - refs.sys     - Minstore tx run cache
+MSrb - refs.sys     - Minstore redo block
+MSre - refs.sys     - Minstore AVL lite entries (incl. and primarily SmsRangeMapEntry)
+MSrk - refs.sys     - Minstore key rules
+MSrm - refs.sys     - Minstore range map
+MSro - refs.sys     - Minstore container rotation buffer
+MSrp - refs.sys     - Minstore read cache pages array
+MSrr - refs.sys     - Minstore AVL lite entries (incl. and primarily SmsRCRangeMapEntry)
+MSrv - refs.sys     - Minstore reserved buffers
+MSst - refs.sys     - Minstore stream object
+MStb - refs.sys     - Minstore table object
+MStu - refs.sys     - Minstore tree update filter
+MStx - refs.sys     - Minstore transaction
+MSur - refs.sys     - Minstore undo record
+MSvc - refs.sys     - Minstore volume context
+MSvs - refs.sys     - Minstore valid/invalid checksum debug buffers (debug only)
+MSvu - refs.sys     - Minstore volume/instance object
+
+MST? - <unknown>    - MSTEE (mstee.sys)
+MSTa - <unknown>    -    associated stream header
+MSTc - <unknown>    -    filer connection
+MSTd - <unknown>    -    data format
+MSTf - <unknown>    -    filter instance
+MSTp - <unknown>    -    pin instance
+MSTs - <unknown>    -    stream header
+
+MouC - mouclass.sys - Mouse Class Driver
+MouH - mouhid.sys   - Mouse HID mapper Driver
+MsFc - <unknown>    - Mailslot CCB, Client control block. Each client with an opened mailslot has one of these
+MsFC - <unknown>    - Mailslot root CCB, A client control block for the top level mailslot directory
+MsFd - <unknown>    - Mailslot data entry write buffer, This is writes buffered inside mailslots
+MsFD - <unknown>    - Mailslot root DCB and its name buffer
+MsFf - <unknown>    - Mailslot FCB, File control block, Service side block for each created mailslot.
+MsFg - <unknown>    - Mailslot global resource
+MsFn - <unknown>    - Mailslot temporary name buffer
+MsFN - <unknown>    - Mailslot FCB name buffer, name for each created mailslot
+MsFr - <unknown>    - Mailslot read buffer, buffer created for pended reads issued.
+MsFt - <unknown>    - Mailslot query template, used for directory queries.
+MsFw - <unknown>    - Mailslot work context block, blocks create when we need to timeout reads.
+
+MsvC - ksecdd.sys   - Msv/Ntlm client package
+Mup  - mup.sys      - Multiple UNC provider allocations, generic
+MupI - mup.sys      - Windows Server 2003 and prior versions: DFS Irp Context allocation
+MuDn - mup.sys      - Device name
+MuFc - mup.sys      - File Context
+MuFn - mup.sys      - File name rewrite
+MuIc - mup.sys      - IRP Context
+MuMc - mup.sys      - Master context
+MuQc - mup.sys      - Query context
+MuSi - mup.sys      - Surrogate info
+MuSf - mup.sys      - Surrogate file info
+MuSr - mup.sys      - Surrogate IRP info
+MuPe - mup.sys      - Known prefix entry
+MuPi - mup.sys      - Provider info
+MuUn - mup.sys      - UNC provider
+
+Muta - <unknown>    - Mutant objects
+
+Nb01 - netbt.sys    - NetBT hash table
+Nb02 - netbt.sys    - NetBT remote name address cache
+Nb03 - netbt.sys    - NetBT remote name address cache
+Nb04 - netbt.sys    - NetBT failed address list
+Nb05 - netbt.sys    - NetBT client element
+Nb06 - netbt.sys    - NetBT general buffer allocation
+Nb07 - netbt.sys    - NetBT datagram request tracker
+Nb08 - netbt.sys    - NetBT domain address list
+Nb09 - netbt.sys    - NetBT domain name
+Nb10 - netbt.sys    - NetBT domain address list
+Nb11 - netbt.sys    - NetBT lmhosts path
+Nb12 - netbt.sys    - NetBT lmhosts path
+Nb13 - netbt.sys    - NetBT lmhosts path
+Nb14 - netbt.sys    - NetBT lmhosts path
+Nb16 - netbt.sys    - NetBT timer entry
+Nb17 - netbt.sys    - NetBT registry path
+Nb18 - netbt.sys    - NetBT lmhosts file
+Nb19 - netbt.sys    - NetBT lmhosts data
+Nb20 - netbt.sys    - NetBT lmhosts path
+Nb21 - netbt.sys    - NetBT control object
+Nb22 - netbt.sys    - NetBT work item context
+Nb23 - netbt.sys    - NetBT lmhosts path
+Nb25 - netbt.sys    - NetBT device bindings
+Nb26 - netbt.sys    - NetBT device exports
+Nb27 - netbt.sys    - NetBT bind list cache
+Nb28 - netbt.sys    - NetBT name server addresses
+Nb29 - netbt.sys    - NetBT registry string
+Nb30 - netbt.sys    - NetBT registry string
+Nb31 - netbt.sys    - NetBT configuration entry
+Nb33 - netbt.sys    - NetBT registry data
+Nb35 - netbt.sys    - NetBT registry data
+Nb36 - netbt.sys    - NetBT string
+Nb37 - netbt.sys    - NetBT lmhosts path
+Nb38 - netbt.sys    - NetBT string
+Nb39 - netbt.sys    - NetBT file objects
+NbL0 - netbt.sys    - NetBT lower connection
+NbL1 - netbt.sys    - NetBT lower connection
+NbL2 - netbt.sys    - NetBT lower connection
+NbL3 - netbt.sys    - NetBT lower connection
+NbL4 - netbt.sys    - NetBT lower connection
+NbTA - netbt.sys    - NetBT internal address
+Nba9 - netbt.sys    - NetBT IP request buffer
+Nbb0 - netbt.sys    - NetBT IP request buffer
+Nbt0 - netbt.sys    - NetBT name address
+Nbt1 - netbt.sys    - NetBT name address
+Nbt2 - netbt.sys    - NetBT NetBIOS address
+Nbt4 - netbt.sys    - NetBT client list
+Nbt5 - netbt.sys    - NetBT client list
+Nbt6 - netbt.sys    - NetBT datagram
+Nbt8 - netbt.sys    - NetBT address list
+Nbt9 - netbt.sys    - NetBT temporary allocation
+NbtA - netbt.sys    - NetBT datagram
+NbtC - netbt.sys    - NetBT address element
+NbtD - netbt.sys    - NetBT connection
+NbtF - netbt.sys    - NetBT remote name
+NbtG - netbt.sys    - NetBT datagram
+NbtH - netbt.sys    - NetBT work item context
+NbtI - netbt.sys    - NetBT listen requests
+NbtJ - netbt.sys    - NetBT receive element
+NbtK - netbt.sys    - NetBT name address
+NbtL - netbt.sys    - NetBT datagram
+NbtM - netbt.sys    - NetBT address list
+NbtN - netbt.sys    - NetBT address list
+NbtO - netbt.sys    - NetBT adapter status
+NbtP - netbt.sys    - NetBT connection list
+NbtQ - netbt.sys    - NetBT name stats
+NbtR - netbt.sys    - NetBT name address
+NbtS - netbt.sys    - NetBT datagram
+NbtV - netbt.sys    - NetBT work item context
+NbtX - netbt.sys    - NetBT datagram
+NbtY - netbt.sys    - NetBT datagram
+NbtZ - netbt.sys    - NetBT datagram
+Nbta - netbt.sys    - NetBT DPC
+Nbtb - netbt.sys    - NetBT NetBIOS address
+Nbtc - netbt.sys    - NetBT address info
+Nbte - netbt.sys    - NetBT delayed connect
+Nbtf - netbt.sys    - NetBT DPC
+Nbtg - netbt.sys    - NetBT MDL buffer
+Nbti - netbt.sys    - NetBT device list
+Nbtj - netbt.sys    - NetBT EA buffer
+Nbtm - netbt.sys    - NetBT EA buffer
+Nbtn - netbt.sys    - NetBT device string
+Nbtk - netbt.sys    - NetBT transport address
+Nbtt - netbt.sys    - NetBT MDL buffer
+Nbtu - netbt.sys    - NetBT MDL buffer
+Nbtv - netbt.sys    - NetBT WINS allocation
+Nbtw - netbt.sys    - NetBT device linkage names
+Nbuf - netio.sys    - NetIO Memory Descriptor List allocations
+
+NBF  - <unknown>    - general NBF allocations
+NBFa - <unknown>    - NBF address object
+NBFb - <unknown>    - NBF receive buffer
+NBFc - <unknown>    - NBF connection object
+NBFd - <unknown>    - NBF packet pool descriptor
+NBFe - <unknown>    - NBF bind & export names
+NBFf - <unknown>    - NBF address file object
+NBFg - <unknown>    - NBF registry path name
+NBFi - <unknown>    - NBF tdi connection info
+NBFk - <unknown>    - NBF loopback buffer
+NBFl - <unknown>    - NBF link object
+NBFn - <unknown>    - NBF netbios name
+NBFo - <unknown>    - NBF config data
+NBFp - <unknown>    - NBF packet
+NBFq - <unknown>    - NBF query buffer
+NBFr - <unknown>    - NBF request
+NBFs - <unknown>    - NBF provider stats
+NBFt - <unknown>    - NBF connection table
+NBFu - <unknown>    - NBF UI frame
+NBFw - <unknown>    - NBF work item
+NBI  - <unknown>    - NwlnkNb transport
+NBS  - <unknown>    - general NetBIOS allocations
+NBSa - <unknown>    -     address block
+NBSc - <unknown>    -     connection block
+NBSe - <unknown>    -     EA buffer
+NBSf - <unknown>    -     FCB
+NBSl - <unknown>    -     LANA block
+NBSn - <unknown>    -     copy of user NCB
+NBSr - <unknown>    -     registry allocations
+NBSx - <unknown>    -     XNS NETONE address (connect block)
+NBSy - <unknown>    -     NetBIOS address (connect block)
+NBSz - <unknown>    -     NetBIOS address (listen block)
+NBqh - <unknown>    -     Non-blocking queue entries used to carry the real data in the queue.
+
+NCSt - <unknown>    - EXIFS NC
+
+ND   - ndis.sys     - general NDIS allocations
+NDA  - ndis.sys     - NDIS PacketDirect tag prefix
+NDAa - ndis.sys     - NDIS_PD_ASSOCIATION
+NDAb - ndis.sys     - NDIS_PD_BLOCK
+NDAc - ndis.sys     - NDIS_PD_CLIENT
+NDAe - ndis.sys     - NDIS_PD_EC
+NDAf - ndis.sys     - NDIS_PD_FILTER
+NDAg - ndis.sys     - NDIS_PD_GLOBAL
+NDAm - ndis.sys     - NDIS_PD_MEM_BLOCK NDIS_PD_SGL_BLOCK
+NDAn - ndis.sys     - NDIS_PD_COUNTER
+NDAo - ndis.sys     - NDIS_PD_CONFIG
+NDAq - ndis.sys     - NDIS_PD_PLATFORM_QUEUE
+NDAt - ndis.sys     - NDIS_PD_QUEUE_TRACKER
+NDDl - ndis.sys     - NDIS_TAG_DBG_LOG
+NDMb - ndis.sys     - NDIS_TAG_MAC_BLOCK
+NDPX - ndis.sys     -     NDIS Proxy allocations
+NDPa - ndis.sys     - Apple Talk
+NDPb - ndis.sys     - NBF
+NDPi - ndis.sys     - NWLNKIPX
+NDPn - ndis.sys     - NWLNKNB
+NDPp - ndis.sys     - Packet Scheduler.
+NDPs - ndis.sys     - NWLNKSPX
+NDPt - ndis.sys     - TCPIP
+NDPw - ndis.sys     - WAN_PACKET_TAG
+NDSD - ndis.sys     - NDIS_SETUP_DEVICE_EXTENSION
+NDTr - ndis.sys     - NDIS_TAG_TRANSFER_DATA
+NDam - ndis.sys     -     NdisAllocateMemory
+NDan - ndis.sys     -     adapter name
+NDar - ndis.sys     - NDIS_TAG_ALLOCATED_RESOURCES
+NDas - ndis.sys     - NDIS_TAG_ALLOC_SHARED_MEM_ASYNC
+NDbi - ndis.sys     - NDIS_TAG_BUS_INTERFACE
+NDca - ndis.sys     - NDIS_TAG_NET_CFG_OPS_ACL
+NDch - ndis.sys     - NDIS_TAG_CONFIG_HANDLE
+NDcm - ndis.sys     - NDIS_TAG_CM
+NDcn - ndis.sys     - NDIS_TAG_CANCEL_DEVICE_NAME
+NDco - ndis.sys     - NDIS_TAG_CO
+NDcs - ndis.sys     - NDIS_TAG_NET_CFG_OPS_ID
+NDcw - ndis.sys     - NDIS_TAG_PCW - NDIS Performance Counters
+NDd  - ndis.sys     - NDIS_TAG_DBG
+NDda - ndis.sys     - NDIS_TAG_NET_CFG_DACL
+NDdb - ndis.sys     -     DMA block
+NDdc - ndis.sys     - NDIS_TAG_DCN - Data Center Networking
+NDdi - ndis.sys     - NDIS_TAG_IM_DEVICE_INSTANCE
+NDdl - ndis.sys     - NDIS_TAG_DBG_L
+NDdp - ndis.sys     - NDIS_TAG_DBG_P
+NDds - ndis.sys     - NDIS_TAG_DBG_S
+NDdt - ndis.sys     - NDIS_TAG_DFRD_TMR
+NDel - ndis.sys     - NDIS debugging event log
+NDfa - ndis.sys     - NDIS_TAG_FILTER_ADDR
+NDfb - ndis.sys     - NDIS_TAG_LWFILTER_BLOCK
+NDfd - ndis.sys     - NDIS_TAG_FILE_DESCRIPTOR
+NDfi - ndis.sys     - NDIS_TAG_FILE_IMAGE
+NDfm - ndis.sys     - NDIS_TAG_FAKE_MAC
+NDfn - ndis.sys     - NDIS_TAG_FILE_NAME
+NDfv - ndis.sys     - NDIS_TAG_LWFILTER_DRIVER
+NDif - ndis.sys     - NDIS_TAG_IF
+NDio - ndis.sys     - NDIS_TAG_IOV - IO Virtualization
+NDkr - ndis.sys     - NDIS_TAG_NDK - Kernel Mode Network Direct (kRDMA)
+NDlb - ndis.sys     -     lookahead buffer
+NDlp - ndis.sys     - NDIS_TAG_LOOP_PKT
+NDmb - ndis.sys     -     MAC block
+NDmo - ndis.sys     - NDIS_TAG_M_OPEN_BLK
+NDmr - ndis.sys     -     map register entry array
+NDmt - ndis.sys     - NDIS_TAG_MEDIA_TYPE_ARRAY
+NDnc - ndis.sys     - NDIS_TAG_NBL_CONTEXT
+NDnd - ndis.sys     - NDIS_TAG_POOL_NDIS
+NDoa - ndis.sys     - NDIS_TAG_OID_ARRAY
+NDob - ndis.sys     - open block
+NDoc - ndis.sys     - NDIS_TAG_OPEN_CONTEXT
+NDof - ndis.sys     - NDIS_TAG_OFFLOAD
+NDop - ndis.sys     - NDIS_TAG_PM_PROT_OFFLOAD
+NDpb - ndis.sys     -     protocol block
+NDpc - ndis.sys     - NDIS_TAG_PROTOCOL_CONFIGURATION
+NDpf - ndis.sys     - NDIS_TAG_FILTER
+NDpk - ndis.sys     - NDIS_TAG_PKT_PATTERN
+NDpl - ndis.sys     - NDIS_TAG_PERF_LOG_ID
+NDpn - ndis.sys     - NDIS_TAG_PARAMETER_NODE
+NDpo - ndis.sys     - NDIS_TAG_PORT
+NDpp - ndis.sys     -     packet pool
+NDpr - ndis.sys     - NDIS_TAG_PERIODIC_RECEIVES
+NDpw - ndis.sys     - NDIS_TAG_WOL_PATTERN
+NDqo - ndis.sys     - NDIS_TAG_QUERY_OBJECT_WORKITEM
+NDqs - ndis.sys     - NDIS_TAG_QOS
+NDqu - ndis.sys     - NDIS_TAG_QUEUE
+NDrc - ndis.sys     - NDIS_TAG_RWL_REFCOUNT
+NDrd - ndis.sys     - NDIS_TAG_REG_READ_DATA_BUFFER
+NDre - ndis.sys     - NDIS_TAG_OID_REQUEST
+NDrf - ndis.sys     - NDIS_TAG_RECEIVE_FILTER
+NDrl - ndis.sys     -     resource list
+NDrp - ndis.sys     - NDIS_TAG_REGISTRY_PATH
+NDrq - ndis.sys     - NDIS_TAG_Q_REQ
+NDrs - ndis.sys     - NDIS_TAG_RSS
+NDrt - ndis.sys     - NDIS_TAG_RST_NBL
+NDrw - ndis.sys     - NDIS_TAG_RWLOCK
+NDrx - ndis.sys     - NDIS debugging refcount
+NDsd - ndis.sys     - NDIS_TAG_NET_CFG_SEC_DESC
+NDse - ndis.sys     - NDIS_TAG_SECURITY
+NDsg - ndis.sys     - NDIS_TAG_DOUBLE_BUFFER_PKT
+NDsh - ndis.sys     - NDIS_TAG_SHARED_MEMORY
+NDsi - ndis.sys     - EISA slot information
+NDsk - ndis.sys     - NDIS debugging stacktrace
+NDsm - ndis.sys     - Cached shared memory descriptor
+NDss - ndis.sys     - NDIS_TAG_SS - Selective Suspend
+NDst - ndis.sys     - NDIS_TAG_STRING
+NDtk - ndis.sys     - NDIS_TAG_NBL_TRACKER - Lost packet diagnostics
+NDvm - ndis.sys     - NDIS_TAG_ALLOC_MEM_VERIFY_ON
+NDw0 - ndis.sys     - NDIS_TAG_WMI_REG_INFO
+NDw1 - ndis.sys     - NDIS_TAG_WMI_GUID_TO_OID
+NDw2 - ndis.sys     - NDIS_TAG_WMI_OID_SUPPORTED_LIST
+NDw3 - ndis.sys     - NDIS_TAG_WMI_EVENT_ITEM
+NDwh - ndis.sys     - NDIS_TAG_WRAPPER_HANDLE
+NDwi - ndis.sys     - NDIS_TAG_WORK_ITEM
+NDwr - ndis.sys     - NDIS_TAG_WMI_REQUEST
+NDwx - ndis.sys     - NDIS_TAG_WOL_XLATE
+NDxc - ndis.sys     - NDIS_TAG_POOL_XLATE
+
+Net  - tcpip.sys    - NetIO Generic Buffers (iBFT Table allocations)
+NeWQ - tcpip.sys    - NetIO WorkQueue Data
+
+NEEB - newt_ndis6.sys - NEWT Emulation Bench
+NEFT - newt_ndis6.sys - NEWT Filter Object
+NEIM - newt_ndis6.sys - NEWT IM Object
+NEOD - newt_ndis6.sys - NEWT OID
+NEPK - newt_ndis6.sys - NEWT Packet
+NEWI - newt_ndis6.sys - NEWT Work Item
+
+Nb?? - <unknown>    - NetBT allocations
+Nf?? - nfssvr.sys   - NFS (Network File System) allocations
+NfR? - nfsrdr.sys   - NFS (Network File System) client re-director
+Nls  - <unknown>    - Nls strings
+NlsK - nt!ex        - Nls data
+Nmdd - <unknown>    - NetMeeting display driver miniport 1 MB block
+
+Nhfs - tcpip.sys    - NetIO Hash Function State Data
+
+NicT - mslbfoprovider.sys - Microsoft NDIS LBFO Provider (NIC Teaming)
+
+Navl - tcpip.sys    - Network Layer AVL Tree allocations
+NLbd - tcpip.sys    - Network Layer Buffer Data
+NLcc - tcpip.sys    - Network Layer Client Contexts
+NLpd - tcpip.sys    - Network Layer Client Requests
+NLcp - tcpip.sys    - Network Layer Compartments
+NLuh - <unknown>    - Network Layer Ul Handles
+NLap - tcpip.sys    - Network Layer Netio Helper Function allocations
+NLNa - tcpip.sys    - Network Layer Network Address Lists
+
+NMhf - netio.sys    - Handle Factory pool
+NMpt - <unknown>    - Generic AVL Tree allocations
+
+NMRb - tcpip.sys    - Network Module Registrar Bindings
+NMRc - tcpip.sys    - Network Module Registrar Arrays
+NMRf - tcpip.sys    - Network Module Registrar Filters
+NMRg - tcpip.sys    - Network Module Registrar Generic Buffers
+NMRm - tcpip.sys    - Network Module Registrar Modules
+NMRn - tcpip.sys    - Network Module Registrar Network Protocol Identifiers
+
+Nnbl - netio.sys    - NetIO NetBufferLists
+Nnbf - netio.sys    - NetIO NetBuffers
+Nnnn - netio.sys    - NetIO NetBuffers And NetBufferLists
+Nph1 - netio.sys    - NetIO Protocol Header1 Data
+Nph2 - netio.sys    - NetIO Protocol Header2 Data
+
+None - <unknown>    - call to ExAllocatePool
+
+NpEv - npfs.sys     - Npfs events
+Npf* - npfs.sys     - Npfs Allocations
+NpFc - npfs.sys     - CCB, client control block
+NpFC - npfs.sys     - ROOT_DCB CCB
+NpFD - npfs.sys     - DCB, directory block
+NpFg - npfs.sys     - Global storage
+NpFi - npfs.sys     - NPFS client info buffer.
+NpFn - npfs.sys     - Name block
+NpFq - npfs.sys     - Query template buffer used for directory query
+NpFr - npfs.sys     - DATA_ENTRY records (read/write buffers)
+NpFs - npfs.sys     - Client security context
+NpFw - npfs.sys     - Write block
+NpFW - npfs.sys     - Write block
+
+Npta - <unknown>    - NPT Addresses
+Nptx - <unknown>    - NPT Packets
+Nptr - <unknown>    - NPT Receive Completes
+Npts - <unknown>    - NPT Send sCompletes
+
+NS?? - <unknown>    - Netware server allocations
+
+NSIk - nsi.dll      - NSI RPC Tansactions
+NSIr - nsi.dll      - NSI Generic Buffers
+NSpc - nsi.dll      - NSI Proxy Contexts
+NSpg - nsi.dll      - NSI Proxy Generic Buffers
+
+REM NTFS Specific allocation tags
+NtAR - ntfs.sys     -     Ntfs Async Cached Read allocation
+Ntf0 - ntfs.sys     -     General pool allocation
+Ntf9 - ntfs.sys     -     Large Temporary Buffer
+NtfC - ntfs.sys     -     CCB
+Ntfc - ntfs.sys     -     CCB_DATA
+Ntfd - ntfs.sys     -     DEALLOCATED_CLUSTERS
+NtfD - ntfs.sys     -     DEALLOCATED_RECORDS
+NtfE - ntfs.sys     -     INDEX_CONTEXT
+Ntff - ntfs.sys     -     FCB_DATA
+NtfF - ntfs.sys     -     FCB_INDEX
+NtfI - ntfs.sys     -     IO_CONTEXT
+Ntfi - ntfs.sys     -     IRP_CONTEXT
+NtfK - ntfs.sys     -     KEVENT
+Ntfk - ntfs.sys     -     FILE_LOCK
+Ntfl - ntfs.sys     -     LCB
+NtfM - ntfs.sys     -     NTFS_MCB_ENTRY
+Ntfm - ntfs.sys     -     NTFS_MCB_ARRAY
+NtfN - ntfs.sys     -     NUKEM
+Ntfn - ntfs.sys     -     SCB_NONPAGED
+Ntfo - ntfs.sys     -     SCB_INDEX normalized named buffer
+NtfQ - ntfs.sys     -     QUOTA_CONTROL_BLOCK
+Ntfq - ntfs.sys     -     General Allocation with Quota
+NtfR - ntfs.sys     -     READ_AHEAD_THREAD
+Ntfr - ntfs.sys     -     ERESOURCE
+NtfS - ntfs.sys     -     SCB_INDEX
+Ntfs - ntfs.sys     -     SCB_DATA
+NtfT - ntfs.sys     -     SCB_SNAPSHOT
+Ntft - ntfs.sys     -     SCB (Prerestart)
+Ntfu - ntfs.sys     -     NTFS_MARK_UNUSED_CONTEXT
+NtfV - ntfs.sys     -     VPB
+Ntfv - ntfs.sys     -     COMPRESSION_SYNC
+Ntfw - ntfs.sys     -     Workspace
+Ntfx - ntfs.sys     -     General Allocation
+Ntf? - ntfs.sys     -     Unkown allocation
+NtTc - ntfs.sys     -     FILE_LEVEL_TRIM_CONTEXT
+NtTf - ntfs.sys     -     NTFS_DISK_FLUSH_CONTEXT           NtfsDiskFlushContextLookasideList
+NtTr - ntfs.sys     -     DEVICE_MANAGE_DATA_SET_ATTRIBUTES NtfsDeviceManageDataSetAttributesLookasideList
+NtTo - ntfs.sys     -     DEVICE_MANAGE_DATA_SET_ATTRIBUTES NtfsFileOffloadLookasideList
+NtTe - ntfs.sys     -     NTFS Telemetry
+
+REM NTFS tags based on source module
+NtFa - ntfs.sys     -     AllocSup.c
+NtFA - ntfs.sys     -     AttrSup.c
+NtFB - ntfs.sys     -     BitmpSup.c
+NtFC - ntfs.sys     -     Create.c
+NtFD - ntfs.sys     -     DevioSup.c
+NtFd - ntfs.sys     -     DirCtrl.c
+NtFE - ntfs.sys     -     Ea.c
+NtFF - ntfs.sys     -     FileInfo.c
+NtFf - ntfs.sys     -     FsCtrl.c
+NtFH - ntfs.sys     -     SelfHeal.c
+NtFI - ntfs.sys     -     IndexSup.c
+NtFL - ntfs.sys     -     LogSup.c
+NtFM - ntfs.sys     -     McbSup.c
+NtFm - ntfs.sys     -     Ntfs MFT View Ref Counter Arrays
+NtFN - ntfs.sys     -     NtfsData.c
+NtFO - ntfs.sys     -     ObjIdSup.c
+NtFQ - ntfs.sys     -     QuotaSup.c
+NtFR - ntfs.sys     -     RestrSup.c
+NtFS - ntfs.sys     -     SecurSup.c
+NtFs - ntfs.sys     -     StrucSup.c
+NtFU - ntfs.sys     -     usnsup.c
+NtFV - ntfs.sys     -     VerfySup.c
+NtFv - ntfs.sys     -     ViewSup.c
+NtFW - ntfs.sys     -     Write.c
+NtF? - ntfs.sys     -     Unknown NTFS source module
+
+NulB - tlnull.sys   - Null TDI Buffers
+NulR - tlnull.sys   - Null TDI Requests
+NulS - tlnull.sys   - Null TDI Sockets
+NulE - tlnull.sys   - Null Tl Endpoints
+Null - tlnull.sys   - Null TL Generics
+NulI - tlnull.sys   - Null TL Indications
+Nulr - tlnull.sys   - Null Tl Requests
+
+NV   - <unknown>      - nVidia video driver
+NvLA - <nvlddmkm.sys> - nVidia video driver
+NvLa - <nvlddmkm.sys> - nVidia video driver
+NvLC - <nvlddmkm.sys> - nVidia video driver
+NvLc - <nvlddmkm.sys> - nVidia video driver
+NvLD - <nvlddmkm.sys> - nVidia video driver
+NvLd - <nvlddmkm.sys> - nVidia video driver
+NvLE - <nvlddmkm.sys> - nVidia video driver
+NvLH - <nvlddmkm.sys> - nVidia video driver
+NvLm - <nvlddmkm.sys> - nVidia video driver
+NvLP - <nvlddmkm.sys> - nVidia video driver
+NvLp - <nvlddmkm.sys> - nVidia video driver
+NvLR - <nvlddmkm.sys> - nVidia video driver
+NvLr - <nvlddmkm.sys> - nVidia video driver
+NvLS - <nvlddmkm.sys> - nVidia video driver
+NvLs - <nvlddmkm.sys> - nVidia video driver
+NvLT - <nvlddmkm.sys> - nVidia video driver
+
+Nwcs - <unknown>    - Client Services for NetWare
+NwFw - <unknown>    - ntos\tdi\fwd
+
+
+ObSq - nt!ob        - object security descriptors (query)
+ObCi - nt!ob        - captured information for ObCreateObject
+ObCI - nt!ob        - object creation lookaside list
+ObDi - nt!ob        - object directory
+ObHd - nt!ob        - object handle count data base
+ObNm - nt!ob        - object names
+ObNM - nt!ob        - name buffer per processor lookaside pointers
+ObRt - nt!ob        - object reference stack tracing
+ObZn - nt!ob        - object zone
+ObjT - nt!ob        - object type objects
+Obtb - nt!ob        - object tables via EX handle.c
+ObTR - nt!ob        - object table ERESOURCEs
+Obeb - nt!ob        - object tables extra bit tables via EX handle.c
+ObDm - nt!ob        - object device map
+ObSc - nt!ob        - Object security descriptor cache block
+ObSt - nt!ob        - Object Manager temporary storage
+ObWm - nt!ob        - Object Manager wait blocks
+
+ODMg - dxgkrnl.sys  - Output Duplication component
+
+OHCI - <unknown>    - Open Host Controller Interface for USB
+ohci - <unknown>    - 1394 OHCI host controller driver
+
+OlmC - tcpip.sys    - Offload Manager Connections
+OlmI - tcpip.sys    - Offload Manager Interfaces
+
+Ovfl - <unknown>    - The internal pool tag table has overflowed - usually this is a result of nontagged allocations being made
+
+OvfL - <unknown>    - EXIFS FCBOVF List
+
+PaeD - <unknown>    - PAE top level directory allocation blocks
+
+ParC - <unknown>    - Parallel class driver
+ParL - <unknown>    - Parallel link driver
+ParP - <unknown>    - Parallel port driver
+ParV - <unknown>    - ParVdm driver for vdm<->parallel port communciation
+
+PciB - pci.sys      - PnP pci bus enumerator
+
+Pccr - pacer.sys    - PACER Filter Clone Requests
+Pcfc - pacer.sys    - PACER Filter Contexts
+Pcfl - pacer.sys    - PACER Flows
+Pcge - pacer.sys    - PACER Generic Buffers (DACL, SID allocations)
+Pcle - pacer.sys    - PACER Lines
+Pclt - pacer.sys    - PACER Line Tables
+Pcna - pacer.sys    - PACER Filter Network Addresses
+Pcnt - pacer.sys    - PACER NetBufferTimes
+Pcop - pacer.sys    - PACER Original Packet Contexts
+Pcpc - pacer.sys    - PACER Packet Contexts
+Pcsb - pacer.sys    - PACER Send Buffers
+Pcta - pacer.sys    - PACER Timer Units
+Pctw - pacer.sys    - PACER Timer Wheels
+Pcwc - pacer.sys    - PACER WAN NetworkBufferList CTXs
+
+PcCi - <unknown>    - WDM audio port class adapter device object stuff
+PcCr - <unknown>    - WDM audio stuff
+PcDi - <unknown>    - WDM audio stuff
+PcDm - <unknown>    - DirectMusic MXF objects (WDM audio)
+PcFM - <unknown>    - WDM audio FM synthesizer
+PcFp - <unknown>    - WDM audio stuff
+PcIc - <unknown>    - WDM audio stuff
+PcIl - <unknown>    - WDM audio stuff
+PcNw - <unknown>    - WDM audio stuff
+PcPc - <unknown>    - WDM audio stuff
+PcPr - <unknown>    - WDM audio stuff
+PcSX - <unknown>    - WDM audio stuff
+PcSl - <unknown>    - WDM audio stuff
+PcSt - <unknown>    - WDM audio stuff
+PcSx - <unknown>    - WDM audio stuff
+PcUs - <unknown>    - WDM audio stuff
+
+Pcmc - pcmcia.sys   - Pcmcia bus enumerator, general structures
+Pcic - <unknown>    - Pcmcia bus enumerator, PCIC/Cardbus controller specific structures
+Pcdb - <unknown>    - Pcmcia bus enumerator, Databook controller specific structures
+
+PdcA - pdc.sys      - PDC_ACTIVATION_TAG, ACTIVATOR_CLIENT_TAG
+PdcC - pdc.sys      - PDC_CLIENT_PORT_TAG
+PdcE - pdc.sys      - ACTIVATOR_EVENT_TAG
+PdcI - pdc.sys      - PDC_INCLUSION_LIST_TAG
+PdcM - pdc.sys      - PDC_MESSAGE_TAG
+PdcN - pdc.sys      - PDC_NOTIFICATION_TAG, NOTIFICATION_CLIENT_TAG
+PdcP - pdc.sys      - PDC_PORT_TAG
+PdcR - pdc.sys      - PDC_RESILIENCY_TAG, RESILIENCY_CLIENT_TAG
+PdcS - pdc.sys      - PDC_SUSPRES_TAG
+PdcT - pdc.sys      - PDC_TOKEN_TAG
+PSwt - pdc.sys      - PDC_PSWT_TAG
+Pdcs - pdc.sys      - PDC_SCENARIO_TAG
+
+SPMp - nt!po        - Kernel Scenario Power Manager Policies.
+
+PepT - nt!PopPep    - Default Power Engine Plugin
+
+Petw - pacer.sys    - PACER ETW
+
+Pf?? - nt!pf        - Pf Allocations
+PfAL - nt!pf        - Pf Application launch event data
+PfAS - nt!pf        - Pf Prefetch support array
+PfDq - nt!pf        - Pf Directory query buffers
+PfED - nt!pf        - Pf Generic event data
+PfEL - nt!pf        - Pf Event logging buffers
+PfET - nt!pf        - Pf Entry info tables
+PfFH - nt!pf        - Pf RpContext FileKeyHash buckets
+PfFh - nt!pf        - Pf Prefetch file handle cache array
+PfFK - nt!pf        - Pf RpContext FileKeyHashEntry
+PfLB - nt!pf        - Pf Log buffers
+PfMP - nt!pf        - Pf Prefetch metadata buffers
+PfNL - nt!pf        - Pf Name logging buffers
+PfOB - nt!pf        - Pf Oplock buffers
+PfPB - nt!pf        - Pf Pfn query buffers
+PfRL - nt!pf        - Pf Prefetch read list
+PfRQ - nt!pf        - Pf Prefetch request buffers
+PfSA - nt!pf        - Pf Prefetch support array
+PfTD - nt!pf        - Pf Trace Dump
+PfTt - nt!pf        - Pf Translation tables
+PfVA - nt!pf        - Pf VA prefetching buffers
+PfVH - nt!pf        - Pf Prefetch volume handles
+
+Pfcs - pacer.sys    - PACER Flow Counter Sets
+Pfhc - pacer.sys    - PACER File Handle Contexts
+
+PFXM - nt!PoFx      - Runtime Power Management Framework
+
+PcwC - nt!pcw       - PCW Counter set
+PcwR - nt!pcw       - PCW provider Registration
+PcwI - nt!pcw       - PCW counter set Instance
+PcwQ - nt!pcw       - PCW Query item
+PcwS - nt!pcw       - PCW System call buffer
+PcwT - nt!pcw       - PCW Temporary (short-lived) buffer
+
+Pgm? - <unknown>    - Pgm (Pragmatic General Multicast) protocol: RMCast.sys
+
+Plcp - <unknown>    - Cache aware pushlock list (array of puchlock addresses)
+Plcl - <unknown>    - Cache aware pushlock entry. One per processor
+
+PlMp - storport.sys - PortpReadDriverParameterEntry
+PlRB - storport.sys - PortAllocateRegistryBuffer storport!_PORT_REGISTRY_INFO.Buffer
+
+PmpA - portmap.sys  - Portmap address list
+PmpC - portmap.sys  - Portmap device context
+PmpM - portmap.sys  - Portmap mapping
+PmpR - portmap.sys  - Portmap RPCB
+
+PmAT - partmgr.sys  - Partition Manager attributes table cache
+PmDD - partmgr.sys  - Partition Manager device descriptor
+PmIB - partmgr.sys  - Partition Manager buffer for IOCTL processing
+PmME - partmgr.sys  - Partition Manager migration entry
+PmPE - partmgr.sys  - Partition Manager partition entry
+PmPT - partmgr.sys  - Partition Manager partition table cache
+PmRL - partmgr.sys  - Partition Manager remove lock
+PmRP - partmgr.sys  - Partition Manager registry path
+PmRR - partmgr.sys  - Partition Manager removal relations
+PmSD - partmgr.sys  - Partition Manager snapshot data cache
+PmTE - partmgr.sys  - Partition Manager table entry
+PmVE - partmgr.sys  - Partition Manager volume entry
+
+PNCH - <unknown>    - Power Notify Channel
+PNCL - <unknown>    - Power Notify channel list
+PNDP - <unknown>    - Power Abort Dpc Routine
+PNI  - <unknown>    - Power Notify Instance
+
+PoEa - raspppoe.sys - MTAG_ADAPTER
+PoEb - raspppoe.sys - MTAG_BINDING
+PoEc - raspppoe.sys - MTAG_BUFFERPOOL
+PoEd - raspppoe.sys - MTAG_PACKETPOOL
+PoEe - raspppoe.sys - MTAG_PPPOEPACKET
+PoEf - raspppoe.sys - MTAG_TAPIPROV
+PoEg - raspppoe.sys - MTAG_LINE
+PoEh - raspppoe.sys - MTAG_CALL
+PoEi - raspppoe.sys - MTAG_HANDLETABLE
+PoEj - raspppoe.sys - MTAG_HANDLECB
+PoEk - raspppoe.sys - MTAG_TIMERQ
+PoEl - raspppoe.sys - MTAG_FREED
+PoEm - raspppoe.sys - MTAG_LLIST_WORKITEMS
+PoEu - raspppoe.sys - MTAG_UTIL
+
+Pool - <unknown>    - Pool tables, etc.
+PooL - <unknown>    - Phase 0 initialization of the executive component, paged and nonpaged small pool lookaside structures
+Port - <unknown>    - Port objects
+
+PoSL - <unknown>    - Power shutdown event list
+
+PPMd - <unknown>    - Processor Drivers (Processor Power Management).
+PPMi - nt!po        - Kernel Processor Power Management Idle States.
+PPMp - nt!po        - Kernel Processor Power Management Perf States.
+PPMw - nt!po        - Kernel Processor Power Management WMI interface.
+
+Prof - <unknown>    - Profile objects
+
+POWI - nt!po        - Power Work Item (executive worker thread work item entry)
+PSwt - nt!po        - Power switch structure
+PSTA - nt!po        - Po registered system state
+PDss - nt!po        - Po device system state
+PRTM - nt!po        - Power runtime management
+PCol - nt!po        - Thermal cooling requests and extensions
+
+PpTg - mpsdrv.sys   - MPSDRV PPTP GRE analyzer
+PpTt - mpsdrv.sys   - MPSDRV PPTP TCP analyzer
+
+Prcr - processr.sys - Processr driver allocations
+
+Proc - nt!ps        - Process objects
+Ps   - nt!ps        - general ps allocations
+Psap - nt!ps        - Block used to hold a user mode APC while its queued to a thread
+PsAp - nt!ps        - Process APC queued by user mode process
+PsCa - nt!ps        - APC queued at thread create time.
+PsCr - nt!ps        - Working set change record (temporary allocation)
+PsEx - nt!ps        - Process exit APC
+PsFn - nt!ps        - Captured image file name buffer (temporary allocation)
+PsHl - nt!ps        - Captured list of handles to inherit in child process (temporary allocation)
+PsIm - nt!ps        - Thread impersonation (PS_IMPERSONATE_INFORMATION, pre-Vista)
+PsJa - nt!ps        - Job access control state
+Psjb - nt!ps        - Job set array (temporary allocation)
+PsLd - nt!ps        - Process LDT information blocks
+PsPb - nt!ps        - Captured process parameter block (temporary allocation)
+PsQb - nt!ps        - Process quota block
+PsRl - nt!ps        - Captured memory reserve list (temporary allocation)
+PsSb - nt!ps        - Initial process parameter block (temporary allocation)
+PsSd - nt!ps        - Augmented thread security descriptor (temporary allocation)
+PsTf - nt!ps        - Job object token filter
+Pstb - nt!ps        - Process tables via EX handle.c
+Psta - nt!ps        - Power management system state
+PsTp - nt!ps        - Thread termination port block
+PsWs - nt!ps        - Process working set watch array
+
+PSE3 - pse36.sys    - Physical Size Extension driver
+
+Pnp0 - nt!pnp       - PNPMGR rebalance resource request table
+Pnp1 - nt!pnp       - PNPMGR IRP completion context
+Pnp2 - nt!pnp       - PNPMGR device action request
+Pnp3 - nt!pnp       - PNPMGR HW Profile
+Pnp4 - nt!pnp       - PNPMGR CM API
+Pnp5 - nt!pnp       - PNPMGR assign resources context
+Pnp6 - nt!pnp       - PNPMGR resource request
+Pnp7 - nt!pnp       - PNPMGR deferred notify entry
+Pnp8 - nt!pnp       - PNPMGR async target device change notify
+Pnp9 - nt!pnp       - PNPMGR HW profile notify
+PnpA - nt!pnp       - PNPMGR PnpRtl Operations
+PnpC - nt!pnp       - PNPMGR target device notify
+PnpF - nt!pnp       - PNPMGR eject data
+PnpG - nt!pnp       - PNPMGR generic
+PnpH - nt!pnp       - PNPMGR service name
+PnpI - nt!pnp       - PNPMGR instance path
+PnpJ - nt!pnp       - PNPMGR device event list
+PnpK - nt!pnp       - PNPMGR device event entry
+PnpL - nt!pnp       - PNPMGR device event workitem
+PnpM - nt!pnp       - PNPMGR veto buffer
+PnpN - nt!pnp       - PNPMGR PDO array
+PnpO - nt!pnp       - PNPMGR veto process
+PnpP - nt!pnp       - PNPMGR veto device object
+PnpQ - nt!pnp       - PNPMGR partition resource list
+PnpR - nt!pnp       - PNPMGR memory bitmap
+PnpS - nt!pnp       - PNPMGR dependent info
+PnpT - nt!pnp       - PNPMGR provider info
+PnpU - nt!pnp       - PNPMGR async set status control
+PnpV - nt!pnp       - PNPMGR notify entry loc
+PnpW - nt!pnp       - PNPMGR SwDevice
+PnpX - nt!pnp       - PNPMGR DevQuery
+PnpY - nt!pnp       - PNPMGR usermode device notifications
+PnpZ - nt!pnp       - PNPMGR data model
+PnPb - nt!pnp       - PnP BIOS resource manipulation
+PpEB - nt!pnp       - PNP_POOL_EVENT_BUFFER
+PpEE - nt!pnp       - PNP_DEVICE_EVENT_ENTRY_TAG
+PpEL - nt!pnp       - PNP_DEVICE_EVENT_LIST_TAG
+PpLg - nt!pnp       - PnP last good.
+PpUB - nt!pnp       - PNP_USER_BLOCK_TAG
+PpWI - nt!pnp       - PNP_DEVICE_WORK_ITEM_TAG
+Ppcd - nt!pnp       - PnP critical device database
+Ppcr - nt!pnp       - plug-and-play critical allocations
+Ppdd - nt!pnp       - new Plug-And-Play driver entries and IRPs
+Ppde - nt!pnp       - routines to perform device removal
+Ppei - nt!pnp       - Eisa related code
+Ppen - nt!pnp       - routines to perform device enumeration
+Ppin - nt!pnp       - plug-and-play initialization
+Ppio - nt!pnp       - plug-and-play IO system APIs
+
+PPMi - nt!po        - Processor Power Manager Idle States
+PPMp - nt!po        - Processor Power Manager Perf States
+PPMw - nt!po        - Processor Power Manager WMI Interface
+
+Ppre - nt!pnp       - resource allocation and translation
+Pprl - nt!pnp       - routines to manipulate relations list
+Ppsu - nt!pnp       - plug-and-play subroutines for the I/O system
+
+PPTP - <unknown>    - PPTP_MEMORYPOOL_TAG
+PPT0 - <unknown>    - PPTP_TDIADDR_TAG
+PPT1 - <unknown>    - PPTP_TDICONN_TAG
+PPT2 - <unknown>    - PPTP_CONNINFO_TAG
+PPT3 - <unknown>    - PPTP_ADDRINFO_TAG
+PPT4 - <unknown>    - PPTP_TIMEOUT_TAG
+PPT5 - <unknown>    - PPTP_TIMER_TAG
+PPT6 - <unknown>    - PPTP_TDICOTS_TAG
+PPT7 - <unknown>    - PPTP_WRKQUEUE_TAG
+PPT8 - <unknown>    - PPTP_SEND_CTRLDATA_TAG
+PPT9 - <unknown>    - PPTP_SEND_ACKDATA_TAG
+PPTa - <unknown>    - PPTP_SEND_DGRAMDESC_TAG
+PPTb - <unknown>    - PPTP_TDICLTS_TAG
+PPTc - <unknown>    - PPTP_RECV_CTRLDESC_TAG
+PPTd - <unknown>    - PPTP_RECV_CTRLDATA_TAG
+PPTe - <unknown>    - PPTP_RECV_DGRAMDESC_TAG
+PPTf - <unknown>    - PPTP_RECV_DGRAMDATA_TAG
+PPTg - <unknown>    - PPTP_RECVDESC_TAG
+PPTh - <unknown>    - PPTP_ENGINE_TAG
+PPTi - <unknown>    - PPTP_RECVDATA_TAG
+
+PRF? - nt!wdi       - Performance Allocations
+PRFd - nt!wdi       - Performance Diagnostics Structures
+
+PSC? - <unknown>    - Packet Scheduler (PSCHED) Tags
+
+PSC0 - <unknown>    - NDIS Request
+PSC1 - <unknown>    - GPC Client Vc
+PSC2 - <unknown>    - WanLink
+PSC3 - <unknown>    - Miscellaneous allocations
+PSC4 - <unknown>    - WMI
+PSCa - <unknown>    - Adapter
+PSCb - <unknown>    - CallParameters
+PSCc - <unknown>    - PipeContext
+PSCd - <unknown>    - FlowContext
+PSCe - <unknown>    - ClassMapContext
+PSCf - <unknown>    - Adapter Profile
+PSCg - <unknown>    - Component
+
+PX1  - <unknown>    - ndis ProviderEventLookaside
+
+p2?? - perm2dll.dll - Permedia2 display driver
+p2d3 - perm2dll.dll - Permedia2 display driver - d3d.c
+p2d6 - perm2dll.dll - Permedia2 display driver - d3ddx6.c
+p2de - perm2dll.dll - Permedia2 display driver - debug.c
+p2ds - perm2dll.dll - Permedia2 display driver - d3dstate.c
+p2dt - perm2dll.dll - Permedia2 display driver - d3dtxman.c
+p2su - perm2dll.dll - Permedia2 display driver - ddsurf.c
+p2en - perm2dll.dll - Permedia2 display driver - enable.c
+p2fi - perm2dll.dll - Permedia2 display driver - fillpath.c
+p2he - perm2dll.dll - Permedia2 display driver - heap.c
+p2hw - perm2dll.dll - Permedia2 display driver - hwinit.c
+p2cx - perm2dll.dll - Permedia2 display driver - p2ctxt.c
+p2pa - perm2dll.dll - Permedia2 display driver - palette.c
+p2pe - perm2dll.dll - Permedia2 display driver - permedia.c
+p2tx - perm2dll.dll - Permedia2 display driver - textout.c
+
+P3D? - perm3dd.dll  - Permedia3 display driver - DirectDraw/3D
+P3G? - perm3dd.dll  - Permedia3 display driver
+
+ppPT - pvhdparser.sys - Proxy Virtual Machine Storage VHD Parser Driver (parser)
+ppRT - pvhdparser.sys - Proxy Virtual Machine Storage VHD Parser Driver (parser)
+
+PSHD - pshed.dll    - PSHED
+PSPi - pshed.dll    - PSHED Plug-in
+
+Ppcs - pacer.sys    - PACER Pipe Counter Sets
+Pwff - pacer.sys    - PACER WFP Filters
+Pwmi - pacer.sys    - PACER WMI notifications
+
+PX1 - ndproxy.sys - PX_EVENT_TAG
+PX2 - ndproxy.sys - PX_VCTABLE_TAG
+PX3 - ndproxy.sys - PX_ADAPTER_TAG
+PX4 - ndproxy.sys - PX_CLSAP_TAG
+PX5 - ndproxy.sys - PX_CMSAP_TAG
+PX6 - ndproxy.sys - PX_PARTY_TAG
+PX7 - ndproxy.sys - PX_COCALLPARAMS_TAG
+PX8 - ndproxy.sys - PX_REQUEST_TAG
+PX9 - ndproxy.sys - PX_PROVIDER_TAG
+PXa - ndproxy.sys - PX_ENUMLINE_TAG
+PXb - ndproxy.sys - PX_TAPILINE_TAG
+PXc - ndproxy.sys - PX_ENUMADDR_TAG
+PXd - ndproxy.sys - PX_TAPIADDR_TAG
+PXe - ndproxy.sys - PX_TAPICALL_TAG
+PXf - ndproxy.sys - PX_LINECALLINFO_TAG
+PXg - ndproxy.sys - PX_CMAF_TAG
+PXh - ndproxy.sys - PX_CLAF_TAG
+PXi - ndproxy.sys - PX_VC_TAG
+PXj - ndproxy.sys - PX_TRANSLATE_CALL_TAG
+PXk - ndproxy.sys - PX_TRANSLATE_SAP_TAG
+PXl - ndproxy.sys - PX_LINETABLE_TAG
+
+Qnam - <unknown>    - EXIFS Query Name
+
+Qp?? - <unknown>    - Generic Packet Classifier (MSGPC)
+Qppn - <unknown>    -      Queued Notifications
+Qppi - <unknown>    -      Pending Irp structures
+Qpci - <unknown>    -      CfInfo
+Qpct - <unknown>    -      Client blocks
+Qppa - <unknown>    -      Pattern blocks
+Qphf - <unknown>    -      HandleFactory
+Qpph - <unknown>    -      PathHash
+Qprz - <unknown>    -      Rhizome
+Qppd - <unknown>    -      GenPatternDb
+Qpfd - <unknown>    -      FragmentDb
+Qpcf - <unknown>    -      ClassificationFamily
+Qpcd - <unknown>    -      CfInfoData
+Qpcb - <unknown>    -      ClassificationBlock
+Qppt - <unknown>    -      Protocol
+Qpdg - <unknown>    -      Debug
+
+QuU2 - mpsdrv.sys   - MPSDRV upcall response
+
+RAWb - nt!RAW       - RAW file system buffer
+
+Ra12 - storport.sys - RaidBusEnumeratorAllocateUnitResources storport!_BUS_ENUM_RESOURCES.DataBuffer
+RaAM - storport.sys - RaidAllocateAddressMapping storport!_MAPPED_ADDRESS
+RaCD - storport.sys - RaUnitScsiGetDumpPointersIoctl
+RaDf - storport.sys - RaidInitializeDeferredQueue storport!_RAID_DEFERRED_QUEUE.FreeList
+RaDI - storport.sys - RaidUnitGetDeviceId
+RaDR - storport.sys - RaidpBuildAdapterBusRelations storport!_DEVICE_RELATIONS
+RaDS - storport.sys - StorCreateAnsiString storport!_STRING.Buffer
+RaEt - storport.sys - RaidBusEnumeratorProcessBusUnit
+RaHI - storport.sys - RaSaveDriverInitData storport!_HW_INITIALIZATION_DATA
+RaME - storport.sys - RiAllocateMiniportDeviceExtension
+RaPC - storport.sys - RaInitializeConfiguration storport!_PORT_CONFIGURATION_INFORMATION.AccessRanges
+RaPD - storport.sys - RaidGetPortData storport!RaidpPortData
+RaRL - storport.sys - RaidInitializeResourceList storport!_RAID_RESOURCE_LIST
+RaRl - storport.sys - RaidBusEnumeratorAllocateReportLunsResources storport!_BUS_ENUM_RESOURCES.DataBuffer
+RaRS - storport.sys - RaidUnitAllocateResources
+RaSI - storport.sys - StorUnmapSenseInfo storport!_EXTENDED_REQUEST_BLOCK.Srb.SenseInfoBuffer
+RaSN - storport.sys - RaidBusEnumeratorAllocateUnitResources storport!_BUS_ENUM_RESOURCES.SenseInfo
+RaSr - storport.sys - RaidAllocateSrb storport!_SCSI_REQUEST_BLOCK
+RaTM - storport.sys - RaInitializeTagList storport!_QUEUE_TAG_LIST.Buffer
+RaTQ - storport.sys - RaUnitQueryDeviceTextIrp
+RaUE - storport.sys - RaidUnitAllocateResources
+RaWM - storport.sys - RaidAdapterWmiDeferredRoutine
+
+RaDA - tcpip.sys    - Raw Socket Discretionary ACLs
+RaEW - tcpip.sys    - Raw Socket Endpoint Work Queue Contexts
+RaJP - tcpip.sys    - Raw Socket Join Path Contexts
+RaMI - tcpip.sys    - Raw Socket Message Indication Tags
+RaPM - tcpip.sys    - Raw Socket Partial Memory Descriptor List Tag
+RaSM - tcpip.sys    - Raw Socket Send Messages Requests
+RaSL - tcpip.sys    - Raw Socket Send Message Lists
+RawE - tcpip.sys    - Raw Socket Endpoints
+RawN - tcpip.sys    - Raw Socket Nsi
+
+RB?? - <unknown>    - RedBook Filter Driver, static allocations
+RBEv - <unknown>    - RedBook - Thread Events
+RBRl - <unknown>    - RedBook - Remove lock
+RBRg - <unknown>    - RedBook - driverExtension->RegistryPath
+RBSe - <unknown>    - RedBook - Serialization tracking for checked builds
+RBWa - <unknown>    - RedBook - Wait block for system thread
+
+rb?? - <unknown>    - RedBook Filter Driver, dynamic allocations
+rbBu - <unknown>    - RedBook - Buffer for read/stream
+rbIr - <unknown>    - RedBook - Irp for read/stream
+rbIp - <unknown>    - RedBook - Irp pointer block
+rbMd - <unknown>    - RedBook - Mdl for read/stream
+rbMp - <unknown>    - RedBook - Mdl pointer block
+rbRc - <unknown>    - RedBook - Read completion context
+rbRx - <unknown>    - RedBook - Read Xtra info
+rbSc - <unknown>    - RedBook - Stream completion context
+rbSx - <unknown>    - RedBook - Stream Xtra info
+rbTo - <unknown>    - RedBook - Cached table of contents
+
+Rcp? - sacdrv.sys - SAC Driver (Headless)
+RcpA - sacdrv.sys -     Internal memory mgr alloc block
+RcpI - sacdrv.sys -     Internal memory mgr initial heap block
+RcpS - sacdrv.sys -     Security related block
+
+RDPD - rdpdr.sys - Device list object
+
+ReEv - <unknown>    - Resource Event
+ReSe - <unknown>    - Resource Semaphore
+ReTa - <unknown>    - Resource Extended Table
+ReTr - <unknown>    - Per ETHREAD EXECUTIVE Resource tracking.
+
+REM ReFS Specific allocation tags
+ReAR - refs.sys     -     Refs Async Cached Read allocation
+Ref0 - refs.sys     -     General pool allocation
+Ref9 - refs.sys     -     Large Temporary Buffer
+RefC - refs.sys     -     CCB
+Refc - refs.sys     -     CCB_DATA
+Refd - refs.sys     -     DEALLOCATED_CLUSTERS
+RefD - refs.sys     -     DEALLOCATED_RECORDS
+RefE - refs.sys     -     INDEX_CONTEXT
+Reff - refs.sys     -     FCB_DATA
+RefF - refs.sys     -     FCB_INDEX
+RefI - refs.sys     -     IO_CONTEXT
+Refi - refs.sys     -     IRP_CONTEXT
+RefK - refs.sys     -     KEVENT
+Refk - refs.sys     -     FILE_LOCK
+Refl - refs.sys     -     LCB
+RefN - refs.sys     -     NUKEM
+Refn - refs.sys     -     SCB_NONPAGED
+Refo - refs.sys     -     SCB_INDEX normalized named buffer
+Refq - refs.sys     -     General Allocation with Quota
+RefR - refs.sys     -     READ_AHEAD_THREAD
+Refr - refs.sys     -     ERESOURCE
+RefS - refs.sys     -     SCB_INDEX
+Refs - refs.sys     -     SCB_DATA
+RefH - refs.sys     -     SCB_SNAPSHOT
+Reft - refs.sys     -     SCB (Prerestart)
+Refu - refs.sys     -     NTFS_MARK_UNUSED_CONTEXT
+RefV - refs.sys     -     VPB
+Refv - refs.sys     -     COMPRESSION_SYNC
+Refw - refs.sys     -     Workspace
+Refx - refs.sys     -     General Allocation
+Ref? - refs.sys     -     Unkown allocation
+ReTc - refs.sys     -     FILE_LEVEL_TRIM_CONTEXT
+ReTm - refs.sys     -     DEVICE_MANAGE_DATA_SET_ATTRIBUTES RefsDeviceManageDataSetAttributesLookasideList
+ReTo - refs.sys     -     DEVICE_MANAGE_DATA_SET_ATTRIBUTES RefsFileOffloadLookasideList
+ReTe - refs.sys     -     ReFS Telemetry
+Redf - refs.sys     -     REFS_DISK_FLUSH_CONTEXT allocations
+
+REM ReFS tags based on source module
+ReFa - refs.sys     -     AllocSup.c
+ReFA - refs.sys     -     AttrHelpers.c
+ReFC - refs.sys     -     Create.c
+ReFD - refs.sys     -     DevioSup.c
+ReFd - refs.sys     -     DirCtrl.c
+ReFE - refs.sys     -     Ea.c
+ReFF - refs.sys     -     FileInfo.c
+ReFf - refs.sys     -     FsCtrl.c
+ReFH - refs.sys     -     SelfHeal.c
+ReFN - refs.sys     -     NtfsData.c
+ReFS - refs.sys     -     SecurSup.c
+ReFs - refs.sys     -     StrucSup.c
+ReFU - refs.sys     -     usnsup.c
+ReFV - refs.sys     -     VerfySup.c
+ReFv - refs.sys     -     ViewSup.c
+ReFW - refs.sys     -     Write.c
+ReF? - refs.sys     -     Unknown ReFS source module
+
+RefT - <unknown>    - Bluetooth reference tracking
+Rf?? - <unknown>    - Bluetooth RFCOMM TDI driver
+RfAD - rfcomm.sys   -   RFCOMM Address
+RfBB - rfcomm.sys   -   RFCOMM BRB
+RfBT - rfcomm.sys   -   RFCOMM (bthport)
+RfCB - rfcomm.sys   -   RCOMMM
+RfCH - rfcomm.sys   -   RFCOMM channel
+RfCN - rfcomm.sys   -   RFCOMM connect
+RfDA - rfcomm.sys   -   RFCOMM data
+RfFR - rfcomm.sys   -   RFCOMM frame
+RfRX - rfcomm.sys   -   RFCOMM receive
+RfPP - rfcomm.sys   -   RFCOMM pnp
+RfWR - rfcomm.sys   -   RFCOMM worker
+
+RhHi - tcpip.sys    - Reference History Pool
+
+Rind - tcpip.sys    - Raw Socket Receive Indications
+
+RKRW - mpsdrv.sys   - MPSDRV work item
+RTLF - mpsdrv.sys   - MPSDRV filter
+
+RmPt - netio.sys    - Rtl Mapping Page Table Entries
+
+Rnm  - rndismp.sys  - RNDIS MP driver generic alloc
+Rnms - rndismp.sys  - RNDIS MP driver send frame
+Rnmr - rndismp.sys  - RNDIS MP driver receive frame
+Rnmt - rndismp.sys  - RNDIS MP driver timer
+
+RpcL - msrpc.sys    - debugging log data - present on checked builds only
+RpcM - msrpc.sys    - all msrpc.sys allocations not covered elsewhere
+Rpcr - msrpc.sys    - not currently used
+
+RRle - <unknown>    - RTL_RANGE_LIST_ENTRY_TAG
+RRlm - <unknown>    - RTL_RANGE_LIST_MISC_TAG
+
+RtPi - <unknown>    - Temp allocation for product type key
+
+Rpcl - msrpc.sys    - MSRpc memory logging - checked build only
+Rpcm - msrpc.sys    - MSRpc memory allocations
+Rpcr - msrpc.sys    - MSRpc resources
+Rpcs - msrpc.sys    - Memory shared b/n MSRpc and caller
+
+RPrt - rstorprt.sys - Remote Storage Port Driver
+
+Rqrv - <unknown>    - Registry query buffer
+RS?? - <unknown>    - Remote Storage
+RSFS - <unknown>    -      Recall Queue
+RSFN - <unknown>    -      File Name
+RSSE - <unknown>    -      Security info
+RSWQ - <unknown>    -      Work Queue
+RSQI - <unknown>    -      Queue info
+RSLT - <unknown>    -      Long term data
+RSIO - <unknown>    -      Ioctl Queue
+RSFO - <unknown>    -      File Obj queue
+RSVO - <unknown>    -      Validate Queue
+RSER - <unknown>    -      Error log data
+
+RtlT - nt!rtl       - Temporary RTL allocation
+
+RWan - rawwan.sys   - Raw WAN driver
+
+R300 - <unknown>    - ATI video driver
+RX00 - <unknown>    - ATI video driver
+
+Rx?? - rdbss.sys - RDBSS allocations
+RxSc - rdbss.sys - RDBSS SrvCall
+RxNr - rdbss.sys - RDBSS NetRoot
+RxVn - rdbss.sys - RDBSS VNetRoot
+RxLv - rdbss.sys - RDBSS Logical View
+RxFc - rdbss.sys - RDBSS FCB
+RxSo - rdbss.sys - RDBSS SrvOpen
+RxFx - rdbss.sys - RDBSS fobx
+RxNf - rdbss.sys - RDBSS non paged FCB
+RxWq - rdbss.sys - RDBSS work queue
+RxBm - rdbss.sys - RDBSS buffering manager
+RxCo - rdbss.sys - RDBSS construction context
+RxMs - rdbss.sys - RDBSS miscellaneous
+RxM1 - rdbss.sys - RDBSS VNetRoot name
+RxM2 - rdbss.sys - RDBSS canonical name
+RxM3 - rdbss.sys - RDBSS querypath name
+RxM4 - rdbss.sys - RDBSS treeconnect name
+RxM5 - rdbss.sys - RDBSS reparse buffer name
+RxM9 - rdbss.sys - RDBSS cloned unicode string
+RxIr - rdbss.sys - RDBSS RxContext
+RxTl - rdbss.sys - RDBSS toplevel IRP
+RxMx - rdbss.sys - RDBSS mini-rdr
+RxNc - rdbss.sys - RDBSS name cache
+RxSy - rdbss.sys - RDBSS symlink
+RxCr - rdbss.sys - RDBSS credential
+RxEc - rdbss.sys - RDBSS ECP
+
+RxCt - mrxsmb.sys - RXCE transport
+RxCa - mrxsmb.sys - RXCE address
+RxCc - mrxsmb.sys - RXCE connection
+RxCv - mrxsmb.sys - RXCE VcEndpoint
+RxCd - mrxsmb.sys - RXCE TDI
+
+S3   - <unknown>    - S3 video driver
+SAad - srvnet.sys   - SrvAdmin buffer
+SBad - <unknown>    - bad block simulator - simbad.c
+
+sbp2 - <unknown>    - Sbp2 1394 storage port driver
+
+SC?? - <unknown>    - Smart card driver tags
+SCLb - <unknown>    -  Smart card driver library
+SCB8 - <unknown>    -  Bull CP8 Transac serial reader
+SCB3 - <unknown>    -  Bull SmarTlp PnP
+SCS4 - <unknown>    -  SCM Microsystems pcmcia reader
+SCl0 - <unknown>    -  Litronic 220
+
+Sc?? - <unknown>    - Mass storage driver tags
+
+ScB? - classpnp.sys - ClassPnP misc allocations
+ScB1 - classpnp.sys -  Query registry parameters
+ScB2 - classpnp.sys -  Registry path
+ScB4 - classpnp.sys -  Storage descriptor header
+ScB5 - classpnp.sys -  FDO relations
+ScC? - classpnp.sys - ClassPnP misc allocations
+ScC1 - classpnp.sys -  Registry path buffer
+ScC2 - classpnp.sys -  PDO relations
+ScC6 - classpnp.sys -  START_UNIT completion context
+ScC7 - classpnp.sys -  Sense info buffer
+ScC8 - classpnp.sys -  Registry value name
+ScC9 - classpnp.sys -  Device Control SRB
+
+
+
+ScC? - cdrom.sys    -  CdRom
+ScCA - cdrom.sys    -      Autorun disable functionality
+ScCa - cdrom.sys    -      Media change detection
+ScSB - cdrom.sys    -      Scratch buffer (usually 64k)
+ScCC - cdrom.sys    -      Ioctl GET_CONFIGURATION
+ScCc - cdrom.sys    -      Context of completion routine
+ScCD - cdrom.sys    -      Adaptor & Device descriptor buffer
+ScCd - cdrom.sys    -      Disc information
+ScCe - cdrom.sys    -      Request sync event
+ScCF - cdrom.sys    -      Feature descriptor
+ScCG - cdrom.sys    -      GESN buffer
+ScCI - cdrom.sys    -      Sense info buffers
+ScCi - cdrom.sys    -      Cached inquiry buffer
+ScCM - cdrom.sys    -      Mode data buffer
+SCCO - cdrom.sys    -      Set stream buffer
+ScCo - cdrom.sys    -      Device Notification buffer
+ScCp - cdrom.sys    -      Play active checks
+ScCr - cdrom.sys    -      Registry string
+ScCS - cdrom.sys    -      Srb allocation
+ScCs - cdrom.sys    -      Assorted string data
+ScCU - cdrom.sys    -      Update capacity path
+ScCu - cdrom.sys    -      Read buffer for dvd key
+ScCV - cdrom.sys    -      Read buffer for dvd/rpc2 check
+ScCv - cdrom.sys    -      Read buffer for rpc2 check
+ScCX - cdrom.sys    -      Security descriptor
+
+ScD? - <unknown>    -   Disk
+ScD  - <unknown>    -      generic tag
+ScDa - <unknown>    -      SMART
+ScDA - <unknown>    -      Info Exceptions
+ScDC - <unknown>    -      disable cache paths
+ScDb - classpnp.sys -      ClassPnP debug globals buffer
+ScDc - <unknown>    -      disk allocated completion c
+ScDG - <unknown>    -      disk geometry buffer
+ScDg - <unknown>    -      update disk geometry paths
+ScDI - <unknown>    -      sense info buffers
+ScDp - <unknown>    -      pnp ids
+ScDM - <unknown>    -      mode data buffer
+ScDM - <unknown>    -      mbr checksum code
+ScDN - <unknown>    -      disk name code
+ScDP - <unknown>    -      read capacity buffer
+ScDp - <unknown>    -      disk partition lists
+ScDS - <unknown>    -      srb allocation
+ScDs - <unknown>    -      start device paths
+ScDU - <unknown>    -      update capacity path
+ScDW - <unknown>    -      work-item context
+ScMC - <unknown>    -      medium changer allocations
+
+ScIO - classpnp.sys - ClassPnP device control
+ScL? - classpnp.sys -   Classpnp
+ScLA - classpnp.sys -      allocation to check for autorun disable
+ScLF - classpnp.sys -      File Object Extension
+ScLc - classpnp.sys -      Cache filters
+ScLf - classpnp.sys -      Fault prediction
+ScLm - classpnp.sys -      Mount
+ScLM - classpnp.sys -      Media Change Detection
+ScLq - classpnp.sys -      Release queue
+ScLw - classpnp.sys -      WMI
+ScLW - classpnp.sys -      Power
+
+ScNo - classpnp.sys - ClassPnP notification
+
+ScP? - <unknown>    -   Scsiport
+ScPa - <unknown>    -      Hold registry data
+ScPA - <unknown>    -      Access Ranges
+ScPb - <unknown>    -      Get Bus Dat Holder
+ScPB - <unknown>    -      Queuetag BitMap
+ScPc - <unknown>    -      Fake common buffer
+ScPC - <unknown>    -      reset bus code
+ScPd - <unknown>    -      Pnp id strings
+ScPD - <unknown>    -      SRB_DATA allocations
+ScPE - <unknown>    -      Scatter gather lists
+ScPG - <unknown>    -      Global memory
+ScPh - <unknown>    -      HwDevice Ext
+ScPi - <unknown>    -      Sense Info
+ScPI - <unknown>    -      Init data chain
+ScPl - <unknown>    -      remove lock tracking
+ScPL - <unknown>    -      scatter gather lists
+ScPm - <unknown>    -      address mapping lists
+ScPM - <unknown>    -      scatter gather lists
+ScPp - <unknown>    -      device & adapter enable
+ScpP - <unknown>    -      scsi PortConfig copies
+ScPq - <unknown>    -      inquiry data
+ScPQ - <unknown>    -      request sense
+ScPr - <unknown>    -      resource list copy
+ScPS - <unknown>    -      registry allocations
+ScPt - <unknown>    -      legacy request rerouting
+ScPT - <unknown>    -      interface mapping
+ScPu - <unknown>    -      device relation structs
+ScPv - <unknown>    -      KEVENT
+ScPV - <unknown>    -      Device map allocations
+ScPw - <unknown>    -      Wmi Events
+ScPW - <unknown>    -      Wmi Requests
+ScPx - <unknown>    -      Report Luns
+ScPY - <unknown>    -      Report Targets
+ScPZ - <unknown>    -      Device name buffer
+
+ScR? - <unknown>    -   Partition Manager
+ScRi - <unknown>    -      IOCTL buffer
+ScRp - <unknown>    -      Partition entry
+ScRr - <unknown>    -      Remove lock
+ScRt - <unknown>    -      Table entry
+ScRv - <unknown>    -      Dependant volume relations lists
+ScRV - <unknown>    -      Volume entry
+ScRw - <unknown>    -      Power mgmt private work item
+
+ScS2 - classpnp.sys - Sense interpretation data
+
+ScsC - <unknown>    - non-pnp SCSI CdRom
+ScsD - <unknown>    - non-pnp SCSI Disk
+ScsH - <unknown>    - non-pnp SCSI from class.h (class2)
+ScsI - <unknown>    - non-pnp SCSI port internal
+ScsL - <unknown>    - non-pnp SCSI class.c driver allocations
+ScsP - <unknown>    - non-pnp SCSI port.c
+Scs$ - <unknown>    - Tag for pnp class driver's SRB lookaside list
+
+ScUn - <unknown>    - Default Tag for pnp class driver allocations
+
+ScV? - <unknown>    -  Dvd functionality in cdrom.sys
+ScVk - <unknown>    -      read buffer for DVD keys
+ScVK - <unknown>    -      write buffer for DVD keys
+ScVS - <unknown>    -      buffer for reads of DVD on-disk structures
+
+ScWs - classpnp.sys - Working set
+
+SdCc - <unknown>    - ObsSecurityDescriptorCache / SECURITY_DESCRIPTOR_CACHE_ENTRIES
+
+Sdba - <unknown>    - Application compatibility Sdb* allocations
+
+Sdp? - <unknown>    - Bluetooth SDP functionality in BTHPORT.sys
+SdpC - bthport.sys  -     Bluetooth SDP client connection
+SdpD - bthport.sys  -     Bluetooth SDP database
+SdpI - bthport.sys  -     Bluetooth port driver (SDP)
+
+SD   - smbdirect.sys - SMB Direct allocations
+SDa  - smbdirect.sys - SMB Direct socket objects
+SDb  - smbdirect.sys - SMB Direct adapter objects
+SDc  - smbdirect.sys - SMB Direct MR buffers
+SDd  - smbdirect.sys - SMB Direct connect event contexts
+SDe  - smbdirect.sys - SMB Direct large receive buffers
+SDf  - smbdirect.sys - SMB Direct LAM objects
+SDg  - smbdirect.sys - SMB Direct data transfer packet buffers
+SDh  - smbdirect.sys - SMB Direct FRMR objects
+SDi  - smbdirect.sys - SMB Direct buffer registrations
+SDj  - smbdirect.sys - SMB Direct SQ work requests
+SDk  - smbdirect.sys - SMB Direct operation
+
+Se   - nt!se        - General security allocations
+SeAc - nt!se        - Security ACL
+SeAi - nt!se        - Security Audit Work Item
+SeAk - nt!se        - Security Account Name
+SeAo - nt!se        - Security Attributes and Operations
+SeAp - nt!se        - Security Audit Parameter Record
+SeAt - nt!se        - Security Attributes
+SeCL - nt!se        - Security CONTEXT_TAG
+SeDb - nt!se        - Temp directory query buffer to delete logon session symbolic links
+SeDt - nt!se        - Security Global Singleton attributes table
+SeFS - nt!se        - Security File System Notify Context
+SeGa - nt!se        - Granted Access allocations
+SeHa - nt!se        - Security Handle Array
+SeHn - nt!se        - AppContainer Handles
+SeIf - nt!se        - Security Image Filename
+SeLa - nt!se        - Security Learning Mode ACLs
+SeLs - nt!se        - Security Logon Session
+SeLu - nt!se        - Security LUID and Attributes array
+SeLS - nt!se        - Security Logon Session tracking array
+SeLw - nt!se        - Security LSA Work Item
+SeOI - nt!se        - Security Learning Mode Object Information
+SeOn - nt!se        - Security Captured Object Name information
+SeON - nt!se        - Security Learning Mode Object Name
+SeOp - nt!se        - Security Operation
+SeOT - nt!se        - Security Learning Mode Object Type
+SeOt - nt!se        - Captured object type array, used by access check
+SePa - nt!se        - Process audit image names and captured policy structures
+SePh - nt!se        - Dummy image page hash structure, used when CI is disabled
+SePr - nt!se        - Security Privilege Set
+SeRO - nt!se        - Learning Mode Root Object
+SeSA - nt!se        - Security CAPE Staged Access Array
+SeSa - nt!se        - Security SID and Attributes
+SeSb - nt!se        - Security Secure Boot
+SeSc - nt!se        - Captured Security Descriptor
+SeSd - nt!se        - Security Descriptor
+SeSi - nt!se        - Security SID
+SeSp - nt!se        - Scoped Policy
+SeSs - nt!se        - Shared Sids
+SeSv - nt!se        - Security SID values block
+SeTa - nt!se        - Security Temporary Array
+SeTd - nt!se        - Security Token dynamic part
+SeTI - ksecdd.sys   - Security TargetInfo
+SeTl - nt!se        - Security Token Lock
+SeTn - nt!se        - Security Captured Type Name information
+SeUs - nt!se        - Security Captured Unicode string
+
+Sect - <unknown>    - Section objects
+Sema - <unknown>    - Semaphore objects
+Senm - <unknown>    - Serenum (RS-232 serial bus enumerator)
+SimB - <unknown>    - Simbad (bad sector simulation driver) allocations
+SIfs - <unknown>    - Default tag for user's of ntsrv.h
+sidg - <unknown>    - GDI spooler events
+Sis  - <unknown>    - Single Instance Store (dd\sis\filter)
+SisB - <unknown>    -         SIS per file object break event
+SisC - <unknown>    -         SIS common store file object
+SisF - <unknown>    -         SIS per file object
+SisL - <unknown>    -         SIS per link object
+SisS - <unknown>    -         SIS SCB
+Setp - <unknown>    - SETUPDD SpMemAlloc calls
+
+SRdm - scsirdma.sys - Infiniband SRP driver
+
+StCc - netio.sys    - WFP stream inspection call context
+StDa - netio.sys    - WFP stream inspection data
+StFc - netio.sys    - WFP stream filter conditions
+StCx - netio.sys    - WFP stream internal callout context
+Stdq - netio.sys    - WFP stream DPC queue
+
+SV?? - <unknown>       - Synthetic Video Driver
+
+SVXD - synvidxd.dll    - WDDM Synthetic Video Display Driver
+SVXM - synvidxm.sys    - WDDM Synthetic Video Miniport Driver
+SVid - synthvid.sys    - LDDM Synthetic Video Miniport Driver
+
+SW?? - <unknown>    - Software Bus Enumerator
+SWbi - <unknown>    -         bus ID
+SWbr - <unknown>    -         bus reference
+SWda - <unknown>    -         POOLTAG_DEVICE_ASSOCIATION
+SWdn - <unknown>    -         device name
+SWdr - <unknown>    -         device reference
+SWdr - <unknown>    -         POOLTAG_DEVICE_DRIVER_REGISTRY
+SWfd - <unknown>    -         POOLTAG_DEVICE_FDOEXTENSION
+SWid - <unknown>    -         device ID
+SWii - <unknown>    -         instance ID
+SWip - <unknown>    -         POOLTAG_DEVICE_INTERFACEPATH
+SWki - <unknown>    -         key information
+SWpd - <unknown>    -         POOLTAG_DEVICE_PDOEXTENSION
+SWre - <unknown>    -         relations
+SWrp - <unknown>    -         reparse string
+SWrs - <unknown>    -         reference string
+
+Sm?? - mrxsmb.sys    - SMB miniredirector allocations
+SmCe - mrxsmb.sys    - SMB connection object
+SmXc - mrxsmb.sys    - SMB exchange
+SmBf - mrxsmb.sys    - SMB exchange buffer
+SmKy - mrxsmb.sys    - SMB compounding key
+SmMs - mrxsmb.sys    - SMB miscellaneous
+SmTp - mrxsmb.sys    - SMB transport
+SmVc - mrxsmb.sys    - SMB VC endpoint
+SmDg - mrxsmb.sys    - SMB datagram endpoint
+SmWi - mrxsmb.sys    - SMB sequence window
+SmFi - mrxsmb.sys    - SMB file
+SmTh - mrxsmb.sys    - SMB thunk
+SmSh - mrxsmb.sys    - SMB shadow file (fast loopback)
+SmTd - mrxsmb.sys    - SMB TDI notify
+SmDc - mrxsmb.sys    - SMB directory cache
+
+
+SmMm - mrxsmb.sys   -         SMB mm allocated structures.
+SmAd - mrxsmb10.sys    -      SMB1 session setup/admin exchange
+SmRw - mrxsmb10.sys    -      SMB1 read/write path
+SmTr - mrxsmb10.sys    -      SMB1 transact exchange
+SmRb - mrxsmb10.sys    -      SMB1 remote boot
+
+SmFc - mrxsmb10.sys    -      SMB1   fsctl structures  (special build only)
+SmDc - mrxsmb10.sys    -      SMB1   dir query buffer (special build only)
+SmPi - mrxsmb10.sys    -      SMB1   pipeinfo buffer (special build only)
+SmDO - mrxsmb10.sys    -      SMB1   deferred open context  (special build only)
+SmQP - mrxsmb10.sys    -      SMB1   params for directory query transact  (special build only)
+
+SmVr - mrxsmb10.sys    -      SMB1   VNetroot  (special build only)
+SmSr - mrxsmb10.sys    -      SMB1   Server  (special build only)
+SmSe - mrxsmb10.sys    -      SMB1   Session  (special build only)
+SmNr - mrxsmb10.sys    -      SMB1   NetRoot  (special build only)
+SmMa - mrxsmb10.sys    -      SMB1   mid atlas  (special build only)
+SmMt - mrxsmb10.sys    -      SMB1   mailslot buffer  (special build only)
+SmEc - mrxsmb10.sys    -      SMB1   echo buffer  (special build only)
+SmKs - mrxsmb10.sys    -      SMB1  Kerberos blob  (special build only)
+
+sm?? - nt!store or rdyboost.sys - ReadyBoost allocations
+smCR - nt!store or rdyboost.sys - ReadyBoost encryption allocation
+smMD - nt!store or rdyboost.sys - ReadyBoost store stats MDL
+smWi - nt!store or rdyboost.sys - ReadyBoost various work items
+smSt - nt!store or rdyboost.sys - ReadyBoost various store allocations
+smBt - nt!store or rdyboost.sys - ReadyBoost various B+Tree allocations
+smXt - nt!store or rdyboost.sys - ReadyBoost store extents array
+smAr - nt!store or rdyboost.sys - ReadyBoost generic array allocation
+smIt - nt!store or rdyboost.sys - ReadyBoost store ETA timers
+smRg - nt!store or rdyboost.sys - ReadyBoost in-memory store region array
+smET - nt!store or rdyboost.sys - ReadyBoost ETA check work item
+smWd - nt!store or rdyboost.sys - ReadyBoost store contents rundown work item
+smNp - nt!store or rdyboost.sys - ReadyBoost store node pool allocations
+smDt - nt!store or rdyboost.sys - ReadyBoost store debug trace buffer
+smDa - nt!store     -         ReadyBoost cache file DACL
+smDS - nt!store     -         ReadyBoost cache file SID
+smLb - nt!store     -         ReadyBoost virtual store manager log buffer
+smCa - nt!store     -         ReadyBoost cache
+smEK - nt!store     -         ReadyBoost encryption key
+smEd - nt!store     -         ReadyBoost virtual store manager key descriptor allocation for logging
+smAc - nt!store     -         ReadyBoost device arrival context
+smFh - nt!store     -         ReadyBoost cache file header
+smFp - nt!store     -         ReadyBoost virtual forward progress entry
+smR? - nt!store     -         ReadyBoost virtual forward progress resources
+smKG - nt!store     -         ReadyBoost encryption key registry path buffer
+smms - nt!store     -         ReadyBoost virtual store memory monitor context
+smCr - nt!store     -         ReadyBoost store region bitmap
+smMd - rdyboost.sys -         ReadyBoost MDL allocation
+smMb - rdyboost.sys -         ReadyBoost MDL buffer
+smBP - rdyboost.sys -         ReadyBoot boot plan buffer
+smBD - rdyboost.sys -         ReadyBoot decompressed boot plan buffer
+smBX - rdyboost.sys -         ReadyBoot boot plan decompression workspace buffer
+smMR - rdyboost.sys -         ReadyBoot multi-read ranges
+smRW - rdyboost.sys -         ReadyBoot read-after-write ranges
+smPr - rdyboost.sys -         ReadyBoot population ranges
+smPi - rdyboost.sys -         ReadyBoot population ranges index
+smPl - rdyboost.sys -         ReadyBoot pended IRP lists
+smRT - rdyboost.sys -         ReadyBoot thread params
+smTi - rdyboost.sys -         ReadyBoost debug IO trace buffer
+smPc - rdyboost.sys -         ReadyBoost persist log context
+smPb - rdyboost.sys -         ReadyBoost persist log buffer
+smPm - rdyboost.sys -         ReadyBoost persist partial MDL buffer
+smBR - rdyboost.sys -         ReadyBoost volume ranges array
+smBr - rdyboost.sys -         ReadyBoost volume range
+smVc - rdyboost.sys -         ReadyBoost read verification buffer
+smHB - rdyboost.sys -         ReadyBoost Hybrid Drive command buffer
+
+SPX  - <unknown>    - Nwlnkspx transport
+SQOS - <unknown>    - Security quality of service in IO
+
+Sr?? - sr.sys       - System Restore file system filter driver
+SrCo - sr.sys       -         SR's control object
+SrSC - sr.sys       -         Stream contexts
+SrDB - sr.sys       -         Debug information for lookup blob
+SrDL - sr.sys       -         Device list
+SrFE - sr.sys       -         File information buffer
+SrFN - sr.sys       -         File name
+SrHB - sr.sys       -         Hash bucket
+SrHH - sr.sys       -         Hash header
+SrHK - sr.sys       -         Hash key
+SrLB - sr.sys       -         Log buffer
+SrLC - sr.sys       -         Logging context
+SrLE - sr.sys       -         Log entry
+SrLT - sr.sys       -         Lookup blob
+SrMP - sr.sys       -         Mount point information
+SrOI - sr.sys       -         Overwrite information
+SrPC - sr.sys       -         Persistant configuration information
+SrRB - sr.sys       -         Rename buffer
+SrRG - sr.sys       -         Logger context
+SrRH - sr.sys       -         Reparse data size
+SrRR - sr.sys       -         Registry information
+SrSD - sr.sys       -         Security data information
+SrST - sr.sys       -         Stream data information
+SrTI - sr.sys       -         Directory delete information
+SrWI - sr.sys       -         Work queue item
+
+SslC - ksecdd.sys   - SSL kernel mode client allocations
+
+ST*  - <unknown>    - New MMC compliant storage drivers
+
+Stac - <unknown>    - Stack Trace Database - i386 checked and built with NTNOFPO=1 only
+StEl - storport.sys - PortpErrorInitRecords storport!_STORAGE_TRACE_CONTEXT_INTERNAL.ErrorLogRecords
+Strg - <unknown>    - Dynamic Translated strings
+Strm - <unknown>    - Streams and streams transports allocations
+StTc - storport.sys - PortTraceInitTracing storport!_STORAGE_TRACE_CONTEXT_INTERNAL
+
+svx? - svhdxflt.sys - VHDX sharing among multiple Hyper-V guests
+svxc - svhdxflt.sys -         CDB (SCSI) operations
+svxC - svhdxflt.sys -         Create File processing
+svxd - svhdxflt.sys -         SVHDX communications port
+svxe - svhdxflt.sys -         Stored sense data errors
+svxf - svhdxflt.sys -         File contexts
+svxI - svhdxflt.sys -         Initiator lists
+svxi - svhdxflt.sys -         Instance context
+svxl - svhdxflt.sys -         Shared VHDX RTL
+svxP - svhdxflt.sys -         Persistent Reservation - Registrations
+svxp - svhdxflt.sys -         Persistent Reservation support for shared VHDX files
+svxQ - svhdxflt.sys -         Persistent Reservation - Device context
+svxq - svhdxflt.sys -         Persistent Reservation - Reservation Info
+svxr - svhdxflt.sys -         File read operations
+svxs - svhdxflt.sys -         Stream context
+svxS - svhdxflt.sys -         Stream handle context
+svxt - svhdxflt.sys -         Test Filter
+svxv - svhdxflt.sys -         VHDMP/SVHDX interaction
+svxw - svhdxflt.sys -         File write operations
+
+SwMi - <unknown>    - SWMidi KS filter (WDM Audio)
+Symb - <unknown>    - Symbolic link objects
+Symt - <unknown>    - Symbolic link target strings
+
+SYPK - syspart.lib  - Kernel mode system partition detection allocations
+SYSA - <unknown>    - Sysaudio (wdm audio)
+
+TAPI - <unknown>    - ntos\ndis\ndistapi
+
+TcAR - tcpip.sys    - TCP Abort Requests
+TcBW - tcpip.sys    - TCP Bandwidth Allocations
+TcCC - tcpip.sys    - TCP Create And Connect Tcb Pool
+TcCM - tcpip.sys    - TCP Congestion Control Manager Contexts
+TcCo - tcpip.sys    - TCP Compartment
+TcCR - tcpip.sys    - TCP Connect Requests
+TcCT - tcpip.sys    - TCP Connection Tuples
+TcDD - tcpip.sys    - TCP Debug Delivery Buffers
+TcDQ - tcpip.sys    - TCP Delay Queues
+TcDR - tcpip.sys    - TCP Disconnect Requests
+TcEW - tcpip.sys    - TCP Endpoint Work Queue Contexts
+TcFC - tcpip.sys    - TCP Fastopen Cookies
+TcFR - tcpip.sys    - TCP FineRTT Buffers
+TcHT - tcpip.sys    - TCP Hash Tables
+TcIn - tcpip.sys    - TCP Inputs
+TcLS - tcpip.sys    - TCP Listener SockAddrs
+TcLW - tcpip.sys    - TCP Listener Work Queue Contexts
+TcpA - tcpip.sys    - TCP DMA buffers
+TcpB - tcpip.sys    - TCP Offload Blocks
+TcDM - tcpip.sys    - TCP Delayed Delivery Memory Descriptor Lists
+TcDN - tcpip.sys    - TCP Delayed Delivery Network Buffer Lists
+TcPC - tcpip.sys    - TCP Listener Pending Connections
+TcpE - tcpip.sys    - TCP Endpoints
+TcpI - tcpip.sys    - TCP ISN buffers
+TcpL - tcpip.sys    - TCP Listeners
+TcpM - tcpip.sys    - TCP Offload Miscellaneous buffers
+TcpN - tcpip.sys    - TCP Name Service Interfaces
+TcOD - tcpip.sys    - TCP Offload Devices
+TcpO - tcpip.sys    - TCP Offload Requests
+TcpP - tcpip.sys    - TCP Processor Arrays
+TcPt - tcpip.sys    - TCP Partitions
+Tcpt - tcpip.sys    - TCP Timers
+TcRA - tcpip.sys    - TCP Reassembly Data
+TcRB - tcpip.sys    - TCP Reassembly Buffers
+TcRD - tcpip.sys    - TCP Receive DPC Data
+TcRe - tcpip.sys    - TCP Recovery Buffers
+TcRH - tcpip.sys    - TCP Reassembly Headers
+TcRK - tcpip.sys    - TCP Rack Data
+TcRL - tcpip.sys    - TCP Create And Connect Tcb Rate Limit Pool
+TcRR - tcpip.sys    - TCP Receive Requests
+TcRW - tcpip.sys    - TCP Receive Window Tuning Blocks
+TcSa - tcpip.sys    - TCP Sack Data
+TcSR - tcpip.sys    - TCP Send Requests
+TcST - tcpip.sys    - TCP Syn TCBs
+TcTW - tcpip.sys    - TCP Time Wait TCBs
+TcUD - tcpip.sys    - TCP Urgent Delivery Buffers
+TcWQ - tcpip.sys    - TCP TCB Work Queue Contexts
+TcWS - tcpip.sys    - TCP Window Scaling Diagnostics
+
+TC?? - TCP          - TCP/IP network protocol
+TCh? - <unknown>    - TCP/IP header pools
+TCPC - <unknown>    - TCP connection pool
+TCPT - <unknown>    - TCB pool
+TCPY - <unknown>    - SYN-TCB pool
+TCPr - <unknown>    - TCP request pool
+
+TDIc - <unknown>    - TDI resource
+TDId - <unknown>    - TDI resource
+TDIe - <unknown>    - TDI resource
+TDIf - <unknown>    - TDI resource
+TDIg - <unknown>    - TDI resource
+TDIk - <unknown>    - TDI resource
+TDIu - <unknown>    - TDI resource
+TDIv - <unknown>    - TDI resource
+
+Tdat - <unknown>    - NB Data
+
+TdxC - tdx.sys      - TDX Connections
+TdCI - tdx.sys      - TDX Connection Information
+Tdxc - tdx.sys      - TDX Control Channels
+Tdxo - tdx.sys      - TDX Device Objects
+Tdx  - tdx.sys      - TDX Generic Buffers (Address, Entity information, Interface change allocations)
+TdxI - tdx.sys      - TDX IO Control Buffers
+TdxM - tdx.sys      - TDX Message Indication Buffers
+Tdxn - tdx.sys      - TDX Net Addresses
+TdxR - tdx.sys      - TDX Received Data
+Tdxp - tdx.sys      - TDX Reserved Page Tables Entries
+TdxB - tdx.sys      - TDX Transport Layer Buffers
+Tdxt - tdx.sys      - TDX Transport Layer Clients
+TdxP - tdx.sys      - TDX Transport Layer Providers
+Tdxm - tdx.sys      - TDX Transport Layer TDI Mappings
+TdxA - tdx.sys      - TDX Transport Addresses
+TdxT - tdx.sys      - TDX Transport Provider Contexts
+
+Tedd - tcpip.sys    - TCP/IP Event Data Descriptors
+
+thdd - <unknown>    - DirectDraw/3D handle manager table
+
+Thre - nt!ps        - Thread objects
+Time - nt!ke        - Timer objects
+
+TmDn - nt!tm        - Tm Dynamic Name
+TmEn - nt!tm        - Tm KENLISTMENT object
+TmLo - nt!tm        - Tm Log Entries
+TmNo - nt!tm        - Tm Notification
+TmPa - nt!tm        - Tm Propagate Argument
+TmPb - nt!tm        - Tm Propagation Buffer
+TmPe - nt!tm        - Tm Enlistment Pointers
+TmPi - nt!tm        - Tm Protocol Information
+TmPo - nt!tm        - Tm Propagation Output
+TmPp - nt!tm        - Tm Protocol Pointers
+TmPr - nt!tm        - Tm Protocol
+TmPx - nt!tm        - Tm Protocol Array
+TmRi - nt!tm        - Tm Recovery Information
+TmRm - nt!tm        - Tm KRESOURCEMANAGER object
+TmRq - nt!tm        - Tm Propagation Request
+TmRr - nt!tm        - Tm KTM_RESTART_RECORD
+TmTm - nt!tm        - Tm KTRANSACTIONMANAGER object
+TmTx - nt!tm        - Tm KTRANSACTION object
+
+Tnbl - <unknown>    - NB Lists
+Tnbt - <unknown>    - NB Pool
+
+TNbl - tcpip.sys    - TCP Send NetBufferLists
+
+Toke - nt!se        - Token objects
+
+TOBJ - rdpdr.sys - Topology object
+
+TpWc - nt!ex        - Threadpool minipacket context
+TpWo - nt!ex        - Threadpool worker factory objects
+
+TQoS - tcpip.sys    - TL QoS Client Data
+
+Tran - <unknown>    - EXIFS Translate
+
+Trcd - netiobvt.sys - NB Control Data
+
+Tslc - tcpip.sys    - WFP TL Shim Layer Cache
+Tscf - netio.sys    - WFP Filter Engine Cached Filter Block
+
+TSBV - <unknown>    - WDM mini driver for Toshiba 750 capture
+
+TSdd - rdpdd.sys    - RDPDD - Hydra Display Driver
+TSch - rdpwd.sys    - RDPWD - Hydra char conversion
+TSic - termdd.sys   - Terminal Services - ICA_POOL_TAG
+TSlc - rdpwd.sys    - RDPWD - Hydra Licensing
+TSmc - <unknown>    - PDMCS - Hydra MCS Protocol Driver
+Tspk - ksecdd.sys   - TS Package kernel mode client allocations
+TSq  - <unknown>    - Terminal Services - Queue - TSQ_TAG
+TSrp - termdd.sys   - Terminal Services - RP_ALLOC_TAG
+TSwd - rdpwd.sys    - RDPWD - Hydra Winstation Driver
+
+Ttnc -  tcpip.sys   - WFP tunnel nexthop context
+
+Tsmp - tcpip.sys    - TCP Send Memory Descriptor Lists
+TSNb - tcpip.sys    - TCP Send NetBuffers
+TTsp - tcpip.sys    - TCP TCB Sends
+
+TtCo - <unknown>    - TTCP Connections
+TtcC - <unknown>    - TTCP Controllers
+TtcL - <unknown>    - TTCP Listeners
+TtcM - <unknown>    - TTCP Mappings
+TtcN - <unknown>    - TTCP NPIs
+TtcW - <unknown>    - TTCP Work Items
+
+Ttfd - <unknown>    - TrueType Font driver
+TTFC - <unknown>    - Font file cache
+
+Thrm - <unknown>    - Thermal zone structure
+Tun4  - <unknown>   - Tunnel cache allocation for long file name
+TunL - <unknown>    - Tunnel cache lookaside-allocated elements
+TunP - <unknown>    - Tunnel cache oddsized pool-allocated elements
+TunK - <unknown>    - Tunnel cache temporary key value
+
+TuSB - tunnel.sys   - Tunnel stack block
+
+TWTa - tcpip.sys    - Echo Request Timer Table
+TWTs - netiobvt.sys - BVT TW Generic Buffers
+
+Txcl - ntfs.sys     - TXF_CLR_RESERVATION_CHUNK
+Txdl - ntfs.sys     - TXF_DELETED_LINK
+Txdr - ntfs.sys     - TXF_DEFAULT_READER_SECTION
+Txfc - ntfs.sys     - TXF_FCB
+Txfe - ntfs.sys     - TXF_FCB_EXTENSION
+Txfi - ntfs.sys     - TXF_FCB_INFO
+Txfl - ntfs.sys     - TXF_FCB_CLEANUP
+Txfo - ntfs.sys     - TXF_FO
+Txfq - ntfs.sys     - Txf quota block
+Txgd - ntfs.sys     - TxfData global structure
+Txis - ntfs.sys     - TXF_ISO_SNAPSHOT
+Txlf - ntfs.sys     - TXF_FCB (large)
+Txls - ntfs.sys     - TXF_CANCEL_LSN
+Txre - ntfs.sys     - TXF_TOPS_RANGE_ENTRY
+Txrm - ntfs.sys     - TXF_RMCB
+Txrn - ntfs.sys     - TXF_NONPAGED_RMCB
+Txsa - ntfs.sys     - Txf sorted array item
+Txsc - ntfs.sys     - TXF_SCB
+Txsp - ntfs.sys     - TXF_SAVEPOINT
+Txsp - ntfs.sys     - TXF_SCB_PTR
+Txtc - ntfs.sys     - TXF_TRANS_CANCEL_LIST_ENTRY
+Txte - ntfs.sys     - TXF_RMCB_TABLE_ENTRY
+Txtr - ntfs.sys     - TXF_TRANS (Txf transaction context)
+Txts - ntfs.sys     - TXF_TRANS_SYNC
+Txvc - ntfs.sys     - TXF_VCB
+Txvd - ntfs.sys     - TXF_VSCB_TO_DEREF
+Txvf - ntfs.sys     - TXF_VSCB_FILE_SIZES
+Txvl - ntfs.sys     - TXF_VSCB
+
+Type - <unknown>    - Type objects
+
+U802 - usb8023.sys  - RNDIS USB 8023 driver
+
+UCAM - <unknown>    - USB digital camera library
+
+Udf1 - udfs.sys     - Udfs file set descriptor buffer
+Udf2 - udfs.sys     - Udfs volmume recognition sequence descriptor buffer
+Udf3 - udfs.sys     - Udfs volume descriptor sequence descriptor buffer
+Udf4 - udfs.sys     - Udfs logical volume integrity descriptor buffer
+UdfB - udfs.sys     - Udfs dynamic name buffer
+UdfC - udfs.sys     - Udfs CRC table
+UdfD - udfs.sys     - Udfs FID buffer for view spanning
+UdfF - udfs.sys     - Udfs nonpaged Fcb
+UdfI - udfs.sys     - Udfs IO context
+UdfL - udfs.sys     - Udfs IRP context lite (delayed close)
+UdfN - udfs.sys     - Udfs normalized full filename
+UdfS - udfs.sys     - Udfs short file name
+UdfT - udfs.sys     - Udfs generic table entry
+Udfa - udfs.sys     - Udfs AD buffer
+Udfb - udfs.sys     - Udfs IO buffer
+Udfc - udfs.sys     - Udfs IRP context
+Udfd - udfs.sys     - Udfs file Scb
+Udfe - udfs.sys     - Udfs enumeration match expression
+Udff - udfs.sys     - Udfs Fcb
+Udfi - udfs.sys     - Udfs directory Scb
+Udfl - udfs.sys     - Udfs Lcb
+Udfn - udfs.sys     - Udfs Nonpaged Scb
+Udfp - udfs.sys     - Udfs Pcb
+Udfs - udfs.sys     - Udfs Sparing Mcb
+Udft - udfs.sys     - Udfs CDROM TOC
+Udfv - udfs.sys     - Udfs Vpb
+UdfV - udfs.sys     - Udfs VMCB dirty sector bitmap
+Udfx - udfs.sys     - Udfs Ccb
+
+UdAE - tcpip.sys    - UDP Activate Endpoints
+UdCo - tcpip.sys    - UDP Compartment
+UdJP - tcpip.sys    - UDP Join Path Contexts
+UdEW - tcpip.sys    - UDP Endpoint Work Queue Contexts
+UdMI - tcpip.sys    - UDP Message Indications
+UDNb - tcpip.sys    - UDP NetBuffers
+UdpA - tcpip.sys    - UDP Endpoints
+UdpH - tcpip.sys    - UDP Headers
+UdPM - tcpip.sys    - UDP Partial Memory Descriptor Lists
+UdpN - tcpip.sys    - UDP Name Service Interfaces
+UdSM - tcpip.sys    - UDP Send Messages Requests
+UNbl - tcpip.sys    - UDP NetBufferLists
+
+Udp  - <unknown>    - Udp protocol (TCP/IP driver)
+Ufsc - <unknown>    - User FULLSCREEN
+UHCD - <unknown>    - Universal Host Controller (USB - Intel Controller)
+UHUB - <unknown>    - Universal Serial Bus Hub
+
+Ul?? - http.sys     - tags. Note: In-use tags are of the form "Ul??" or "Uc??".and   Free tags are of the form "uL??" or "uC??";
+Uc?? - http.sys     - i.e., the case of the leading "Ul" or "Uc" has been reversed.
+
+Ucac - http.sys     - Auth Cache Pool
+UcCO - http.sys     - Client Connection
+Ucmp - http.sys     - Multipart String Buffer
+Ucre - http.sys     - Receive Response
+Ucrp - http.sys     - Response App Buffer
+Ucrq - http.sys     - Request Pool
+UcSc - http.sys     - Common Server Information
+UcSN - http.sys     - Server name
+UcSP - http.sys     - Process Server Information
+UcSp - http.sys     - Sspi Pool
+UcST - http.sys     - Server info table
+Uctd - http.sys     - Response Tdi Buffer
+Ucte - http.sys     - Entity Pool
+Ucto - http.sys     - Tdi Objects Pool
+UlAB - http.sys     - Auxiliary Buffer
+UlAO - http.sys     - App Pool Object
+UlAP - http.sys     - App Pool Process
+UlBL - http.sys     - Binary Log File Entry
+UlBO - http.sys     - Outstanding i/o
+UlCC - http.sys     - Control Channel
+UlCE - http.sys     - Config Group Tree Entry
+UlCH - http.sys     - Config Group Tree Header
+UlCI - http.sys     - Config Group URL Info
+UlCJ - http.sys     - Config Group Object Pool
+UlCK - http.sys     - Chunk Tracker
+UlCL - http.sys     - Config Group LogDir
+UlCl - http.sys     - Connection RefTraceLog
+UlCO - http.sys     - Connection
+UlCT - http.sys     - Config Group Timestamp
+UlCY - http.sys     - Connection Count Entry
+UlDB - http.sys     - Debug
+UlDC - http.sys     - Data Chunks array
+UlDO - http.sys     - Disconnect Object
+UlDR - http.sys     - Deferred Remove Item
+UlDT - http.sys     - Debug Thread Pool
+UlEP - http.sys     - Endpoint
+UlFA - http.sys     - Force Abort Work Item
+UlFC - http.sys     - File Cache Entry
+Ulfc - http.sys     - Uri Filter Context
+UlFD - http.sys     - Noncached File Data
+UlFP - http.sys     - Filter Process
+UlFR - http.sys     - Dummy Filter Receive Buffer
+UlFT - http.sys     - Filter Channel
+UlFU - http.sys     - Full Tracker
+UlFW - http.sys     - Filter Write Tracker
+UlHC - http.sys     - Http Connection
+UlHc - http.sys     - Http Connection RefTraceLog
+UlHL - http.sys     - Internal Request RefTraceLog
+UlHR - http.sys     - Internal Request
+UlHT - http.sys     - Hash Table
+UlHV - http.sys     - Header Value
+UlIC - http.sys     - Irp Context
+UlID - http.sys     - Conn ID Table
+UlIR - http.sys     - Internal Response
+UlLD - http.sys     - Log Field
+UlLF - http.sys     - Log File Entry
+UlLG - http.sys     - Log Generic
+UlLH - http.sys     - Log File Handle
+UlLL - http.sys     - Log File Buffer
+UlLS - http.sys     - Ansi Log Data Buffer
+UlLT - http.sys     - Binary Log Data Buffer
+UlNO - http.sys     - NSGO Pool
+UlNP - http.sys     - Non-Paged Data
+UlOE - http.sys     - Endpoint OwnerRefTraceLog PoolTag
+UlOR - http.sys     - Owner RefTrace Signature
+UlOT - http.sys     - Opaque ID Table
+UlPB - http.sys     - APool Proc Binding
+UlPL - http.sys     - Pipeline
+UlQF - http.sys     - TCI Filter
+UlQG - http.sys     - TCI Generic
+UlQI - http.sys     - TCI Interface
+UlQL - http.sys     - TCI Flow
+UlQT - http.sys     - TCI Tracker
+UlQW - http.sys     - TCI WMI
+UlRB - http.sys     - Receive Buffer
+UlRD - http.sys     - Registry Data
+UlRE - http.sys     - Request Body Buffer
+UlRP - http.sys     - Request Buffer
+UlRR - http.sys     - Request Buffer References
+UlRS - http.sys     - Non-Paged Resource
+UlRT - http.sys     - RefTraceLog PoolTag
+UlSC - http.sys     - SSL Cert Data
+UlSD - http.sys     - Security Data
+UlSl - http.sys     - StringLog Buffer PoolTag
+UlSL - http.sys     - StringLog PoolTag
+UlSO - http.sys     - Site Counter Entry
+UlSS - http.sys     - Simple Status Item
+UlTA - http.sys     - Address Pool
+UlTD - http.sys     - UL_TRANSPORT_ADDRESS
+UlTT - http.sys     - Thread Tracker
+UlUB - http.sys     - URL Buffer
+UlUC - http.sys     - Uri Cache Entry
+UlUH - http.sys     - HTTP Unknown Header
+UlUL - http.sys     - URL
+UlUM - http.sys     - URL Map
+UlVH - http.sys     - Virtual Host
+UlWC - http.sys     - Work Context
+UlWI - http.sys     - Work Item
+
+UndP - <unknown>    - EXIFS Underlying Path
+
+UMD? - WUDFRd.sys   - UMDF pool allocation
+USBB - bthusb.sys   - Bluetooth USB minidriver
+USBD - <unknown>    - Universal Serial Bus Class Driver
+UsbS - usbser.sys   - USB Serial Driver
+
+V2ic - vhdmp.sys    - VHD2 external I/O allocation
+V2io - vhdmp.sys    - VHD2 internal I/O allocation
+V2lg - vhdmp.sys    - VHD2 core large allocation
+V2rv - vhdmp.sys    - VHD2 reserved VA mapping
+V2sm - vhdmp.sys    - VHD2 core allocation
+V2sr - vhdmp.sys    - VHD2 SRB range allocation
+V2wi - vhdmp.sys    - VHD2 work item
+V2?? - vhdmp.sys    - VHD2 pool allocation
+
+Vad  - nt!mm        - Mm virtual address descriptors
+VadF - nt!mm        - VADs created by a FreeVM splitting
+Vadl - nt!mm        - Mm virtual address descriptors (long)
+VadS - nt!mm        - Mm virtual address descriptors (short)
+
+Vbus - vmbus.sys    - Virtual Machine Bus Driver
+VbuW - vmbus.sys    - Virtual Machine Bus Driver (WDF)
+Vbxp - vmbus.sys    - Virtual Machine Bus Driver (cross partition)
+
+VcCh - rdpdr.sys - Dynamic Virtual channel object
+VcFl - rdpdr.sys - Dynamic Virtual file object
+VcMn - rdpdr.sys - Dynamic Virtual manager object
+VcSn - rdpdr.sys - Dynamic Virtual session object
+
+VDM  - nt!vdm       - ntos\vdm
+
+VdDr - Vid.sys - Virtual Machine Virtualization Infrastructure Driver
+VdMm - Vid.sys - Virtual Machine Virtualization Infrastructure Driver (VSMM service)
+VdWd - Vid.sys - Virtual Machine Virtualization Infrastructure Driver (WDF)
+
+vDMc - dmvsc.sys - Virtual Machine Dynamic Memory VSC Driver
+vDMW - dmvsc.sys - Virtual Machine Dynamic Memory VSC Driver (WDF)
+
+Vflt - vmstorfl.sys - Virtual Machine Storage Filter Driver
+VflW - vmstorfl.sys - Virtual Machine Storage Filter Driver (WDF)
+
+VdPN - dxgkrnl.sys  - Video display mode management
+Vepp - nt!Vf        - Verifier Pool Tracking information
+VfAT - nt!Vf        - Verifier AVL trees
+VfIT - nt!Vf        - Verifier Import Address Table information
+VfPT - nt!Vf        - Verifier Allocate/Free Pool stack traces
+VfUs - nt!Vf        - Memory allocated by a call to IoSetCompletionRoutineEx.
+Vfwi - nt!Vf        - IO_WORKITEM allocated by I/O verifier version of IoAllocateWorkItem
+VMdl - nt!Vf        - MDL allocated by I/O verifier version of IoAllocateMdl
+VNod - nt!Vf        - Deadlock Verifier nodes
+VRes - nt!Vf        - Deadlock Verifier resources
+VStr - nt!Vf        - String buffer allocated by the Driver Verifier version of Rtl String APIs
+
+VHDa - vhdmp.sys    - VHD generic allocator
+VHDA - vhdmp.sys    - VHD generic allocator pool
+VHDb - vhdmp.sys    - VHD Block Allocation Table
+VHDf - vhdmp.sys    - VHD file entry
+VHDh - vhdmp.sys    - VHD header
+VHDi - vhdmp.sys    - VHD IO Range
+VHDI - vhdmp.sys    - VHD IO Range pool
+VHDl - vhdmp.sys    - VHD LUN
+VHDm - vhdmp.sys    - VHD bitmap
+VHDn - vhdmp.sys    - VHD filename
+VHDo - vhdmp.sys    - VHD footer
+VHDp - vhdmp.sys    - VHD filepath
+VHDr - vhdmp.sys    - VHD read buffer
+VHDs - vhdmp.sys    - VHD sector map
+VHDS - vhdmp.sys    - VHD symbolic link
+VHDt - vhdmp.sys    - VHD tracking information
+VHDw - vhdmp.sys    - VHD work item
+VHDy - vhdmp.sys    - VHD dynamic header
+VHD? - vhdmp.sys    - VHD allocation
+
+VHde - vmusbhub.sys - Virtual Machine USB Hub Driver (descriptor)
+VHif - vmusbhub.sys - Virtual Machine USB Hub Driver (interface)
+VHps - vmusbhub.sys - Virtual Machine USB Hub Driver (Pnp string)
+VHrc - vmusbhub.sys - Virtual Machine USB Hub Driver (request context)
+VHtx - vmusbhub.sys - Virtual Machine USB Hub Driver (text)
+VHub - vmusbhub.sys - Virtual Machine USB Hub Driver (Bus)
+VHur - vmusbhub.sys - Virtual Machine USB Hub Driver (URB)
+VHuW - vmusbhub.sys - Virtual Machine USB Hub Driver (WDF)
+
+VidL - videoprt.sys - VideoPort Allocation List (FDO_EXTENSION)
+VidR - videoprt.sys - VideoPort Allocation on behalf of Miniport
+
+ViMm - dxgkrnl.sys  - Video memory manager
+virt - vmm.sys      - Virtual Machine Manager (VPC/VS)
+ViSh - dxgkrnl.sys  - Video scheduler
+
+Vk?? - vmbkmcl.sys  - Hyper-V VMBus KMCL driver
+Vkin - vmbkmcl.sys  - Hyper-V VMBus KMCL driver (incoming packets)
+Vkou - vmbkmcl.sys  - Hyper-V VMBus KMCL driver (outgoing packets)
+
+VM?? - volmgr.sys   - Volume Manager
+VM   - volmgr.sys   - General allocations
+
+Vm?? - volmgrx.sys  - Volume Manager Extension
+Vm   - volmgrx.sys  - General allocations
+VmBl - volmgrx.sys  - Raw configuration blocks
+VmBu - volmgrx.sys  - I/O buffers
+VmCc - volmgrx.sys  - Configuration copies
+VmCo - volmgrx.sys  - Configurations
+VmCp - volmgrx.sys  - Copies
+VmCr - volmgrx.sys  - Completion routine contexts
+VmDc - volmgrx.sys  - Device changes
+VmDd - volmgrx.sys  - Disk devices
+VmDh - volmgrx.sys  - Disk headers
+VmLa - volmgrx.sys  - Drive layouts
+VmLb - volmgrx.sys  - Log blocks
+VmLc - volmgrx.sys  - Log copies
+VmLo - volmgrx.sys  - Logs
+VmLr - volmgrx.sys  - Log raw content
+VmMm - volmgrx.sys  - Mirror emergency mappings
+VmNe - volmgrx.sys  - Notification entries
+VmOb - volmgrx.sys  - I/O objects
+VmP0 - volmgrx.sys  - Packets
+VmP1 - volmgrx.sys  - Small packets
+VmP2 - volmgrx.sys  - Large packets
+VmP3 - volmgrx.sys  - Huge packets
+VmPa - volmgrx.sys  - Packs
+VmPd - volmgrx.sys  - Physical disks
+VmPs - volmgrx.sys  - Arrays of packets
+VmRb - volmgrx.sys  - Raw record buffers
+VmRc - volmgrx.sys  - Raw configurations
+VmRe - volmgrx.sys  - Records
+VmRi - volmgrx.sys  - Record information
+VmRm - volmgrx.sys  - RAID-5 emergency mappings
+VmRr - volmgrx.sys  - Raw records
+VmTa - volmgrx.sys  - I/O tasks
+VmTc - volmgrx.sys  - Table of contents
+VmTe - volmgrx.sys  - Table of contents entries
+VmTx - volmgrx.sys  - Transactions
+VmUe - volmgrx.sys  - User entries
+VmVd - volmgrx.sys  - Volume devices
+VmWi - volmgrx.sys  - Work items
+
+VmbK - kmcl.lib        - Virtual Machine Bus Kernel Mode Client Library
+
+VmCh - ChimneyLib.lib  - Virtual Machine Network Chimney Library
+
+VmFP - vfpext.sys - Virtual Filtering Platform driver
+
+VMhd - vmbushid.sys    - Virtual Machine Input VSC Driver
+VMIN - vwifimp.sys     - Virtual Wi-Fi miniport
+
+Vmsc - storchannel.lib - Virtual Machine Storage VSC Channel Library
+
+VNC  - netvsc50.sys/netvsc60.sys - Virtual Machine Network VSC Driver
+VNCm - netvsc50.sys/netvsc60.sys - Virtual Machine Network VSC Driver (RNDIS miniport driver library, message or object)
+VNCn - netvsc50.sys/netvsc60.sys - Virtual Machine Network VSC Driver (NBL)
+VNCr - netvsc50.sys/netvsc60.sys - Virtual Machine Network VSC Driver (RNDIS message context signature)
+VNCW - netvsc50.sys/netvsc60.sys - Virtual Machine Network VSC Driver (WDF)
+
+VoS? - volsnap.sys  -  VolSnap (Volume Snapshot Driver)
+VoSa - volsnap.sys  -      Application information allocations
+VoSb - volsnap.sys  -      Buffer allocations
+VoSc - volsnap.sys  -      Snapshot context allocations
+VoSd - volsnap.sys  -      Diff area volume allocations
+VoSf - volsnap.sys  -      Diff area file allocations
+VoSh - volsnap.sys  -      Bit history allocations
+VoSi - volsnap.sys  -      Io status block allocations
+VoSm - volsnap.sys  -      Bitmap allocations
+VoSo - volsnap.sys  -      Old heap entry allocations
+VoSp - volsnap.sys  -      Pnp id allocations
+VoSr - volsnap.sys  -      Device relations allocations
+VoSs - volsnap.sys  -      Short term allocations
+VoSt - volsnap.sys  -      Temp table allocations
+VoSw - volsnap.sys  -      Work queue allocations
+VoSx - volsnap.sys  -      Dispatch context allocations
+
+Vpb  - <unknown>    - Io, vpb's
+
+VPrs - passthruparser.sys - Virtual Machine Storage Passthrough Parser Driver
+
+Vprt - videoprt.sys - Video port for legacy (pre-Vista) display drivers
+
+VraP - <unknown>    - parallel class driver
+Vtfd - <unknown>    - Font file/context
+
+Vrdc - netvsc60.sys - Virtual Machine Network VSC Driver (NDIS 6, RNDIS miniport driver library, chimney neighbor or path context)
+Vrdt - netvsc60.sys - Virtual Machine Network VSC Driver (NDIS 6, RNDIS miniport driver library, chimney TCP context)
+Vrdi - netvsc60.sys - Virtual Machine Network VSC Driver (NDIS 6, RNDIS miniport driver library, chimney initiate offload)
+
+VSAB - utils.lib - Virtual Machine Storage VSP Utility Library
+
+VsAT - vmswitch.sys - Virtual Machine Network Switch Driver (address table)
+VsC4 - vmswitch.sys - Virtual Machine Network Switch Driver (chimney path4 context)
+VsC6 - vmswitch.sys - Virtual Machine Network Switch Driver (chimney path6 context)
+VsCH - vmswitch.sys - Virtual Machine Network Switch Driver (chimney handle)
+VsCN - vmswitch.sys - Virtual Machine Network Switch Driver (chimney neighbor context)
+VsCP - vmswitch.sys - Virtual Machine Network Switch Driver (chimney NBL context)
+VsCs - vmswitch.sys - Virtual Machine Network Switch Driver (configuration store)
+VsCT - vmswitch.sys - Virtual Machine Network Switch Driver (chimney TCP context)
+VsDI - vmswitch.sys - Virtual Machine Network Switch Driver (direct I/O NIC)
+VsNb - vmswitch.sys - Virtual Machine Network Switch Driver (NBL)
+VsOb - vmswitch.sys - Virtual Machine Network Switch Driver (object allocation)
+VsRD - vmswitch.sys - Virtual Machine Network Switch Driver (RNDIS device)
+VsRm - vmswitch.sys - Virtual Machine Network Switch Driver (routing)
+VsRT - vmswitch.sys - Virtual Machine Network Switch Driver (routing table)
+VssB - vmswitch.sys - Virtual Machine Network Switch Driver (balance)
+VssM - vmswitch.sys - Virtual Machine Network Switch Driver (miniport NIC)
+VssP - vmswitch.sys - Virtual Machine Network Switch Driver (protocol NIC)
+VsSw - vmswitch.sys - Virtual Machine Network Switch Driver
+VsSW - vmswitch.sys - Virtual Machine Network Switch Driver (WDF)
+VsVN - vmswitch.sys - Virtual Machine Network Switch Driver (VM NIC)
+Vsvq - vmswitch.sys - Virtual Machine Network Switch Driver (VMQ)
+
+VSt  - storvsp.sys - Virtual Machine Storage VSP Driver
+VSta - storvsp.sys - Virtual Machine Storage VSP Driver (adapter)
+VStb - storvsp.sys - Virtual Machine Storage VSP Driver (balance)
+VStd - storvsp.sys - Virtual Machine Storage VSP Driver (device)
+VStp - storvsp.sys - Virtual Machine Storage VSP Driver (parser)
+VStu - storvsp.sys - Virtual Machine Storage VSP Driver (authentication)
+VStW - storvsp.sys - Virtual Machine Storage VSP Driver (WDF)
+
+VSVL - VMBusVideoM.sys - Virtual Machine Synthetic Video Display Driver
+
+vS3W - vms3cap.sys - Virtual Machine Emulated S3 Device Cap Driver (WDF)
+
+vTDR - dxgkrnl.sys  - Video timeout detection/recovery
+
+VubH - vmusbbus.sys  - Virtual Machine USB Bus Driver
+VubW - vmusbbus.sys  - Virtual Machine USB Bus Driver (WDF)
+
+VuCH - vuc.sys       - Virtual Machine USB Connector Driver (connector handle)
+VuCP - vuc.sys       - Virtual Machine USB Connector Driver (virtual hub ports)
+VuCU - vuc.sys       - Virtual Machine USB Connector Driver (connector URB)
+VuCW - vuc.sys       - Virtual Machine USB Connector Driver (WDF)
+
+VusW - vmusbstub.sys - Virtual Machine USB Stub Driver (WDF)
+
+VVpc - vhdparser.sys - Virtual Machine Storage VHD Parser Driver (context)
+VVpp - vhdparser.sys - Virtual Machine Storage VHD Parser Driver (parser)
+
+VWFB - vwifibus.sys - Virtual Wi-Fi Bus Driver
+VWFF - vwififlt.sys - Virtual Wi-Fi Filter Driver (object allocation)
+VWnd - vwififlt.sys -  Virtual Wi-Fi Filter Driver (requests)
+
+Wait - nt!io        - WaitCompletion Packets
+
+Wan? - <unknown>    - NdisWan Tags (PPP Framing module for Remote Access)
+WanA - <unknown>    - BundleCB
+WanB - <unknown>    - ProtocolCB/LinkCB
+WanC - <unknown>    - DataDesc
+WanD - <unknown>    - WanRequest
+WanE - <unknown>    - LoopbackDesc
+WanG - <unknown>    - MiniportCB
+WanH - <unknown>    - OpenCB
+WanI - <unknown>    - IoPacket
+WanJ - <unknown>    - LineUpInfo
+WanK - <unknown>    - Unicode String Buffer
+WanL - <unknown>    - Protocol Table
+WanM - <unknown>    - Connection Table
+WanN - <unknown>    - NdisPacketPool Desc
+WanQ - <unknown>    - DataBuffer
+WanR - <unknown>    - WanPacket
+WanS - <unknown>    - AfCB/SapCB/VcCB
+WanT - <unknown>    - Transform Driver
+WanV - <unknown>    - RC4 Encryption Context
+WanW - <unknown>    - SHA Encryption
+WanX - <unknown>    - Send Compression Context
+WanY - <unknown>    - Recv Compression Context
+WanZ - <unknown>    - Protocol Specific Info
+
+Wdm  - <unknown>    - WDM
+WDMA - <unknown>    - WDM Audio
+
+Wdog - watchdog.sys - Watchdog object/context allocation
+
+Wfp? - netio.sys    - Windows Filtering Platform Tags
+WfpF - netio.sys    - WFP filters
+WfpM - netio.sys    - WFP filter match buffers
+WfpI - netio.sys    - WFP index
+WfpH - netio.sys    - WFP hash
+WfpR - netio.sys    - WFP RPC
+WfpC - netio.sys    - WFP callouts
+WfpS - netio.sys    - WFP startup
+WfpL - netio.sys    - WFP fast cache
+WfpE - netio.sys    - WFP extension
+Wfpn - netio.sys    - WFP NBL info container
+
+WfTi - <unknown>    - WFP timer
+WfSt - <unknown>    - WFP string
+
+werk - <unknown>    - WER kernel mode reporting allocation
+
+WimF - wimfsf.sys   - WIM Boot Filter
+
+Wl2l - wfplwfs.sys  - WFP L2 LWF context
+Wl2g - wfplwfs.sys  - WFP L2 generic block
+Wl2c - wfplwfs.sys  - WFP L2 classify cache
+Wl2f - wfplwfs.sys  - WFP L2 flow
+Wl2n - wfplwfs.sys  - WFP L2 NBL context
+
+WlBs - writelog.sys - Writelog block store
+WlFc - writelog.sys - Writelog fsd context
+WlGc - writelog.sys - Writelog global context
+WlIb - writelog.sys - Writelog I/O buffer
+WlLb - writelog.sys - Writelog library buffer
+WlCb - writelog.sys - Writelog checkpoint buffer
+WlPw - writelog.sys - Writelog planned write
+WlMh - writelog.sys - Writelog marker header
+WlMp - writelog.sys - Writelog marker payload
+WlDt - writelog.sys - Writelog drain target
+
+Wmii - <unknown>    - Wmi InstId chunks
+Wmij - <unknown>    - Wmi GuidMaps
+Wmim - <unknown>    - Wmi KM to UM Notification Buffers
+Wmin - <unknown>    - Wmi Notification Slot Chunks
+Wmip - <unknown>    - Wmi General purpose allocation
+Wmiq - <unknown>    - Wmi NBQ Blocks
+Wmis - <unknown>    - Wmi SysId allocations
+Wmit - <unknown>    - Wmi Trace
+Wmiw - <unknown>    - Wmi Notification Waiting Buffers, in paged queue waiting for IOCTL
+Wmiz - <unknown>    - Wmi MCA Insertions debug code
+
+WmiA - <unknown>    - Wmi ACPI mapper
+WmiC - <unknown>    - Wmi Create Pump Thread Work Item
+WmiD - <unknown>    - Wmi Registration DataSouce
+WmiG - <unknown>    - Allocation of WMIGUID
+WmiI - <unknown>    - Wmi Instance Names
+WmiL - <unknown>    - WmiLIb
+WmiN - <unknown>    - Wmi Notification Notification Packet
+WmiR - <unknown>    - Wmi Registration info blocks
+
+WmDS - <unknown>    - Wmi DataSource chunks
+WmGE - <unknown>    - Wmi GuidEntry chunks
+WmIS - <unknown>    - Wmi InstanceSet chunks
+WmMR - <unknown>    - Wmi MofResouce chunks
+
+WMca - <unknown>    - WMI MCA Handling
+
+Wnf  - nt!wnf       - Windows Notification Facility
+
+WofD - wof.sys      - Wof directory buffer
+WofF - wof.sys      - Wof file context
+Woff - wof.sys      - Wof extended file context
+WofG - wof.sys      - Wof general allocation
+WofH - wof.sys      - Wof handle context
+WofI - wof.sys      - Wof inflate buffer
+WofS - wof.sys      - Wof stream context
+Woft - wof.sys      - Wof transaction context
+WofV - wof.sys      - Wof volume context
+
+wpcf - wof.sys      - Wim config file
+wpci - wof.sys      - Wim integrity
+wpct - wof.sys      - Wim chunk table
+wpcx - wof.sys      - Wim IO context
+wpdw - wof.sys      - Wim decompression workspace
+wpgn - wof.sys      - Wim general
+wppm - wof.sys      - Wim IO parameters
+wprd - wof.sys      - Wim small read buffer
+wpRD - wof.sys      - Wim large read buffer
+wprt - wof.sys      - Wim resource table
+wpvo - wof.sys      - Wim volume overlay
+wpwf - wof.sys      - Wim file
+wpwi - wof.sys      - Wim work item
+wpxp - wof.sys      - Wim xpress context
+
+Wrp? - <unknown>    - WanArp Tags (ARP module for Remote Access)
+
+Wrpa - <unknown>    - WAN_ADAPTER_TAG
+Wrpi - <unknown>    - WAN_INTERFACE_TAG
+Wrpr - <unknown>    - WAN_REQUEST_TAG
+Wrps - <unknown>    - WAN_STRING_TAG
+Wrpc - <unknown>    - WAN_CONN_TAG
+Wrpw - <unknown>    - WAN_PACKET_TAG
+Wrpf - <unknown>    - FREE_TAG (checked builds only)
+Wrpd - <unknown>    - WAN_DATA_TAG
+Wrph - <unknown>    - WAN_HEADER_TAG
+Wrpn - <unknown>    - WAN_NOTIFICATION_TAG
+
+WSCD - WFPSamplerCalloutDriver.sys - WFPSampler Callout Driver
+
+WSKs - afd.sys      - WSK socket
+
+WSNP - WFPSamplerCalloutDriver.sys - WFPSampler Callout Driver NDIS Pool
+
+WvCy - <unknown>    - WDM Audio WaveCyc port
+WvPc - <unknown>    - WDM Audio WavePCI port
+
+xCVD - mrxdav.sys - AsyncEngineContext Tag
+
+XDR? - rpcxdr.sys   - NFS (Network File System) XDR driver
+
+xSMB - smbmrx.sys - IFSKIT sample SMB mini-redirector
+
+XWan - <unknown>    - ndis\usrwan allocations
+
+Xtra - <unknown>    - EXIFS Extra Create
+
+ZsaB - <unknown>    - EXIFS ZeroBlock
+Adbe - win32k.sys                           - GDITAG_ATM_FONT
+Bmfd - win32k.sys                           - GDITAG_BMP_FONT
+Dfsm - win32k.sys                           - GDITAG_ENG_EVENT
+DwmL - win32k!HwndLookupAllocTableData      - GDITAG_DWM_HWND_LOOKUP
+DWMt - win32k.sys                           - GDITAG_DWM_SENDTOUCHCONTACTS
+DWMv - win32k.sys                           - GDITAG_DWM_VALIDATION
+Dxdd - win32k!DxLddmSharedPrimaryLockNotification - GDITAG_LOCKED_PRIMARY
+Gadb - win32k!XDCOBJ::bAddColorTransform    - GDITAG_DC_COLOR_TRANSFORM
+Gadd - win32k.sys                           - GDITAG_DC_FONT
+Galp - win32k!AlphaScanLineBlend            - GDITAG_ALPHABLEND
+Gbaf - win32k.sys                           - GDITAG_BRUSH_FREELIST
+Gbdl - win32k!BRUSH::bAddIcmDIB             - GDITAG_ICM_DIB_LIST
+Gcac - win32k.sys                           - GDITAG_FONTCACHE
+Gcsl - win32k!InitializeScripts             - GDITAG_SCRIPTS
+Gcwc - win32k!ConvertToAndFromWideChar      - GDITAG_CHAR_TO_WIDE_CHAR
+Gdbr - win32k!BRUSHOBJ_pvAllocRbrush        - GDITAG_RBRUSH
+Gdcf - win32k.sys                           - GDITAG_DC_FREELIST
+GDcs - win32k!GreDwmStartup                 - GDITAG_DWMSTATE
+Gdev - win32k.sys                           - GDITAG_DEVMODE
+GDev - win32k.sys                           - GDITAG_PDEV
+Gdfm - win32k!DoFontManagement              - GDITAG_HGLYPH_ARRAY
+Gdrs - win32k.sys                           - GDITAG_DRVSUP
+Gdrv - win32k!EngCreateClip                 - GDITAG_CLIPOBJ
+Gdtd - win32k!GreAcquireSemaphoreAndValidate - GDITAG_SEMAPHORE_VALIDATE
+Gdwd - win32k.sys                           - GDITAG_WATCHDOG
+Gebr - win32k!EngRealizeBrush               - GDITAG_ENGBRUSH
+Gedd - win32k.sys                           - GDITAG_ENUM_DISPLAY_DEVICES
+Gedg - win32k!bFill                         - GDITAG_EDGE
+gEdg - win32k!bTriangleMesh                 - GDITAG_TRIANGLEDATA
+Geto - win32k.sys                           - GDITAG_TEXTOUT
+Gfda - win32k!UmfdAllocation::Create        - GDITAG_UMFD_ALLOCATION
+Gfdf - win32k!InitializeDefaultFamilyFonts  - GDITAG_FONT_DEFAULT_FAMILY
+Gffv - win32k.sys                           - GDITAG_FONTFILEVIEW
+Gfid - win32k.sys                           - GDITAG_UNIVERSAL_FONT_ID
+GFil - win32k.sys                           - GDITAG_FILEPATH
+Gfil - win32k.sys                           - GDITAG_MAPFILE
+GFld - win32k.sys                           - GDITAG_FLOODFILL
+Gfnt - win32k!RFONTOBJ::bRealizeFont        - GDITAG_RFONT
+Gfsb - win32k.sys                           - GDITAG_FONT_SUB
+Gfsf - win32k!bInitStockFontsInternal       - GDITAG_FONT_STOCKFONT
+Gfsm - win32k!GreCreateFastMutex            - GDITAG_FAST_MUTEX
+Gful - win32k.sys                           - GDITAG_FULLSCREEN
+Gfvi - win32k!bUnloadAllButPermanentFonts   - GDITAG_FONTVICTIM
+Ggb  - win32k!RFONTOBJ::pgbCheckGlyphCache  - GDITAG_GLYPHBLOCK
+Ggdv - win32k.sys                           - GDITAG_GDEVICE
+Ggls - win32k.sys                           - GDITAG_GLYPHSET
+Ggly - win32k.sys                           - GDITAG_HGLYPH
+Gh?: - win32k.sys                           - GDITAG_HMGR_LFONT_TYPE
+Gh?; - win32k.sys                           - GDITAG_HMGR_RFONT_TYPE
+Gh?@ - win32k.sys                           - GDITAG_HMGR_BRUSH_TYPE
+Gh?> - win32k.sys                           - GDITAG_HMGR_ICMCXF_TYPE
+Gh?0 - win32k.sys                           - GDITAG_HMGR_DEF_TYPE
+Gh?1 - win32k.sys                           - GDITAG_HMGR_DC_TYPE
+Gh?4 - win32k.sys                           - GDITAG_HMGR_RGN_TYPE
+Gh?5 - win32k.sys                           - GDITAG_HMGR_SURF_TYPE
+Gh?6 - win32k.sys                           - GDITAG_HMGR_CLIENTOBJ_TYPE
+Gh?7 - win32k.sys                           - GDITAG_HMGR_PATH_TYPE
+Gh?8 - win32k.sys                           - GDITAG_HMGR_PAL_TYPE
+Gh?9 - win32k.sys                           - GDITAG_HMGR_ICMLCS_TYPE
+Gh?A - win32k.sys                           - GDITAG_HMGR_UMPD_TYPE
+Gh?B - win32k.sys                           - GDITAG_HMGR_HLSURF_TYPE
+Gh?E - win32k.sys                           - GDITAG_HMGR_META_TYPE
+Gh?L - win32k.sys                           - GDITAG_HMGR_DRVOBJ_TYPE
+Gh?? - win32k.sys                           - GDITAG_HMGR_SPRITE_TYPE
+Gh00 - win32k.sys                           - GDITAG_HMGR_START
+Ghab - win32k!FHOBJ::bAddPFELink            - GDITAG_PFE_HASHBUCKET
+Ghas - win32k!FHMEMOBJ::FHMEMOBJ            - GDITAG_PFE_HASHTABLE
+Ghml - win32k.sys                           - GDITAG_HMGR_LOCK
+Ghtc - win32k!bSetHTSrcSurfInfo             - GDITAG_HALFTONE_COLORTRIAD
+Ghtm - win32k.sys                           - GDITAG_HMGR_TEMP
+Gi2c - win32k.sys                           - GDITAG_DDCCI
+Gicm - win32k.sys                           - GDITAG_ICM
+Gkbm - win32k.sys                           - GDITAG_KMODE_BITMAP
+Gla: - win32k.sys                           - GDITAG_HMGR_LOOKASIDE_LFONT_TYPE
+Gla; - win32k.sys                           - GDITAG_HMGR_LOOKASIDE_RFONT_TYPE
+Gla@ - win32k.sys                           - GDITAG_HMGR_LOOKASIDE_BRUSH_TYPE
+Gla0 - win32k.sys                           - GDITAG_HMGR_LOOKASIDE_START
+Gla1 - win32k.sys                           - GDITAG_HMGR_LOOKASIDE_DC_TYPE
+Gla4 - win32k.sys                           - GDITAG_HMGR_LOOKASIDE_RGN_TYPE
+Gla5 - win32k.sys                           - GDITAG_HMGR_LOOKASIDE_SURF_TYPE
+Gla8 - win32k.sys                           - GDITAG_HMGR_LOOKASIDE_PAL_TYPE
+Gldv - win32k.sys                           - GDITAG_LDEV
+Glid - win32k!GetLanguageID                 - GDITAG_LOCALEINFO
+Glnk - win32k!FHOBJ::bAddPFELink            - GDITAG_PFE_LINK
+Gmap - win32k!InitializeFontSignatures      - GDITAG_FONT_MAPPER
+Gmso - win32k!MULTISORTBLTORDER::MULTISORTBLTORDER - GDITAG_DISPURF_SORT
+Gmul - win32k!MULTIFONT::MULTIFONT          - GDITAG_MULTIFONT
+Gnls - win32k.sys                           - GDITAG_NLS
+Gogl - win32k!iOpenGLExtEscape              - GDITAG_OPENGL
+GOPM - win32k.sys                           - GDITAG_OPM
+GPal - win32k.sys                           - GDITAG_PALETTE
+Gpan - win32k.sys                           - GDITAG_PANNING_PDEV
+Gpat - win32k.sys                           - GDITAG_PATHOBJ
+Gpfe - win32k!PFFMEMOBJ::bAllocPFEData      - GDITAG_PFF_INDEXES
+Gpff - win32k.sys                           - GDITAG_PFF
+Gpft - win32k!pAllocateAndInitializePFT     - GDITAG_PFT
+Gpgb - win32k!EngPlgBlt                     - GDITAG_PLGBLT_DATA
+Gpid - win32k!NtGdiSetPUMPDOBJ              - GDITAG_PRINTCLIENTID
+Gppo - win32k!XCLIPOBJ::ppoGetPath          - GDITAG_CLIP_PATHOBJ
+Gppt - win32k!PROXYPORT::PROXYPORT          - GDITAG_PROXYPORT
+Gpre - win32k!pSpCreatePresent              - GDITAG_PRESENT
+Gqnk - win32k!bComputeQuickLookup           - GDITAG_LFONT_QUICKLOOKUP
+Grgb - win32k.sys                           - GDITAG_PALETTE_RGB_XLATE
+Grgn - win32k.sys                           - GDITAG_REGION
+Gsem - win32k.sys                           - GDITAG_SEMAPHORE
+Gsp  - win32k!pSpCreateSprite               - GDITAG_SPRITE
+Gspm - win32k.sys                           - GDITAG_METASPRITE
+Gspr - win32k.sys                           - GDITAG_SPRITESCAN
+Gsta - win32k.sys                           - GDITAG_STACKTRACE
+Gsth - win32k.sys                           - GDITAG_STRETCHBLT
+Gsty - win32k!GreExtCreatePen               - GDITAG_PENSTYLE
+Gsux - win32k.sys                           - GDITAG_SFM
+Gtmp - win32k.sys                           - GDITAG_TEMP
+GTmp - win32k!AllocFreeTmpBuffer            - GDITAG_TEMP_THREADLOCK
+Gtmw - win32k!bIFIMetricsToTextMetricW      - GDITAG_TEXTMETRICS
+Gtvp - win32k!PFFOBJ::bAddPvtData           - GDITAG_PFF_DATA
+Gtvt - win32k!bTriangleMesh                 - GDITAG_TRIANGLE_MESH
+Gtxt - win32k.sys                           - GDITAG_TEXT
+Gubm - win32k.sys                           - GDITAG_UMODE_BITMAP
+GUma - win32k!GDIEngUserMemAllocNodeAlloc   - GDITAG_ENG_USER_MEM_ALLOC_TABLE
+Gump - win32k.sys                           - GDITAG_UMPD
+Gvds - win32k!MulEnablePDEV                 - GDITAG_HDEV
+GVdv - win32k.sys                           - GDITAG_VDEV
+GVms - win32k!MulSaveScreenBits             - GDITAG_MULTISAVEBITS
+GVsf - win32k!MulCreateDeviceBitmap         - GDITAG_MDSURF
+Gwnd - win32k.sys                           - GDITAG_WNDOBJ
+Gxlt - win32k.sys                           - GDITAG_PXLATE
+Gxpd - win32k!XUMPDOBJ::XUMPDOBJ            - GDITAG_UMPDOBJ
+knlf - win32k.sys                           - GDITAG_FONT_LINK
+PASf - win32k.sys                           - GDITAG_PANNING_SURFACE
+PSlo - win32k.sys                           - GDITAG_PANNING_SHADOWLOCK
+Ssrl - win32k.sys                           - GDITAG_SINGLEREADERLOCK
+TTFC - win32k.sys                           - GDITAG_TT_FONT_CACHE
+Ttfd - win32k.sys                           - GDITAG_TT_FONT
+Vtfd - win32k.sys                           - GDITAG_VF_FONT
+W32l - win32k!W32PIDLOCK::vInit             - GDITAG_W32PIDLOCK
+SFMb - win32k!SfmTokenArray::EnsureTokenBufferSize - GDITAG_TOKENARRAY
+Gnff - win32k.sys                           - GDITAG_NETWORKED_FONT_FILE_TABLE
+Gtff - win32k.sys                           - GDITAG_TRUSTED_FONT_FILE_TABLE
+Gala - win32k.sys                           - GDITAG_ADAPTER_LUID_ARRAY
+FDpd - win32k.sys                           - GDITAG_UMFD_PDEV
+FDev - win32k.sys                           - GDITAG_UMFD_EVENT
+FDUm - win32k.sys                           - GDITAG_UMFD_UM_BUFFER
+FDtl - win32k.sys                           - GDITAG_UMFD_TLS
+FDrq - win32k.sys                           - GDITAG_UMFD_REQUEST
+GFdk - win32k.sys                           - GDITAG_UMFD_KERNEL_ALLOCATION
+UHFF - win32k.sys                           - GDITAG_UMFD_HFF
+FDat - win32k.sys                           - GDITAG_UMFD_GLYPHATTRS
+GMFF - win32k.sys                           - GDITAG_FONT_MAPPER_FAMILY_FALLBACK
+GFIC - win32k.sys                           - GDITAG_FONT_INTENSITY_CORRECTION
+Ghmc - win32k!GdiHandleManager::Create      - GDITAG_HANDLE_MANAGER
+Getc - win32k!GdiHandleEntryTable::_Create  - GDITAG_HANDLE_ENTRY_TABLE
+Gelt - win32k!EntryDataLookupTable::Create  - GDITAG_ENTRY_DATA_LOOKUP_TABLE
+Gelc - win32k!EntryDataLookupTable::Initialize - GDITAG_ENTRY_DATA_LOOKUP_TABLE_COLUMN
+Ucal - win32k!DriverEntry                   - USERTAG_SERVICE_TABLE
+Umam - win32k!UpdateDesktopThresholds       - USERTAG_MONITOR_MARGIN
+Uman - win32k!NtUserSetManipulationInputTarget - USERTAG_DWM_MANIPULATION
+Urdr - win32k!SetRedirectionBitmap          - USERTAG_REDIRECT
+Usac - win32k!_CreateAcceleratorTable       - USERTAG_ACCEL
+Usai - win32k!zzzAttachThreadInput          - USERTAG_ATTACHINFO
+Usal - win32k!InitSwitchWndInfo             - USERTAG_ALTTAB
+Usbg - win32k!xxxLogClipData                - USERTAG_DEBUG
+Usbm - win32k!SetGestureConfigSettings      - USERTAG_BITMASK
+Usbr - win32k!NtUserShutdownBlockReasonCreate - USERTAG_BLOCKREASON
+Usca - win32k!NtUserSetCalibrationData      - USERTAG_CALIBRATIONDATA
+Uscb - win32k!_ConvertMemHandle             - USERTAG_CLIPBOARD
+Uscc - win32k!AllocCallbackMessage          - USERTAG_CALLBACK
+Uscd - win32k!SetWindowCompositionInfo      - USERTAG_COMPOSITIONPROP
+UsCd - win32k!xxxUserChangeDisplaySettings  - USERTAG_CDS
+Usce - win32k!RetrieveLinkCollection        - USERTAG_COLLINK
+Usci - win32k!InitSystemThread              - USERTAG_CLIENTTHREADINFO
+UscI - win32k!CitStart                      - USERTAG_COMPAT_IMPACT
+Uscl - win32k!ClassAlloc                    - USERTAG_CLASS
+Uscm - win32k!InitScancodeMap               - USERTAG_SCANCODEMAP
+Uscp - win32k!CreateDIBPalette              - USERTAG_CLIPBOARDPALETTE
+Uscr - win32k!NtUserSetSysColors            - USERTAG_COLORS
+Usct - win32k!CkptRestore                   - USERTAG_CHECKPT
+Uscu - win32k!_CreateEmptyCursorObject      - USERTAG_CURSOR
+Uscv - win32k!NtUserSetSysColors            - USERTAG_COLORVALUES
+Uscw - win32k!CacheAxisChildIndex           - USERTAG_CONTACTRELATIVE
+UsDI - win32k!CreateDeviceInfo              - USERTAG_DEVICEINFO
+UsDc - win32k!NtUserDisplayConfigSetDeviceInfo - USERTAG_DISPLAYCONFIG
+UsDt - win32k!NtUserCtxDisplayIOCtl         - USERTAG_DISPLAYIOCTL
+Usd1 - win32k!FreeListAdd                   - USERTAG_DDE1
+Usd2 - win32k!_DdeSetQualityOfService       - USERTAG_DDE2
+Usd4 - win32k!AddPublicObject               - USERTAG_DDE4
+Usd5 - win32k!xxxCsEvent                    - USERTAG_DDE5
+Usd6 - win32k!xxxCsEvent                    - USERTAG_DDE6
+Usd7 - win32k!xxxCsEvent                    - USERTAG_DDE7
+Usd8 - win32k!xxxMessageEvent               - USERTAG_DDE8
+Usd9 - win32k!xxxCsDdeInitialize            - USERTAG_DDE9
+UsdA - win32k!NewConversation               - USERTAG_DDEa
+UsdB - win32k!Createpxs                     - USERTAG_DDEb
+Usdc - win32k!CreateCacheDC                 - USERTAG_DCE
+UsdD - win32k!NtUserfnDDEINIT               - USERTAG_DDEd
+UsdE - win32k!xxxClientCopyDDEIn1           - USERTAG_DDE
+Usdi - win32k!CreateMonitor                 - USERTAG_DISPLAYINFO
+Usdm - win32k!CreateDCompositionHwndTargetInfo - USERTAG_DCOMPHWNDTARGETINFO
+Usdp - win32k!NtUserDelegateCapturePointers - USERTAG_DELEGATEPOINTERSTRUCT
+Usds - win32k!xxxDragObject                 - USERTAG_DRAGDROP
+Usdv - win32k!NtUserfnINDEVICECHANGE        - USERTAG_DEVICECHANGE
+Usdw - win32k!GetProductString              - USERTAG_DEVICENAME
+UsEC - win32k!AddWEFCOMPInvalidateSListEntry - USERTAG_WSEXCOMPINVALID
+Used - win32k!AddOrUpdateListener           - USERTAG_EDGY
+User - win32k!InitCreateUserCrit            - USERTAG_ERESOURCE
+Usex - win32k!IsDeviceExcluded              - USERTAG_EXCLUDEDLIST
+Usfi - win32k!CreatePointerDeviceInfo       - USERTAG_FEATUREIOCTL
+Usft - win32k!CreateValidTouchInputInfo     - USERTAG_FORWARDTOUCHMESSAGE
+Usgc - win32k!_StoreGestureConfig           - USERTAG_GESTURECONFIG
+Usgd - win32k!SetGestureConfigSettings      - USERTAG_GESTUREDATA
+Usgh - win32k!NtUserUserHandleGrantAccess   - USERTAG_GRANTEDHANDLES
+Usgi - win32k!NtUserSendGestureInput        - USERTAG_GESTUREINFO
+Usgt - win32k!AddGhost                      - USERTAG_GHOST
+Usha - win32k!AllocateHidData               - USERTAG_HIDDATA
+Ushc - win32k!AllocateHidConfigDesc         - USERTAG_HIDCONFIG
+UshD - Win32k!AllocateHidDesc               - USERTAG_HIDDESC
+Ushf - win32k!AllocateHidConfigDesc         - USERTAG_HIDFEATURE
+Ushh - win32k!HidGetCaps                    - USERTAG_HID
+Ushi - win32k!AllocateHidDesc               - USERTAG_HIDINPUT
+Ushk - win32k!_RegisterHotKey               - USERTAG_HOTKEY
+Ushl - win32k!INLPHLPSTRUCT                 - USERTAG_HELP
+Ushp - win32k!GetDeviceParent               - USERTAG_HIDPARENT
+UshP - win32k!HidCreateDeviceInfo           - USERTAG_HIDPREPARSED
+Ushr - win32k!AllocateAndLinkHidPageOnlyRequest - USERTAG_HIDPAGEREQUEST
+UshR - win32k!AllocateHidProcessRequest     - USERTAG_HIDPROCREQUEST
+Usht - win32k!AllocateProcessHidTable       - USERTAG_HIDTABLE
+UshT - win32k!AllocateAndLinkHidTLCInfo     - USERTAG_HIDTLC
+Usih - win32k!SetImeHotKey                  - USERTAG_IMEHOTKEY
+Usim - win32k!CreateInputContext            - USERTAG_IME
+Usip - win32k!CreateNode                    - USERTAG_INPUTPOINTERNODE
+Usiq - win23k!CInputQueueProp               - USERTAG_COMPOSITIONINPUTQUEUE
+Usit - win32k!InjectTouchInput              - USERTAG_INJECT_TOUCH
+Usim - win32k!InjectMouseInput              - USERTAG_INJECT_MOUSE
+Usik - win32k!InjectKeyboardInput           - USERTAG_INJECT_KEYBOARD
+Usix - win32k!AllocInputTransformEntry      - USERTAG_INPUT_TRANSFORM
+Usjb - win32k!CreateW32Job                  - USERTAG_W32JOB
+Usjx - win32k!JobCalloutAddProcess          - USERTAG_W32JOBEXTRA
+UsKe - win32k!CreateKernelEvent             - USERTAG_KEVENT
+UsKf - win32k!InitCreateUserCrit            - USERTAG_FASTMUTEX
+UsKm - win32k!DriverEntry                   - USERTAG_KMUTEX
+UsKs - win32k!CreateKernelSemaphore         - USERTAG_KSEMAPHORE
+UsKt - win32k!RemoteConnect                 - USERTAG_KTIMER
+UsKw - win32k!xxxDesktopThread              - USERTAG_KWAITBLOCK
+UsKv - win32k!ReadTabletButtonConfig        - USERTAG_KEYVALUEINFORMATION
+Uskb - win32k!xxxLoadKeyboardLayoutEx       - USERTAG_KBDLAYOUT
+Uske - win32k!GetKbdExId                    - USERTAG_KBDEXID
+Uskf - win32k!LoadKeyboardLayoutFile        - USERTAG_KBDFILE
+Usks - win32k!PostUpdateKeyStateEvent       - USERTAG_KBDSTATE
+Uskt - win32k!ReadLayoutFile                - USERTAG_KBDTABLE
+Usla - win32k!InitLockRecordLookaside       - USERTAG_LOOKASIDE
+Usld - win32k!GrowLogIfNecessary            - USERTAG_LOGDESKTOP
+Uslr - win32k!InitLockRecordLookaside       - USERTAG_LOCKRECORD
+UsMP - win32k!GeneratePointerMessageFromMouse - USERTAG_MOUSEINPOINTER
+usmd - win32k!xxxSetModernAppWindow         - USERTAG_MODERNDESKTOPAPP
+Usmg - win32k!Magxxx                        - USERTAG_MAGNIFICATION
+Usmi - win32k!MirrorRegion                  - USERTAG_MIRROR
+Usml - win32k!MsgLookupTableAlloc           - USERTAG_MESSAGE_FILTER
+Usmo - win32k!_EnableIAMAccess              - USERTAG_MOSH
+Usmp - win32k!AllocMousePromotionEntry      - USERTAG_MOUSEPROMOTIONENTRY
+Usmr - win32k!SnapshotMonitorRects          - USERTAG_MONITORRECTS
+Usms - win32k!xxxMoveSize                   - USERTAG_MOVESIZE
+Usmt - win32k!xxxMNAllocMenuState           - USERTAG_MENUSTATE
+Usmx - win32k!InitializeMonitorDpiRectsAndTransforms - USERTAG_MATRIX
+Usna - win32k!UserPostNKAPC                 - USERTAG_NKAPC
+Usny - win32k!CreateNotify                  - USERTAG_NOTIFY
+Uspa - win32k!AllocPointerMsgParamsList     - USERTAG_POINTERMSGPARAMS
+Uspb - win32k!fnPOWERBROADCAST              - USERTAG_POWERBROADCAST
+Uspd - win32k!PointerList::AddMsgData       - USERTAG_POINTERINPUTMSGDATA
+Uspc - win32k!CreatePointerDeviceInfo       - USERTAG_POINTERDEVICE
+UspC - win32k!AssignPointerCaptureData      - USERTAG_POINTERCAPTUREDATA
+Uspe - win32k!AllocPointerInfoNodeList      - USERTAG_POINTERINPUTEVENT
+Uspf - win32k!CommitHoldingFrame            - USERTAG_POINTERINPUTFRAME
+Uspg - win32k!GeneratePointerMessage        - USERTAG_POINTERINPUTMSG
+Uspi - win32k!MapDesktop                    - USERTAG_PROCESSINFO
+Uspk - win32k!GetProductString              - USERTAG_PRODUCTSTRING
+Uspl - win32k!xxxPollAndWaitForSingleObject - USERTAG_POLLEVENT
+UsPM - win32k!InitPostMortemLogging         - USERTAG_POSTMORTEM_LOGGING
+Uspm - win32k!MNAllocPopup                  - USERTAG_POPUPMENU
+Uspn - win32k!CreateProfileUserName         - USERTAG_PROFILEUSERNAME
+Uspo - win32k!QueuePowerRequest             - USERTAG_POWER
+Uspp - win32k!AllocateAndLinkHidTLCInfo     - USERTAG_PNP
+Uspq - win32k!CreatePointerDeviceInfo       - USERTAG_PARALLELPROP
+UspQ - win32k!AllocPointerQFrameList        - USERTAG_POINTERQFRAME
+Uspr - win32k!GetPrivateProfileStruct       - USERTAG_PROFILE
+Uspt - win32k!AllocThreadPointerData        - USERTAG_POINTERTHREADDATA
+Uspv - win32k!ContactVisualization          - USERTAG_POINTERVISUALIZATION
+Uspw - win32k!CDynamicArray::Add            - USERTAG_DYNAMICARRAY
+Uspx - win32k!GetCustomFlickPath            - USERTAG_PTRCFG
+USqm - win32k!_WinSqmAllocate               - USERTAG_SQM
+Usql - win32k!EnsureQMsgLog                 - USERTAG_QMSGLOG
+Usqm - win32k!InitQEntryLookaside           - USERTAG_QMSG
+Usqq - win32k!InitQMiPTrace                 - USERTAG_QMIPTRACE
+Usqu - win32k!InitQEntryLookaside           - USERTAG_Q
+Usrd - win32k!StoreRawDataBlock             - USERTAG_POINTERRAWDATA
+Usri - win32k!NtUserRegisterRawInputDevices - USERTAG_RAWINPUTDEVICE
+Usrt - win32k!xxxDrawMenuItemText           - USERTAG_RTL
+Ussa - win32k!xxxBroadcastMessage           - USERTAG_SMS_ASYNC
+Ussb - win32k!CreateSpb                     - USERTAG_SPB
+Ussc - win32k!xxxInterSendMsgEx             - USERTAG_SMS_CAPTURE
+Ussd - win32k!xxxAddShadow                  - USERTAG_SHADOW
+Usse - win32k!SetDisconnectDesktopSecurity  - USERTAG_SECURITY
+Ussi - win32k!NtUserSendInput               - USERTAG_SENDINPUT
+Ussj - win32k!NtUserSendTouchInput          - USERTAG_SENDTOUCHINPUT
+Ussm - win32k!InitSMSLookaside              - USERTAG_SMS
+Usss - win32k!xxxBroadcastMessage           - USERTAG_SMS_STRING
+Usst - win32k!xxxSBTrackInit                - USERTAG_SCROLLTRACK
+Ussw - win32k!_BeginDeferWindowPos          - USERTAG_SWP
+Ussw - win32k!xxxDesktopRecalc              - USERTAG_ADR
+Ussy - win32k!xxxDesktopThread              - USERTAG_SYSTEM
+UsTI - win32k!NtUserQueryInformationThread  - USERTAG_THREADINFORMATION
+Usta - win32k!AssociateShellFrameAppThreads - USERTAG_THREADASSOCIATION
+Ustd - win32k!TrackAddDesktop               - USERTAG_TRACKDESKTOP
+Usti - win32k!AllocateW32Thread             - USERTAG_THREADINFO
+Ustn - win32k!AllocateW32Thread             - USERTAG_THREADINFONP
+Ustk - win32k!HeavyAllocPool                - USERTAG_STACK
+Ustm - win32k!InternalSetTimer              - USERTAG_TIMER
+Usto - win32k!xxxConnectService             - USERTAG_TOKEN
+Ustp - win32k!FindOrCreateHoldingFrameForDevice   - USERTAG_TOUCHPADSTATE
+Usts - win32k!_Win32CreateSection           - USERTAG_SECTION
+Ustx - win32k!NtUserDrawCaptionTemp         - USERTAG_TEXT
+Usty - win32k!NtUserResolveDesktopForWOW    - USERTAG_TEXT2
+Ustz - win32k!AllocTouchInputInfo           - USERTAG_TOUCHINPUTINFO
+Usua - win32k!TabletButtonHandler           - USERTAG_TABLETBUTTONUSAGE
+Usub - win32k!NtUserToUnicodeEx             - USERTAG_UNICODEBUFFER
+Usus - win32k!MsgSQMGetMsgList              - USERTAG_UIPI_SQM
+Usvc - win32k!_GetPointerDeviceProperties   - USERTAG_VALUECAP
+Usvi - win32k!ResizeVisExcludeMemory        - USERTAG_VISRGN
+Usvl - win32k!VWPLAdd                       - USERTAG_VWPL
+UsWE - win32k!ReportHungExplorerToWer       - USERTAG_WER
+UsWP - win32k!SetGlobalWallpaperSettings    - USERTAG_WALLPAPER
+Uswc - win32k!SetSwapChainProp              - USERTAG_SWAPCHAIN
+Uswd - win32k!xxxCreateWindowEx             - USERTAG_WINDOW
+Uswe - win32k!_SetWinEventHook              - USERTAG_WINEVENT
+Uswi - win32k!RemoteShadowStart             - USERTAG_WIREDATA
+Uswl - win32k!BuildHwndList                 - USERTAG_WINDOWLIST
+Uswo - win32k!zzzInitTask                   - USERTAG_WOWTDB
+Uswp - win32k!xxxRegisterUserHungAppHandlers - USERTAG_WOWPROCESSINFO
+Uswr - win32k!CoreWindowProp                - USERTAG_COREWINDOWPROP
+Uswt - win32k!xxxUserNotifyProcessCreate    - USERTAG_WOWTHREADINFO
+Usrr - win32k!TouchTargetingRankForRegion   - USERTAG_RANKFORRGN
+Uslt - win32k!InitializeWin32PoolTracking   - USERTAG_LEAKEDTAG
+UsI0 - win32k!NSInstrumentation::CBackTraceStorageUnit::Create   - USERTAG_BACKTRACE_STORAGE_UNIT
+UsI1 - win32k!NSInstrumentation::CBackTraceBucket::Create   - USERTAG_BACKTRACE_BUCKET
+UsI2 - win32k!NSInstrumentation::CBackTraceBucket::CreateContext   - USERTAG_BACKTRACE_BUCKET_CONTEXT
+UsI3 - win32k!NSInstrumentation::CBackTraceStoreEx::Create   - USERTAG_BACKTRACE_STORE
+UsI4 - win32k!NSInstrumentation::CBloomFilter::Create   - USERTAG_BLOOMFILTER
+UsI5 - win32k!NSInstrumentation::CPlatformSignal::Create   - USERTAG_INSTRUMENTATION_EVENT
+UsI6 - win32k!NSInstrumentation::CLeakTrackingAllocator::Create   - USERTAG_LEAK_TRACKING_ALLOCATOR
+UsI7 - win32k!NSInstrumentation::CPrioritizedWriterLock::Create   - USERTAG_PRIORITIZED_WRITER_LOCK
+UsI8 - win32k!NSInstrumentation::CPointerHashTable::Create   - USERTAG_POINTER_HASH_TABLE
+UsI9 - win32k!NSInstrumentation::CReferenceTracker::Create   - USERTAG_REFERENCE_TRACKER
+UsIa - win32k!NSInstrumentation::CReferenceTracker::CReferenceCountedType::Create   - USERTAG_REFERENCE_COUNTED_TYPE_HANDLE
+UsIb - win32k!NSInstrumentation::CReferenceTracker::CReferenceCountedType::BeginTrack   - USERTAG_REFERENCE_COUNTED_OBJECT_HANDLE
+UsIc - win32k!NSInstrumentation::CSortedVector::Create   - USERTAG_SORTED_VECTOR
+UsId - win32k!NSInstrumentation::CSharedStorage::InitializeCommon   - USERTAG_SHARED_STORAGE
+Udpi - win32k!CreateSystemFontsForDpi       - USERTAG_DPIMETRICS
+DCab - win32kbase!DirectComposition::CAnimationBinding::_allocate                           - DCOMPOSITIONTAG_ANIMATIONBINDING
+DCac - win32kbase!DirectComposition::CApplicationChannel::_allocate                         - DCOMPOSITIONTAG_APPLICATIONCHANNEL
+DCae - win32kbase!DirectComposition::CAnimationMarshaler::SetBufferProperty                 - DCOMPOSITIONTAG_ANIMATIONTIMEEVENTDATA
+DCag - win32kbase!DirectComposition::CAnimationMarshaler::SetBufferProperty                 - DCOMPOSITIONTAG_ANIMATIONSCENARIOGUID
+DCal - win32kbase!DirectComposition::CAnimationTimeList::_allocate                          - DCOMPOSITIONTAG_ANIMATIONTIMELIST
+DCam - win32kbase!DirectComposition::CCompositionAmbientLight::_allocate                    - DCOMPOSITIONTAG_AMBIENTLIGHTMARSHALER
+DCan - win32kbase!DirectComposition::CAnimationMarshaler::_allocate                         - DCOMPOSITIONTAG_ANIMATIONMARSHALER
+DCat - win32kbase!DirectComposition::CAnimationTriggerMarshaler::_allocate                  - DCOMPOSITIONTAG_ANIMATIONTRIGGERMARSHALER
+DCau - win32kbase!DirectComposition::CSharedReadAnimationTriggerMarshaler::_allocate        - DCOMPOSITIONTAG_SHAREDREADANIMATIONTRIGGERMARSHALER
+DCav - win32kbase!DirectComposition::CSharedWriteAnimationTriggerMarshaler::_allocate       - DCOMPOSITIONTAG_SHAREDWRITEANIMATIONTRIGGERMARSHALER
+DCax - win32kbase!DirectComposition::CAnalogExclusiveViewMarshaler::_allocate               - DCOMPOSITIONTAG_ANALOGEXCLUSIVEVIEWMARSHALER
+DCay - win32kbase!DirectComposition::CAnalogTextureTargetMarshaler::_allocate               - DCOMPOSITIONTAG_ANALOGTEXTURETARGETMARSHALER
+DCaz - win32kbase!DirectComposition::CAnalogCompositorMarshaler::_allocate                  - DCOMPOSITIONTAG_ANALOGCOMPOSITORMARSHALER
+DCba - win32kbase!DirectComposition::CBatch::_allocate                                      - DCOMPOSITIONTAG_BATCH
+DCbc - win32kbase!DirectComposition::CChannel::_allocate                                    - DCOMPOSITIONTAG_CHANNEL
+DCbf - win32kbase!DirectComposition::Memory::Allocate                                       - DCOMPOSITIONTAG_BUFFER
+DCbl - win32kbase!DirectComposition::CBackChannelMarshaler::_allocate                       - DCOMPOSITIONTAG_BACKCHANNELMARSHALER
+DCbr - win32kbase!DirectComposition::CBatch::CSystemResourceReference::_allocate            - DCOMPOSITIONTAG_BATCH_RESOURCEREF
+DCbs - win32kbase!DirectComposition::CBatchSharedMemoryPool::_allocate                      - DCOMPOSITIONTAG_BATCH_SHARED_MEMORY_POOL
+DCc2 - win32kbase!DirectComposition::CComponentTransform2DMarshaler::_allocate              - DCOMPOSITIONTAG_COMPONENTTRANSFORM2DMARSHALER
+DCca - win32kbase!DirectComposition::CConditionalExpressionMarshaler::_allocate             - DCOMPOSITIONTAG_CONDITIONALEXPRESSIONMARSHALER
+DCcb - win32kbase!DirectComposition::CCompositionSurfaceBitmapMarshaler::_allocate          - DCOMPOSITIONTAG_HCOMPBITMAPMARSHALER
+DCcc - win32kbase!DirectComposition::CConnection::_allocate                                 - DCOMPOSITIONTAG_CONNECTION
+DCce - win32kbase!DirectComposition::CCompositionFrame::TokenTableEntry::Allocate           - DCOMPOSITIONTAG_COMPOSITIONFRAMETOKENTABLEENTRY
+DCcf - win32kbase!DirectComposition::CCompositionFrame::Create                              - DCOMPOSITIONTAG_COMPOSITIONFRAME
+DCcg - win32kbase!DirectComposition::CClipGroupMarshaler::_allocate                         - DCOMPOSITIONTAG_CLIPGROUPMARSHALER
+DCch - win32kbase!DirectComposition::CChannelHandleTable::_allocate                         - DCOMPOSITIONTAG_CHANNELHANDLETABLE
+DCcl - win32kbase!DirectComposition::CCompositionLight::_allocate                           - DCOMPOSITIONTAG_LIGHTMARSHALER
+DCco - win32kbase!DirectComposition::CComponentTransform3DMarshaler::_allocate              - DCOMPOSITIONTAG_COMPONENTTRANSFORM3DMARSHALER
+DCcp - win32kbase!DirectComposition::CPushLockCriticalSection::_allocate                    - DCOMPOSITIONTAG_PUSHLOCKCRITICALSECTION
+DCcs - win32kbase!DirectComposition::CCriticalSection::_allocate                            - DCOMPOSITIONTAG_CRITICALSECTION
+DCct - win32kbase!DirectComposition::CApplicationChannel::AllocateTableEntry                - DCOMPOSITIONTAG_CHANNELTABLE
+DCcv - win32kbase!DirectComposition::CrossChannelVisualData::_allocate                      - DCOMPOSITIONTAG_CROSSCHANNELVISUALDATA
+DCda - win32kbase!DirectComposition::CDCompDynamicArray::_allocate                          - DCOMPOSITIONTAG_DYNAMICARRAY
+DCdb - win32kbase!DirectComposition::CDCompDynamicArrayBase::_allocate                      - DCOMPOSITIONTAG_DYNAMICARRAYBASE
+DCdc - win32kbase!DirectComposition::CDwmChannel::_allocate                                 - DCOMPOSITIONTAG_DWMCHANNEL
+DCde - win32kbase!DirectComposition::CDesktopTargetMarshaler::_allocate                     - DCOMPOSITIONTAG_DESKTOPTARGETMARSHALER
+DCdf - win32kbase!DirectComposition::CSharedReadDesktopTargetMarshaler::_allocate           - DCOMPOSITIONTAG_SHAREDREADDESKTOPTARGETMARSHALER
+DCdg - win32kbase!DirectComposition::CSharedWriteDesktopTargetMarshaler::_allocate          - DCOMPOSITIONTAG_SHAREDWRITEDESKTOPTARGETMARSHALER
+DCdh - win32kbase!DirectComposition::CDesktopTargetMarshaler::_allocate                     - DCOMPOSITIONTAG_DESKTOPTARGETMARSHALERMONITORS
+DCdi - win32kbase!DirectComposition::CSharedReadDcompTargetMarshaler::_allocate             - DCOMPOSITIONTAG_SHAREDREADDCOMPTARGETMARSHALER
+DCdj - win32kbase!DirectComposition::CSharedWriteDcompTargetMarshaler::_allocate            - DCOMPOSITIONTAG_SHAREDWRITEDCOMPTARGETMARSHALER
+DCdk - win32kbase!DirectComposition::CDcompTargetGroupMarshaler::_allocate                  - DCOMPOSITIONTAG_DCOMPTARGETGROUPMARSHALER
+DCdl - win32kbase!DirectComposition::CCompositionDistantLight::_allocate                    - DCOMPOSITIONTAG_DISTANTLIGHTMARSHALER
+DCds - win32kbase!DirectComposition::CDropShadowMarshaler::_allocate                        - DCOMPOSITIONTAG_DROPSHADOWMARSHALER
+DCef - win32kbase!DirectComposition::CCompiledEffect::_allocate                             - DCOMPOSITIONTAG_COMPILEDEFFECTMARSHALER
+DCeg - win32kbase!DirectComposition::CEffectGroupMarshaler::_allocate                       - DCOMPOSITIONTAG_EFFECTGROUPMARSHALER
+DCem - win32kbase!DirectComposition::CBaseExpressionMarshaler::SetBufferProperty            - DCOMPOSITIONTAG_EXPRESSIONTARGETMASK
+DCdn - win32kbase!DirectComposition::CBaseExpressionMarshaler::SetBufferProperty            - DCOMPOSITIONTAG_DEBUGINFO
+DCep - win32kbase!DirectComposition::CCompiledEffectPropertyBag::_allocate                  - DCOMPOSITIONTAG_COMPILEDEFFECTPROPERTYBAGMARSHALER
+DCet - win32kbase!DirectComposition::CCompiledEffectTemplate::_allocate                     - DCOMPOSITIONTAG_COMPILEDEFFECTTEMPLATEMARSHALER
+DCev - win32kbase!DirectComposition::CEvent::_allocate                                      - DCOMPOSITIONTAG_EVENT
+DCex - win32kbase!DirectComposition::CExpressionMarshaler::_allocate                        - DCOMPOSITIONTAG_EXPRESSIONMARSHALER
+DCfb - win32kbase!DirectComposition::CTableTransferEffectMarshaler::SetBufferProperty       - DCOMPOSITIONTAG_FILTEREFFECTBUFFER
+DCfe - win32kbase!DirectComposition::CFilterEffectMarshaler::_allocate                      - DCOMPOSITIONTAG_FILTEREFFECTMARSHALER
+DCff - win32kbase!DirectComposition::CFilterEffectMarshaler::Initialize                     - DCOMPOSITIONTAG_FILTERINPUTFLAGS
+DCfi - win32kbase!DirectComposition::CFilterEffectMarshaler::Initialize                     - DCOMPOSITIONTAG_FILTERINPUTS
+DCfj - win32kbase!DirectComposition::CFilterEffectMarshaler::Initialize                     - DCOMPOSITIONTAG_SUBRECTINPUTFLAGS
+DCg3 - win32kbase!DirectComposition::CTransform3DGroupMarshaler::_allocate                  - DCOMPOSITIONTAG_TRANSFORM3DGROUPMARSHALER
+DCgb - win32kbase!DirectComposition::CGdiBitmapMarshaler::_allocate                         - DCOMPOSITIONTAG_GDIBITMAPMARSHALER
+DCge - win32kbase!DirectComposition::CGaussianBlurEffectMarshaler::_allocate                - DCOMPOSITIONTAG_GAUSSIANBLUREFFECTMARSHALER
+DChb - win32kbase!DirectComposition::CHwndBitmapMarshaler::_allocate                        - DCOMPOSITIONTAG_HWNDBITMAPMARSHALER
+DCht - win32kbase!DirectComposition::CHwndTargetMarshaler::_allocate                        - DCOMPOSITIONTAG_HWNDTARGETMARSHALER
+DChv - win32kbase!DirectComposition::CHostVisualMarshaler::_allocate                        - DCOMPOSITIONTAG_HOSTVISUALMARSHALER
+DCic - win32kbase!DirectComposition::CInteractionConfigurationGroup::_allocate              - DCOMPOSITIONTAG_INTERACTIONCONFIGURATIONGROUP
+DCik - win32kbase!DirectComposition::CInkMarshaler::_allocate                               - DCOMPOSITIONTAG_INKMARSHALER
+DCpk - win32kbase!DirectComposition::CPencilMarshaler::_allocate                            - DCOMPOSITIONTAG_PENCILMARSHALER
+DCio - win32kbase!DirectComposition::CInteractionMarshaler::_allocate                       - DCOMPOSITIONTAG_INTERACTIONMARSHALER
+DCir - win32kbase!DirectComposition::CInteractionTrackerMarshaler::_allocate                - DCOMPOSITIONTAG_INTERACTIONTRACKERMARSHALER
+DCit - win32kbase!DirectComposition::CInteractionMarshaler::EnsureTouchConfigurationList    - DCOMPOSITIONTAG_INTERACTIONTOUCHCONFIGURATION
+DCjb - win32kbase!DirectComposition::CBackdropBrushMarshaler::_allocate                     - DCOMPOSITIONTAG_BACKDROPBRUSHMARSHALER
+DCjc - win32kbase!DirectComposition::CColorBrushMarshaler::_allocate                        - DCOMPOSITIONTAG_COLORBRUSHMARSHALER
+DCje - win32kbase!DirectComposition::CEffectBrushMarshaler::_allocate                       - DCOMPOSITIONTAG_EFFECTBRUSHMARSHALER
+DCjl - win32kbase!DirectComposition::CLinearGradientBrushMarshaler::_allocate               - DCOMPOSITIONTAG_LINEARGRADIENTBRUSHMARSHALER
+DCjm - win32kbase!DirectComposition::CMaskBrushMarshaler::_allocate                         - DCOMPOSITIONTAG_MASKBRUSHMARSHALER
+DCjn - win32kbase!DirectComposition::CNineGridBrushMarshaler::_allocate                     - DCOMPOSITIONTAG_NINEGRIDBRUSHMARSHALER
+DCjs - win32kbase!DirectComposition::CSurfaceBrushMarshaler::_allocate                      - DCOMPOSITIONTAG_SURFACEBRUSHMARSHALER
+DCkf - win32kbase!DirectComposition::CKeyframeAnimationMarshaler::_allocate                 - DCOMPOSITIONTAG_KEYFRAMEANIMATIONMARSHALER
+DCkt - win32kbase!DirectComposition::CSkewTransformMarshaler::_allocate                     - DCOMPOSITIONTAG_SKEWTRANSFORMMARSHALER
+DClc - win32kbase!DirectComposition::CVisualMarshaler::_allocate                            - DCOMPOSITIONTAG_LAYOUTCONSTRAINTINFO
+DClt - win32kbase!DirectComposition::CLinearObjectTableBase::_allocate                      - DCOMPOSITIONTAG_LINEAROBJECTTABLEDATA
+DCm3 - win32kbase!DirectComposition::CMatrixTransform3DMarshaler::_allocate                 - DCOMPOSITIONTAG_MATRIXTRANSFORM3DMARSHALER
+DCm4 - win32kbase!DirectComposition::CSharedMatrixTransform3DMarshaler::_allocate           - DCOMPOSITIONTAG_SHAREDMATRIXTRANSFORM3DMARSHALER
+DCma - win32kbase!DirectComposition::CManipulationTransformMarshaler::_allocate             - DCOMPOSITIONTAG_MANIPULATIONTRANSFORMMARSHALER
+DCmb - win32kbase!DirectComposition::CSharedManipulationTransformMarshaler::_allocate       - DCOMPOSITIONTAG_SHAREDMANIPULATIONTRANSFORMMARSHALER
+DCmh - win32kbase!DirectComposition::CMessageHandleInfo::_allocate                          - DCOMPOSITIONTAG_MESSAGEHANDLEINFO
+DCmi - win32kbase!DirectComposition::CManipulationMarshaler::_allocate                      - DCOMPOSITIONTAG_MANIPULATIONMARSHALER
+DCmt - win32kbase!DirectComposition::CMatrixTransformMarshaler::_allocate                   - DCOMPOSITIONTAG_MATRIXTRANSFORMMARSHALER
+DCmu - win32kbase!DirectComposition::CSharedReadTransformMarshaler::_allocate               - DCOMPOSITIONTAG_SHAREDREADTRANSFORMMARSHALER
+DCmv - win32kbase!DirectComposition::CSharedMatrixTransformMarshaler::_allocate             - DCOMPOSITIONTAG_SHAREDMATRIXTRANSFORMMARSHALER
+DCnb - win32kbase!DirectComposition::CDeletedNotificationList::EnsureTagAllocation          - DCOMPOSITIONTAG_DELETEDNOTIFICATIONLISTBUFFER
+DCnl - win32kbase!DirectComposition::CDeletedNotificationList::_allocate                    - DCOMPOSITIONTAG_DELETEDNOTIFICATIONLIST
+DCpb - win32kbase!DirectComposition::CPropertyBagMarshaler::_allocate                       - DCOMPOSITIONTAG_PROPERTYBAGMARSHALER
+DCpc - win32kbase!DirectComposition::CPrimitveColorMarshaler::_allocate                     - DCOMPOSITIONTAG_PRIMITIVECOLORMARSHALER
+DCpd - win32kbase!DirectComposition::CProcessData::_allocate                                - DCOMPOSITIONTAG_PROCESSDATA
+DCpe - win32kbase!DirectComposition::CSharedReadPrimitiveColorMarshaler::_allocate          - DCOMPOSITIONTAG_SHAREDREADPRIMITIVECOLORMARSHALER
+DCpf - win32kbase!DirectComposition::CSharedWritePrimitiveColorMarshaler::_allocate         - DCOMPOSITIONTAG_SHAREDWRITEPRIMITIVECOLORMARSHALER
+DCpg - win32kbase!DirectComposition::CPrimitiveGroupMarshaler::_allocate                    - DCOMPOSITIONTAG_PRIMITIVEGROUPMARSHALER
+DCpo - win32kbase!DirectComposition::CCompositionPointLight::_allocate                      - DCOMPOSITIONTAG_POINTLIGHTMARSHALER
+DCpr - win32kbase!DirectComposition::CPrimitiveMarshaler::_allocate                         - DCOMPOSITIONTAG_PRIMITIVEMARSHALER
+DCpx - win32kbase!DirectComposition::CPropertyBagMarshaler::SetBufferProperty               - DCOMPOSITIONTAG_PROPERTYBAGBUFFER
+DCr3 - win32kbase!DirectComposition::CRotateTransform3DMarshaler::_allocate                 - DCOMPOSITIONTAG_ROTATETRANSFORM3DMARSHALER
+DCro - win32kbase!DirectComposition::CRotateTransformMarshaler::_allocate                   - DCOMPOSITIONTAG_ROTATETRANSFORMMARSHALER
+DCrt - win32kbase!DirectComposition::CResourceTable::_allocate                              - DCOMPOSITIONTAG_RESOURCETABLE
+DCs3 - win32kbase!DirectComposition::CScaleTransform3DMarshaler::_allocate                  - DCOMPOSITIONTAG_SCALETRANSFORM3DMARSHALER
+DCsa - win32kbase!DirectComposition::CSnapshotMarshaler::_allocate                          - DCOMPOSITIONTAG_SNAPSHOTMARSHALER
+DCsc - win32kbase!DirectComposition::CSystemChannel::_allocate                              - DCOMPOSITIONTAG_SYSTEMCHANNEL
+DCsd - win32kbase!DirectComposition::CStructDynamicArray::_allocate                         - DCOMPOSITIONTAG_STRUCTDYNAMICARRAY
+DCse - win32kbase!DirectComposition::CSynchronizationManager::_allocate                     - DCOMPOSITIONTAG_SYNCHRONIZATIONENTRY
+DCsi - win32kbase!DirectComposition::CSharedInteractionMarshaler::_allocate                 - DCOMPOSITIONTAG_SHAREDINTERACTIONMARSHALER
+DCsj - win32kbase!DirectComposition::CSharedReadInteractionMarshaler::_allocate             - DCOMPOSITIONTAG_SHAREDREADINTERACTIONMARSHALER
+DCsl - win32kbase!DirectComposition::CScalarMarshaler::_allocate                            - DCOMPOSITIONTAG_SCALARMARSHALER
+DCsm - win32kbase!DirectComposition::CSharedReadScalarMarshaler::_allocate                  - DCOMPOSITIONTAG_SHAREDREADSCALARMARSHALER
+DCsn - win32kbase!DirectComposition::CSharedWriteScalarMarshaler::_allocate                 - DCOMPOSITIONTAG_SHAREDWRITESCALARMARSHALER
+DCso - win32kbase!DirectComposition::CSemaphore::_allocate                                  - DCOMPOSITIONTAG_SEMAPHORE
+DCsp - win32kbase!DirectComposition::CCompositionSpotLight::_allocate                       - DCOMPOSITIONTAG_SPOTLIGHTMARSHALER
+DCss - win32kbase!DirectComposition::CSharedSectionMarshaler                                - DCOMPOSITIONTAG_SHAREDSECTIONMARSHALER
+DCst - win32kbase!DirectComposition::CScaleTransformMarshaler::_allocate                    - DCOMPOSITIONTAG_SCALETRANSFORMMARSHALER
+DCsv - win32kbase!DirectComposition::CSpriteVisualMarshaler::_allocate                      - DCOMPOSITIONTAG_SPRITEVISUALMARSHALER
+DCsw - win32kbase!DirectComposition::CCompositionSurfaceWrapperMarshaler::_allocate         - DCOMPOSITIONTAG_SURFACEWRAPPERMARSHALER
+DCt3 - win32kbase!DirectComposition::CTranslateTransform3DMarshaler::_allocate              - DCOMPOSITIONTAG_TRANSLATETRANSFORM3DMARSHALER
+DCtg - win32kbase!DirectComposition::CTransformGroupMarshaler::_allocate                    - DCOMPOSITIONTAG_TRANSFORMGROUPMARSHALER
+DCto - win32kbase!DirectComposition::CTelemetryInfo::_allocate                              - DCOMPOSITIONTAG_TELEMETRYINFO
+DCts - win32kbase!DirectComposition::_allocate                                              - DCOMPOSITIONTAG_TELEMETRYSTRING
+DCtt - win32kbase!DirectComposition::CTranslateTransformMarshaler::_allocate                - DCOMPOSITIONTAG_TRANSLATETRANSFORMMARSHALER
+DCtv - win32kbase!DirectComposition::CTargetVisualMarshaler::_allocate                      - DCOMPOSITIONTAG_TARGETVISUALMARSHALER
+DCrc - win32kbase!DirectComposition::CRectangleClipMarshaler::_allocate                     - DCOMPOSITIONTAG_RECTANGLECLIPMARSHALER
+DCvc - win32kbase!DirectComposition::CVisualMarshaler::AllocateChildrenArray                - DCOMPOSITIONTAG_VISUALMARSHALERCHILDREN
+DCvi - win32kbase!DirectComposition::CVisualMarshaler::_allocate                            - DCOMPOSITIONTAG_VISUALMARSHALER
+DCtc - win32kbase!DirectComposition::CTileClumpMarshaler::_allocate                         - DCOMPOSITIONTAG_TILECLUMPMARSHALER
+DCvs - win32kbase!DirectComposition::CVirtualSurfaceMarshaler::_allocate                    - DCOMPOSITIONTAG_VIRTUALSURFACEMARSHALER
+DCwr - win32kbase!DirectComposition::CWeakReferenceBase::_allocate                          - DCOMPOSITIONTAG_WEAKREFERENCE
+DCwt - win32kbase!DirectComposition::CApplicationChannel::GetWeakReferenceBase              - DCOMPOSITIONTAG_WEAKREFERENCETABLEENTRY
+DCxc - win32kbase!DirectComposition::CCrossChannelChildVisualMarshaler::_allocate           - DCOMPOSITIONTAG_CROSSCHANNELCHILDVISUALMARSHALER
+DCxp - win32kbase!DirectComposition::CCrossChannelParentVisualMarshaler::_allocate          - DCOMPOSITIONTAG_CROSSCHANNELPARENTVISUALMARSHALER
+DCys - win32kbase!DirectComposition::CYCbCrSurfaceMarshaler::_allocate                      - DCOMPOSITIONTAG_YCBCRSURFACEMARSHALER
+CSMb - win32k!CCompositionBuffer::Create        - COMPOSITIONSURFACEMANAGER_BUFFER
+CSMr - win32k!CBufferRealization::Create        - COMPOSITIONSURFACEMANAGER_REALIZATION
+TMcb - win32k!CCompositionToken::Initialize                 - TOKENMANAGER_COMPOSITIONTOKENBUFFER
+TMlt - win32k!CTokenManager::EnsureLegacyTokenBuffer        - TOKENMANAGER_LEGACYTOKENBUFFER
+TMsg - win32k!CreateSessionTokenManager                     - TOKENMANAGER_SESSIONGLOBAL
+TMtb - win32k!CLegacyTokenBuffer::TokenBlock::Create        - TOKENMANAGER_TOKENBLOCK
+TMte - win32k!CTokenManager::TokenQueueTableEntry::Allocate - TOKENMANAGER_TOKENQUEUETABLEENTRY
+TMto - win32k!CToken::Create                                - TOKENMANAGER_TOKENOBJECT
+TMtq - win32k!CTokenQueue::Create                           - TOKENMANAGER_TOKENQUEUE
+IMhq - win32k!CInputQueue::Create                           - INPUTMANAGER_INPUTQUEUE
+IMsg - win32k!CInputManager::Create                         - INPUTMANAGER_SESSIONGLOBAL
+


### PR DESCRIPTION
This PR migrates PoolMon from the plugins-extra into ExtendedTools.

![image](https://user-images.githubusercontent.com/11687482/188284514-bf61a5cf-b10e-49f3-bc30-1e327b246afb.png)

![image](https://user-images.githubusercontent.com/11687482/188284534-69d914ca-10f2-403c-b5d1-6ffc2c6382d4.png)

![image](https://user-images.githubusercontent.com/11687482/188284763-30e9a8b5-bdec-40bf-b646-2a70f46d40e0.png)

