### PR TITLE
driver ps set apis

### DIFF
--- a/KSystemInformer/comms_handlers.c
+++ b/KSystemInformer/comms_handlers.c
@@ -30,6 +30,8 @@ KPHM_DEFINE_HANDLER(KphpCommsSetInformationObject);
 KPHM_DEFINE_HANDLER(KphpCommsOpenDriver);
 KPHM_DEFINE_HANDLER(KphpCommsQueryInformationDriver);
 KPHM_DEFINE_HANDLER(KphpCommsQueryInformationProcess);
+KPHM_DEFINE_HANDLER(KphpCommsSetInformationProcess);
+KPHM_DEFINE_HANDLER(KphpCommsSetInformationThread);
 
 KPHM_DEFINE_REQUIRED_STATE(KphpCommsRequireMaximum);
 KPHM_DEFINE_REQUIRED_STATE(KphpCommsRequireMedium);
@@ -60,6 +62,8 @@ KPH_MESSAGE_HANDLER KphCommsMessageHandlers[] =
 { KphMsgOpenDriver,                  KphpCommsOpenDriver,                  KphpCommsRequireMaximum },
 { KphMsgQueryInformationDriver,      KphpCommsQueryInformationDriver,      KphpCommsRequireMaximum },
 { KphMsgQueryInformationProcess,     KphpCommsQueryInformationProcess,     KphpCommsQueryInformationProcessRequires },
+{ KphMsgSetInformationProcess,       KphpCommsSetInformationProcess,       KphpCommsRequireMaximum },
+{ KphMsgSetInformationThread,        KphpCommsSetInformationThread,        KphpCommsRequireMaximum },
 };
 
 ULONG KphCommsMessageHandlerCount = ARRAYSIZE(KphCommsMessageHandlers);
@@ -629,6 +633,54 @@ NTSTATUS KSIAPI KphpCommsQueryInformationProcess(
                                              msg->ProcessInformationLength,
                                              msg->ReturnLength,
                                              UserMode);
+
+    return STATUS_SUCCESS;
+}
+
+_Function_class_(KPHM_HANDLER)
+_IRQL_requires_max_(PASSIVE_LEVEL)
+_Must_inspect_result_
+NTSTATUS KSIAPI KphpCommsSetInformationProcess(
+    _Inout_ PKPH_MESSAGE Message
+    )
+{
+    PKPHM_SET_INFORMATION_PROCESS msg;
+
+    PAGED_PASSIVE();
+    NT_ASSERT(ExGetPreviousMode() == UserMode);
+    NT_ASSERT(Message->Header.MessageId == KphMsgSetInformationProcess);
+
+    msg = &Message->User.SetInformationProcess;
+
+    msg->Status = KphSetInformationProcess(msg->ProcessHandle,
+                                           msg->ProcessInformationClass,
+                                           msg->ProcessInformation,
+                                           msg->ProcessInformationLength,
+                                           UserMode);
+
+    return STATUS_SUCCESS;
+}
+
+_Function_class_(KPHM_HANDLER)
+_IRQL_requires_max_(PASSIVE_LEVEL)
+_Must_inspect_result_
+NTSTATUS KSIAPI KphpCommsSetInformationThread(
+    _Inout_ PKPH_MESSAGE Message
+    )
+{
+    PKPHM_SET_INFORMATION_THREAD msg;
+
+    PAGED_PASSIVE();
+    NT_ASSERT(ExGetPreviousMode() == UserMode);
+    NT_ASSERT(Message->Header.MessageId == KphMsgSetInformationThread);
+
+    msg = &Message->User.SetInformationThread;
+
+    msg->Status = KphSetInformationThread(msg->ThreadHandle,
+                                          msg->ThreadInformationClass,
+                                          msg->ThreadInformation,
+                                          msg->ThreadInformationLength,
+                                          UserMode);
 
     return STATUS_SUCCESS;
 }

--- a/KSystemInformer/include/kph.h
+++ b/KSystemInformer/include/kph.h
@@ -399,6 +399,16 @@ NTSTATUS KphQueryInformationProcess(
     _In_ KPROCESSOR_MODE AccessMode
     );
 
+_IRQL_requires_max_(PASSIVE_LEVEL)
+_Must_inspect_result_
+NTSTATUS KphSetInformationProcess(
+    _In_ HANDLE ProcessHandle,
+    _In_ KPH_PROCESS_INFORMATION_CLASS ProcessInformationClass,
+    _In_reads_bytes_(ProcessInformationLength) PVOID ProcessInformation,
+    _In_ ULONG ProcessInformationLength,
+    _In_ KPROCESSOR_MODE AccessMode
+    );
+
 _IRQL_requires_max_(APC_LEVEL)
 _Must_inspect_result_
 NTSTATUS KphGetProcessProtection(
@@ -491,6 +501,16 @@ NTSTATUS KphCaptureStackBackTraceThreadByHandle(
     _In_ KPROCESSOR_MODE AccessMode,
     _In_ ULONG Flags,
     _In_opt_ PLARGE_INTEGER Timeout
+    );
+
+_IRQL_requires_max_(PASSIVE_LEVEL)
+_Must_inspect_result_
+NTSTATUS KphSetInformationThread(
+    _In_ HANDLE ThreadHandle,
+    _In_ KPH_THREAD_INFORMATION_CLASS ThreadInformationClass,
+    _In_reads_bytes_(ThreadInformationLength) PVOID ThreadInformation,
+    _In_ ULONG ThreadInformationLength,
+    _In_ KPROCESSOR_MODE AccessMode
     );
 
 // util
@@ -723,13 +743,6 @@ _IRQL_requires_max_(PASSIVE_LEVEL)
 BOOLEAN KphSinglePrivilegeCheck(
     _In_ LUID PrivilegeValue,
     _In_ KPROCESSOR_MODE AccessMode
-    );
-
-_IRQL_requires_max_(PASSIVE_LEVEL)
-NTSTATUS KphCheckMembership(
-    _In_ PSECURITY_SUBJECT_CONTEXT SubjectSecurityContext,
-    _In_ PSID SidToCheck,
-    _Out_ PBOOLEAN IsMember
     );
 
 // vm

--- a/KSystemInformer/include/ntfill.h
+++ b/KSystemInformer/include/ntfill.h
@@ -632,6 +632,21 @@ PsIsProcessBeingDebugged(
     _In_ PEPROCESS Process
     );
 
+NTKERNELAPI
+NTSTATUS
+NTAPI
+ZwSetInformationProcess(
+    _In_ HANDLE ProcessHandle,
+    _In_ PROCESSINFOCLASS ProcessInformationClass,
+    _In_reads_bytes_(ProcessInformationLength) PVOID ProcessInformation,
+    _In_ ULONG ProcessInformationLength
+    );
+
+#define ProcessPowerThrottlingState    77
+#define ProcessPriorityClassEx        108
+
+#define ThreadPowerThrottlingState     49
+
 // RTL
 
 #ifndef RTL_MAX_DRIVE_LETTERS

--- a/KSystemInformer/include/pooltags.h
+++ b/KSystemInformer/include/pooltags.h
@@ -33,9 +33,14 @@
 
 #define KPH_TAG_OBJECT_QUERY                    '0OpK'
 
+// process
+
+#define KPH_TAG_PROCESS_INFO                    '0PpK'
+
 // thread
 
 #define KPH_TAG_BACKTRACE                       '0TpK'
+#define KPH_TAG_THREAD_INFO                     '1TpK'
 
 // util
 
@@ -82,4 +87,4 @@
 
 // protection
 
-#define KPH_TAG_IMAGE_LOAD_APC                  '0PpK'
+#define KPH_TAG_IMAGE_LOAD_APC                  '0ppK'

--- a/SystemInformer/SystemInformer.def
+++ b/SystemInformer/SystemInformer.def
@@ -338,6 +338,9 @@ EXPORTS
     PhUpdateDosDevicePrefixes
     PhUpdateMupDevicePrefixes
     PhWaitForNamedPipe
+    PhSetProcessPriorityBoost
+    PhSetThreadBasePriority
+    PhSetThreadIoPriority
 
 ; phutil
     PhAdjustRectangleToBounds

--- a/kphlib/include/kphapi.h
+++ b/kphlib/include/kphapi.h
@@ -99,10 +99,37 @@ typedef KPH_PROCESS_STATE* PKPH_PROCESS_STATE;
 
 typedef enum _KPH_PROCESS_INFORMATION_CLASS
 {
-    KphProcessBasicInformation, // q: KPH_PROCESS_BASIC_INFORMATION
-    KphProcessStateInformation, // q: KPH_PROCESS_STATE
+    KphProcessBasicInformation,      // q: KPH_PROCESS_BASIC_INFORMATION
+    KphProcessStateInformation,      // q: KPH_PROCESS_STATE
+    KphProcessQuotaLimits,           // s: QUOTA_LIMITS
+    KphProcessBasePriority,          // s: KPRIORITY
+    KphProcessRaisePriority,         // s: ULONG
+    KphProcessPriorityClass,         // s: PROCESS_PRIORITY_CLASS
+    KphProcessAffinityMask,          // s: KAFFINITY/GROUP_AFFINITY
+    KphProcessPriorityBoost,         // s: ULONG
+    KphProcessIoPriority,            // s: IO_PRIORITY_HINT
+    KphProcessPagePriority,          // s: PAGE_PRIORITY_INFORMATION
+    KphProcessPowerThrottlingState,  // s: POWER_THROTTLING_PROCESS_STATE
+    KphProcessPriorityClassEx,       // s: PROCESS_PRIORITY_CLASS_EX
 
 } KPH_PROCESS_INFORMATION_CLASS;
+
+typedef enum _KPH_THREAD_INFORMATION_CLASS
+{
+    KphThreadPriority,               // s: KPRIORITY
+    KphThreadBasePriority,           // s: KPRIORITY
+    KphThreadAffinityMask,           // s: KAFFINITY
+    KphThreadIdealProcessor,         // s: ULONG
+    KphThreadPriorityBoost,          // s: ULONG
+    KphThreadIoPriority,             // s: IO_PRIORITY_HINT
+    KphThreadPagePriority,           // s: PAGE_PRIORITY_INFORMATION 
+    KphThreadActualBasePriority,     // s: LONG
+    KphThreadGroupInformation,       // s: GROUP_AFFINITY
+    KphThreadIdealProcessorEx,       // s: PROCESSOR_NUMBER
+    KphThreadActualGroupAffinity,    // s: GROUP_AFFINITY
+    KphThreadPowerThrottlingState,   // s: POWER_THROTTLING_THREAD_STATE
+
+} KPH_THREAD_INFORMATION_CLASS;
 
 typedef struct _KPH_PROCESS_BASIC_INFORMATION
 {

--- a/kphlib/include/kphmsg.h
+++ b/kphlib/include/kphmsg.h
@@ -40,6 +40,8 @@ typedef enum _KPH_MESSAGE_ID
     KphMsgOpenDriver,
     KphMsgQueryInformationDriver,
     KphMsgQueryInformationProcess,
+    KphMsgSetInformationProcess,
+    KphMsgSetInformationThread,
 
     MaxKphMsgClient,
     MaxKphMsgClientAllowed = 0x40000000,
@@ -150,6 +152,8 @@ typedef struct _KPH_MESSAGE
             KPHM_OPEN_DRIVER OpenDriver;
             KPHM_QUERY_INFORMATION_DRIVER QueryInformationDriver;
             KPHM_QUERY_INFORMATION_PROCESS QueryInformationProcess;
+            KPHM_SET_INFORMATION_PROCESS SetInformationProcess;
+            KPHM_SET_INFORMATION_THREAD SetInformationThread;
 
         } User;
 

--- a/kphlib/include/kphmsgdefs.h
+++ b/kphlib/include/kphmsgdefs.h
@@ -175,6 +175,26 @@ typedef struct _KPHM_QUERY_INFORMATION_PROCESS
 
 } KPHM_QUERY_INFORMATION_PROCESS, *PKPHM_QUERY_INFORMATION_PROCESS;
 
+typedef struct _KPHM_SET_INFORMATION_PROCESS
+{
+    NTSTATUS Status;
+    HANDLE ProcessHandle;
+    KPH_PROCESS_INFORMATION_CLASS ProcessInformationClass;
+    PVOID ProcessInformation;
+    ULONG ProcessInformationLength;
+
+} KPHM_SET_INFORMATION_PROCESS, *PKPHM_SET_INFORMATION_PROCESS;
+
+typedef struct _KPHM_SET_INFORMATION_THREAD
+{
+    NTSTATUS Status;
+    HANDLE ThreadHandle;
+    KPH_THREAD_INFORMATION_CLASS ThreadInformationClass;
+    PVOID ThreadInformation;
+    ULONG ThreadInformationLength;
+
+} KPHM_SET_INFORMATION_THREAD, *PKPHM_SET_INFORMATION_THREAD;
+
 //
 // KPH -> PH
 //

--- a/phlib/include/kphuser.h
+++ b/phlib/include/kphuser.h
@@ -261,6 +261,26 @@ KphLevel(
     VOID
     );
 
+PHLIBAPI
+NTSTATUS
+NTAPI
+KphSetInformationProcess(
+    _In_ HANDLE ProcessHandle,
+    _In_ KPH_PROCESS_INFORMATION_CLASS ProcessInformationClass,
+    _In_reads_bytes_(ProcessInformationLength) PVOID ProcessInformation,
+    _In_ ULONG ProcessInformationLength
+    );
+
+PHLIBAPI
+NTSTATUS
+NTAPI
+KphSetInformationThread(
+    _In_ HANDLE ThreadHandle,
+    _In_ KPH_THREAD_INFORMATION_CLASS ThreadInformationClass,
+    _In_reads_bytes_(ThreadInformationLength) PVOID ThreadInformation,
+    _In_ ULONG ThreadInformationLength
+    );
+
 // kphdata
 
 PHLIBAPI

--- a/phlib/include/phnative.h
+++ b/phlib/include/phnative.h
@@ -865,6 +865,71 @@ PhSetProcessModuleLoadCount32(
     );
 
 PHLIBAPI
+NTSTATUS
+NTAPI
+PhSetProcessQuotaLimits(
+    _In_ HANDLE ProcessHandle,
+    _In_ QUOTA_LIMITS QuotaLimits
+    );
+
+PHLIBAPI
+NTSTATUS
+NTAPI
+PhSetProcessPriority(
+    _In_ HANDLE ProcessHandle,
+    _In_ PROCESS_PRIORITY_CLASS PriorityClass
+    );
+
+PHLIBAPI
+NTSTATUS
+NTAPI
+PhSetProcessIoPriority(
+    _In_ HANDLE ProcessHandle,
+    _In_ IO_PRIORITY_HINT IoPriority
+    );
+
+PHLIBAPI
+NTSTATUS
+NTAPI
+PhSetProcessPagePriority(
+    _In_ HANDLE ProcessHandle,
+    _In_ ULONG PagePriority
+    );
+
+PHLIBAPI
+NTSTATUS
+NTAPI
+PhSetProcessPriorityBoost(
+    _In_ HANDLE ProcessHandle,
+    _In_ BOOLEAN PriorityBoost
+    );
+
+PHLIBAPI
+NTSTATUS
+NTAPI
+PhSetProcessAffinityMask(
+    _In_ HANDLE ProcessHandle,
+    _In_ KAFFINITY AffinityMask
+    );
+
+PHLIBAPI
+NTSTATUS
+NTAPI
+PhSetProcessGroupAffinity(
+    _In_ HANDLE ProcessHandle,
+    _In_ GROUP_AFFINITY GroupAffinity
+    );
+
+PHLIBAPI
+NTSTATUS
+NTAPI
+PhSetProcessPowerThrottlingState(
+    _In_ HANDLE ProcessHandle,
+    _In_ ULONG ControlMask,
+    _In_ ULONG StateMask
+    );
+
+PHLIBAPI
 PVOID
 NTAPI
 PhGetDllHandle(
@@ -1785,6 +1850,63 @@ NTAPI
 PhSetThreadName(
     _In_ HANDLE ThreadHandle,
     _In_ PCWSTR ThreadName
+    );
+
+PHLIBAPI
+NTSTATUS
+NTAPI
+PhSetThreadAffinityMask(
+    _In_ HANDLE ThreadHandle,
+    _In_ KAFFINITY AffinityMask
+    );
+
+PHLIBAPI
+NTSTATUS
+NTAPI
+PhSetThreadBasePriority(
+    _In_ HANDLE ThreadHandle,
+    _In_ KPRIORITY Increment
+    );
+
+PHLIBAPI
+NTSTATUS
+NTAPI
+PhSetThreadIoPriority(
+    _In_ HANDLE ThreadHandle,
+    _In_ IO_PRIORITY_HINT IoPriority
+    );
+
+PHLIBAPI
+NTSTATUS
+NTAPI
+PhSetThreadPagePriority(
+    _In_ HANDLE ThreadHandle,
+    _In_ ULONG PagePriority
+    );
+
+PHLIBAPI
+NTSTATUS
+NTAPI
+PhSetThreadPriorityBoost(
+    _In_ HANDLE ThreadHandle,
+    _In_ BOOLEAN PriorityBoost
+    );
+
+PHLIBAPI
+NTSTATUS
+NTAPI
+PhSetThreadIdealProcessor(
+    _In_ HANDLE ThreadHandle,
+    _In_ PPROCESSOR_NUMBER ProcessorNumber,
+    _Out_opt_ PPROCESSOR_NUMBER PreviousIdealProcessor
+    );
+
+PHLIBAPI
+NTSTATUS
+NTAPI
+PhSetThreadGroupAffinity(
+    _In_ HANDLE ThreadHandle,
+    _In_ GROUP_AFFINITY GroupAffinity
     );
 
 PHLIBAPI

--- a/phlib/include/phnativeinl.h
+++ b/phlib/include/phnativeinl.h
@@ -301,21 +301,6 @@ PhGetProcessPriority(
         );
 }
 
-FORCEINLINE
-NTSTATUS
-PhSetProcessPriority(
-    _In_ HANDLE ProcessHandle,
-    _In_ PROCESS_PRIORITY_CLASS PriorityClass
-    )
-{
-    return NtSetInformationProcess(
-        ProcessHandle, 
-        ProcessPriorityClass, 
-        &PriorityClass,
-        sizeof(PROCESS_PRIORITY_CLASS)
-        );
-}
-
 /**
  * Gets a process' I/O priority.
  *
@@ -336,27 +321,6 @@ PhGetProcessIoPriority(
         IoPriority,
         sizeof(IO_PRIORITY_HINT),
         NULL
-        );
-}
-
-/**
- * Sets a process' I/O priority.
- *
- * \param ProcessHandle A handle to a process. The handle must have PROCESS_SET_INFORMATION access.
- * \param IoPriority The new I/O priority.
- */
-FORCEINLINE
-NTSTATUS
-PhSetProcessIoPriority(
-    _In_ HANDLE ProcessHandle,
-    _In_ IO_PRIORITY_HINT IoPriority
-    )
-{
-    return NtSetInformationProcess(
-        ProcessHandle,
-        ProcessIoPriority,
-        &IoPriority,
-        sizeof(IO_PRIORITY_HINT)
         );
 }
 
@@ -395,25 +359,6 @@ PhGetProcessPagePriority(
 
 FORCEINLINE
 NTSTATUS
-PhSetProcessPagePriority(
-    _In_ HANDLE ProcessHandle,
-    _In_ ULONG PagePriority
-    )
-{
-    PAGE_PRIORITY_INFORMATION pagePriorityInfo;
-
-    pagePriorityInfo.PagePriority = PagePriority;
-
-    return NtSetInformationProcess(
-        ProcessHandle,
-        ProcessPagePriority,
-        &pagePriorityInfo,
-        sizeof(PAGE_PRIORITY_INFORMATION)
-        );
-}
-
-FORCEINLINE
-NTSTATUS
 PhGetProcessPriorityBoost(
     _In_ HANDLE ProcessHandle,
     _Out_ PBOOLEAN PriorityBoost
@@ -436,25 +381,6 @@ PhGetProcessPriorityBoost(
     }
 
     return status;
-}
-
-FORCEINLINE
-NTSTATUS
-PhSetProcessPriorityBoost(
-    _In_ HANDLE ProcessHandle,
-    _In_ BOOLEAN PriorityBoost
-    )
-{
-    ULONG priorityBoost;
-
-    priorityBoost = PriorityBoost ? 1 : 0;
-
-    return NtSetInformationProcess(
-        ProcessHandle,
-        ProcessPriorityBoost,
-        &priorityBoost,
-        sizeof(ULONG)
-        );
 }
 
 /**
@@ -576,21 +502,6 @@ PhGetProcessQuotaLimits(
 
 FORCEINLINE
 NTSTATUS
-PhSetProcessQuotaLimits(
-    _In_ HANDLE ProcessHandle,
-    _In_ QUOTA_LIMITS QuotaLimits
-    )
-{
-    return NtSetInformationProcess(
-        ProcessHandle,
-        ProcessQuotaLimits,
-        &QuotaLimits,
-        sizeof(QUOTA_LIMITS)
-        );
-}
-
-FORCEINLINE
-NTSTATUS
 PhSetProcessEmptyWorkingSet(
     _In_ HANDLE ProcessHandle
     )
@@ -645,27 +556,6 @@ PhGetProcessAffinityMask(
     }
 
     return status;
-}
-
-/**
- * Sets a process' affinity mask.
- *
- * \param ProcessHandle A handle to a process. The handle must have PROCESS_SET_INFORMATION access.
- * \param AffinityMask The new affinity mask.
- */
-FORCEINLINE
-NTSTATUS
-PhSetProcessAffinityMask(
-    _In_ HANDLE ProcessHandle,
-    _In_ KAFFINITY AffinityMask
-    )
-{
-    return NtSetInformationProcess(
-        ProcessHandle,
-        ProcessAffinityMask,
-        &AffinityMask,
-        sizeof(KAFFINITY)
-        );
 }
 
 FORCEINLINE
@@ -733,21 +623,6 @@ PhGetProcessGroupAffinity(
     }
 
     return status;
-}
-
-FORCEINLINE
-NTSTATUS
-PhSetProcessGroupAffinity(
-    _In_ HANDLE ProcessHandle,
-    _In_ GROUP_AFFINITY GroupAffinity
-    )
-{
-    return NtSetInformationProcess(
-        ProcessHandle,
-        ProcessAffinityMask,
-        &GroupAffinity,
-        sizeof(GROUP_AFFINITY)
-        );
 }
 
 FORCEINLINE
@@ -930,29 +805,6 @@ PhGetProcessPowerThrottlingState(
     return status;
 }
 
-FORCEINLINE
-NTSTATUS
-PhSetProcessPowerThrottlingState(
-    _In_ HANDLE ProcessHandle,
-    _In_ ULONG ControlMask,
-    _In_ ULONG StateMask
-    )
-{
-    POWER_THROTTLING_PROCESS_STATE powerThrottlingState;
-
-    memset(&powerThrottlingState, 0, sizeof(POWER_THROTTLING_PROCESS_STATE));
-    powerThrottlingState.Version = POWER_THROTTLING_PROCESS_CURRENT_VERSION;
-    powerThrottlingState.ControlMask = ControlMask;
-    powerThrottlingState.StateMask = StateMask;
-
-    return NtSetInformationProcess(
-        ProcessHandle,
-        ProcessPowerThrottlingState,
-        &powerThrottlingState,
-        sizeof(POWER_THROTTLING_PROCESS_STATE)
-        );
-}
-
 /**
  * Gets basic information for a thread.
  *
@@ -1020,21 +872,6 @@ PhGetThreadStartAddress(
         );
 }
 
-FORCEINLINE
-NTSTATUS
-PhSetThreadBasePriority(
-    _In_ HANDLE ThreadHandle,
-    _In_ KPRIORITY Increment
-    )
-{
-    return NtSetInformationThread(
-        ThreadHandle,
-        ThreadBasePriority,
-        &Increment,
-        sizeof(KPRIORITY)
-        );
-}
-
 /**
  * Gets a thread's I/O priority.
  *
@@ -1055,28 +892,6 @@ PhGetThreadIoPriority(
         IoPriority,
         sizeof(IO_PRIORITY_HINT),
         NULL
-        );
-}
-
-/**
- * Sets a thread's I/O priority.
- *
- * \param ThreadHandle A handle to a thread. The handle must have THREAD_SET_LIMITED_INFORMATION
- * access.
- * \param IoPriority The new I/O priority.
- */
-FORCEINLINE
-NTSTATUS
-PhSetThreadIoPriority(
-    _In_ HANDLE ThreadHandle,
-    _In_ IO_PRIORITY_HINT IoPriority
-    )
-{
-    return NtSetInformationThread(
-        ThreadHandle,
-        ThreadIoPriority,
-        &IoPriority,
-        sizeof(IO_PRIORITY_HINT)
         );
 }
 
@@ -1115,25 +930,6 @@ PhGetThreadPagePriority(
 
 FORCEINLINE
 NTSTATUS
-PhSetThreadPagePriority(
-    _In_ HANDLE ThreadHandle,
-    _In_ ULONG PagePriority
-    )
-{
-    PAGE_PRIORITY_INFORMATION pagePriorityInfo;
-
-    pagePriorityInfo.PagePriority = PagePriority;
-
-    return NtSetInformationThread(
-        ThreadHandle,
-        ThreadPagePriority,
-        &pagePriorityInfo,
-        sizeof(PAGE_PRIORITY_INFORMATION)
-        );
-}
-
-FORCEINLINE
-NTSTATUS
 PhGetThreadPriorityBoost(
     _In_ HANDLE ThreadHandle,
     _Out_ PBOOLEAN PriorityBoost
@@ -1156,25 +952,6 @@ PhGetThreadPriorityBoost(
     }
 
     return status;
-}
-
-FORCEINLINE
-NTSTATUS
-PhSetThreadPriorityBoost(
-    _In_ HANDLE ThreadHandle,
-    _In_ BOOLEAN PriorityBoost
-    )
-{
-    ULONG priorityBoost;
-
-    priorityBoost = PriorityBoost ? 1 : 0;
-
-    return NtSetInformationThread(
-        ThreadHandle,
-        ThreadPriorityBoost,
-        &priorityBoost,
-        sizeof(ULONG)
-        );
 }
 
 /**
@@ -1224,31 +1001,6 @@ PhGetThreadIdealProcessor(
         sizeof(PROCESSOR_NUMBER),
         NULL
         );
-}
-
-FORCEINLINE
-NTSTATUS
-PhSetThreadIdealProcessor(
-    _In_ HANDLE ThreadHandle,
-    _In_ PPROCESSOR_NUMBER ProcessorNumber,
-    _Out_opt_ PPROCESSOR_NUMBER PreviousIdealProcessor
-    )
-{
-    NTSTATUS status;
-    PROCESSOR_NUMBER processorNumber;
-
-    processorNumber = *ProcessorNumber;
-    status = NtSetInformationThread(
-        ThreadHandle,
-        ThreadIdealProcessorEx,
-        &processorNumber,
-        sizeof(PROCESSOR_NUMBER)
-        );
-
-    if (PreviousIdealProcessor)
-        *PreviousIdealProcessor = processorNumber;
-
-    return status;
 }
 
 FORCEINLINE
@@ -1447,28 +1199,6 @@ PhGetThreadAffinityMask(
     //    );
 }
 
-/**
- * Sets a thread's affinity mask.
- *
- * \param ThreadHandle A handle to a thread. The handle must have THREAD_SET_LIMITED_INFORMATION
- * access.
- * \param AffinityMask The new affinity mask.
- */
-FORCEINLINE
-NTSTATUS
-PhSetThreadAffinityMask(
-    _In_ HANDLE ThreadHandle,
-    _In_ KAFFINITY AffinityMask
-    )
-{
-    return NtSetInformationThread(
-        ThreadHandle,
-        ThreadAffinityMask,
-        &AffinityMask,
-        sizeof(KAFFINITY)
-        );
-}
-
 FORCEINLINE
 NTSTATUS
 PhGetThreadGroupAffinity(
@@ -1482,21 +1212,6 @@ PhGetThreadGroupAffinity(
         GroupAffinity,
         sizeof(GROUP_AFFINITY),
         NULL
-        );
-}
-
-FORCEINLINE
-NTSTATUS
-PhSetThreadGroupAffinity(
-    _In_ HANDLE ThreadHandle,
-    _In_ GROUP_AFFINITY GroupAffinity
-    )
-{
-    return NtSetInformationThread(
-        ThreadHandle,
-        ThreadGroupInformation,
-        &GroupAffinity,
-        sizeof(GROUP_AFFINITY)
         );
 }
 

--- a/phlib/kph.c
+++ b/phlib/kph.c
@@ -1199,3 +1199,69 @@ KPH_LEVEL KphLevel(
 {
     return KphProcessLevel(NtCurrentProcess());
 }
+
+NTSTATUS KphSetInformationProcess(
+    _In_ HANDLE ProcessHandle,
+    _In_ KPH_PROCESS_INFORMATION_CLASS ProcessInformationClass,
+    _In_reads_bytes_(ProcessInformationLength) PVOID ProcessInformation,
+    _In_ ULONG ProcessInformationLength
+    )
+{
+    NTSTATUS status;
+    PKPH_MESSAGE msg;
+
+    msg = PhAllocate(sizeof(KPH_MESSAGE));
+
+    KphMsgInit(msg, KphMsgSetInformationProcess);
+
+    msg->User.SetInformationProcess.ProcessHandle = ProcessHandle;
+    msg->User.SetInformationProcess.ProcessInformationClass = ProcessInformationClass;
+    msg->User.SetInformationProcess.ProcessInformation = ProcessInformation;
+    msg->User.SetInformationProcess.ProcessInformationLength = ProcessInformationLength;
+
+    status = KphCommsSendMessage(msg);
+    if (!NT_SUCCESS(status))
+    {
+        PhFree(msg);
+        return status;
+    }
+
+    status = msg->User.SetInformationProcess.Status;
+
+    PhFree(msg);
+
+    return status;
+}
+
+NTSTATUS KphSetInformationThread(
+    _In_ HANDLE ThreadHandle,
+    _In_ KPH_THREAD_INFORMATION_CLASS ThreadInformationClass,
+    _In_reads_bytes_(ThreadInformationLength) PVOID ThreadInformation,
+    _In_ ULONG ThreadInformationLength
+    )
+{
+    NTSTATUS status;
+    PKPH_MESSAGE msg;
+
+    msg = PhAllocate(sizeof(KPH_MESSAGE));
+
+    KphMsgInit(msg, KphMsgSetInformationThread);
+
+    msg->User.SetInformationThread.ThreadHandle = ThreadHandle;
+    msg->User.SetInformationThread.ThreadInformationClass = ThreadInformationClass;
+    msg->User.SetInformationThread.ThreadInformation = ThreadInformation;
+    msg->User.SetInformationThread.ThreadInformationLength = ThreadInformationLength;
+
+    status = KphCommsSendMessage(msg);
+    if (!NT_SUCCESS(status))
+    {
+        PhFree(msg);
+        return status;
+    }
+
+    status = msg->User.SetInformationThread.Status;
+
+    PhFree(msg);
+
+    return status;
+}

--- a/phlib/native.c
+++ b/phlib/native.c
@@ -5098,6 +5098,247 @@ NTSTATUS PhSetProcessModuleLoadCount32(
     return context.Status;
 }
 
+NTSTATUS PhSetProcessQuotaLimits(
+    _In_ HANDLE ProcessHandle,
+    _In_ QUOTA_LIMITS QuotaLimits
+    )
+{
+    NTSTATUS status;
+
+    status = NtSetInformationProcess(
+        ProcessHandle,
+        ProcessQuotaLimits,
+        &QuotaLimits,
+        sizeof(QUOTA_LIMITS)
+        );
+
+    if ((status == STATUS_ACCESS_DENIED) && (KphLevel() == KphLevelMax))
+    {
+        status = KphSetInformationProcess(
+            ProcessHandle, 
+            KphProcessQuotaLimits,
+            &QuotaLimits,
+            sizeof(QUOTA_LIMITS)
+            );
+    }
+
+    return status;
+}
+
+NTSTATUS PhSetProcessPriority(
+    _In_ HANDLE ProcessHandle,
+    _In_ PROCESS_PRIORITY_CLASS PriorityClass
+    )
+{
+    NTSTATUS status;
+
+    status = NtSetInformationProcess(
+        ProcessHandle, 
+        ProcessPriorityClass, 
+        &PriorityClass,
+        sizeof(PROCESS_PRIORITY_CLASS)
+        );
+
+    if ((status == STATUS_ACCESS_DENIED) && (KphLevel() == KphLevelMax))
+    {
+        status = KphSetInformationProcess(
+            ProcessHandle, 
+            KphProcessPriorityClass, 
+            &PriorityClass,
+            sizeof(PROCESS_PRIORITY_CLASS)
+            );
+    }
+
+    return status;
+}
+
+/**
+ * Sets a process' I/O priority.
+ *
+ * \param ProcessHandle A handle to a process. The handle must have PROCESS_SET_INFORMATION access.
+ * \param IoPriority The new I/O priority.
+ */
+NTSTATUS PhSetProcessIoPriority(
+    _In_ HANDLE ProcessHandle,
+    _In_ IO_PRIORITY_HINT IoPriority
+    )
+{
+    NTSTATUS status;
+
+    status = NtSetInformationProcess(
+        ProcessHandle,
+        ProcessIoPriority,
+        &IoPriority,
+        sizeof(IO_PRIORITY_HINT)
+        );
+
+    if ((status == STATUS_ACCESS_DENIED) && (KphLevel() == KphLevelMax))
+    {
+        status = KphSetInformationProcess(
+            ProcessHandle, 
+            KphProcessIoPriority,
+            &IoPriority,
+            sizeof(IO_PRIORITY_HINT)
+            );
+    }
+
+    return status;
+}
+
+NTSTATUS PhSetProcessPagePriority(
+    _In_ HANDLE ProcessHandle,
+    _In_ ULONG PagePriority
+    )
+{
+    NTSTATUS status;
+    PAGE_PRIORITY_INFORMATION pagePriorityInfo;
+
+    pagePriorityInfo.PagePriority = PagePriority;
+
+    status = NtSetInformationProcess(
+        ProcessHandle,
+        ProcessPagePriority,
+        &pagePriorityInfo,
+        sizeof(PAGE_PRIORITY_INFORMATION)
+        );
+
+    if ((status == STATUS_ACCESS_DENIED) && (KphLevel() == KphLevelMax))
+    {
+        status = KphSetInformationProcess(
+            ProcessHandle,
+            KphProcessPagePriority,
+            &pagePriorityInfo,
+            sizeof(PAGE_PRIORITY_INFORMATION)
+            );
+    }
+
+    return status;
+}
+
+NTSTATUS PhSetProcessPriorityBoost(
+    _In_ HANDLE ProcessHandle,
+    _In_ BOOLEAN PriorityBoost
+    )
+{
+    NTSTATUS status;
+    ULONG priorityBoost;
+
+    priorityBoost = PriorityBoost ? 1 : 0;
+
+    status = NtSetInformationProcess(
+        ProcessHandle,
+        ProcessPriorityBoost,
+        &priorityBoost,
+        sizeof(ULONG)
+        );
+
+    if ((status == STATUS_ACCESS_DENIED) && (KphLevel() == KphLevelMax))
+    {
+        status = KphSetInformationProcess(
+            ProcessHandle,
+            KphProcessPriorityBoost,
+            &priorityBoost,
+            sizeof(ULONG)
+            );
+    }
+
+    return status;
+}
+
+/**
+ * Sets a process' affinity mask.
+ *
+ * \param ProcessHandle A handle to a process. The handle must have PROCESS_SET_INFORMATION access.
+ * \param AffinityMask The new affinity mask.
+ */
+NTSTATUS PhSetProcessAffinityMask(
+    _In_ HANDLE ProcessHandle,
+    _In_ KAFFINITY AffinityMask
+    )
+{
+    NTSTATUS status;
+
+    status = NtSetInformationProcess(
+        ProcessHandle,
+        ProcessAffinityMask,
+        &AffinityMask,
+        sizeof(KAFFINITY)
+        );
+
+    if ((status == STATUS_ACCESS_DENIED) && (KphLevel() == KphLevelMax))
+    {
+        status = KphSetInformationProcess(
+            ProcessHandle,
+            KphProcessAffinityMask,
+            &AffinityMask,
+            sizeof(KAFFINITY)
+            );
+    }
+
+    return status;
+}
+
+NTSTATUS PhSetProcessGroupAffinity(
+    _In_ HANDLE ProcessHandle,
+    _In_ GROUP_AFFINITY GroupAffinity
+    )
+{
+    NTSTATUS status;
+
+    status = NtSetInformationProcess(
+        ProcessHandle,
+        ProcessAffinityMask,
+        &GroupAffinity,
+        sizeof(GROUP_AFFINITY)
+        );
+
+    if ((status == STATUS_ACCESS_DENIED) && (KphLevel() == KphLevelMax))
+    {
+        status = KphSetInformationProcess(
+            ProcessHandle,
+            KphProcessAffinityMask,
+            &GroupAffinity,
+            sizeof(GROUP_AFFINITY)
+            );
+    }
+
+    return status;
+}
+
+NTSTATUS PhSetProcessPowerThrottlingState(
+    _In_ HANDLE ProcessHandle,
+    _In_ ULONG ControlMask,
+    _In_ ULONG StateMask
+    )
+{
+    NTSTATUS status;
+    POWER_THROTTLING_PROCESS_STATE powerThrottlingState;
+
+    memset(&powerThrottlingState, 0, sizeof(POWER_THROTTLING_PROCESS_STATE));
+    powerThrottlingState.Version = POWER_THROTTLING_PROCESS_CURRENT_VERSION;
+    powerThrottlingState.ControlMask = ControlMask;
+    powerThrottlingState.StateMask = StateMask;
+
+    status = NtSetInformationProcess(
+        ProcessHandle,
+        ProcessPowerThrottlingState,
+        &powerThrottlingState,
+        sizeof(POWER_THROTTLING_PROCESS_STATE)
+        );
+
+    if ((status == STATUS_ACCESS_DENIED) && (KphLevel() == KphLevelMax))
+    {
+        status = KphSetInformationProcess(
+            ProcessHandle,
+            KphProcessPowerThrottlingState,
+            &powerThrottlingState,
+            sizeof(POWER_THROTTLING_PROCESS_STATE)
+            );
+    }
+
+    return status;
+}
+
 PVOID PhGetDllHandle(
     _In_ PWSTR DllName
     )
@@ -10304,6 +10545,222 @@ NTSTATUS PhSetThreadName(
         sizeof(THREAD_NAME_INFORMATION)
         );
 }
+
+/**
+ * Sets a thread's affinity mask.
+ *
+ * \param ThreadHandle A handle to a thread. The handle must have THREAD_SET_LIMITED_INFORMATION
+ * access.
+ * \param AffinityMask The new affinity mask.
+ */
+NTSTATUS PhSetThreadAffinityMask(
+    _In_ HANDLE ThreadHandle,
+    _In_ KAFFINITY AffinityMask
+    )
+{
+    NTSTATUS status;
+
+    status = NtSetInformationThread(
+        ThreadHandle,
+        ThreadAffinityMask,
+        &AffinityMask,
+        sizeof(KAFFINITY)
+        );
+
+    if ((status == STATUS_ACCESS_DENIED) && (KphLevel() == KphLevelMax))
+    {
+        status = KphSetInformationThread(
+            ThreadHandle,
+            KphThreadAffinityMask,
+            &AffinityMask,
+            sizeof(KAFFINITY)
+            );
+    }
+
+    return status;
+}
+
+NTSTATUS PhSetThreadBasePriority(
+    _In_ HANDLE ThreadHandle,
+    _In_ KPRIORITY Increment
+    )
+{
+    NTSTATUS status;
+
+    status = NtSetInformationThread(
+        ThreadHandle,
+        ThreadBasePriority,
+        &Increment,
+        sizeof(KPRIORITY)
+        );
+
+    if ((status == STATUS_ACCESS_DENIED) && (KphLevel() == KphLevelMax))
+    {
+        status = KphSetInformationThread(
+            ThreadHandle,
+            KphThreadBasePriority,
+            &Increment,
+            sizeof(KPRIORITY)
+            );
+    }
+
+    return status;
+}
+
+/**
+ * Sets a thread's I/O priority.
+ *
+ * \param ThreadHandle A handle to a thread. The handle must have THREAD_SET_LIMITED_INFORMATION
+ * access.
+ * \param IoPriority The new I/O priority.
+ */
+NTSTATUS PhSetThreadIoPriority(
+    _In_ HANDLE ThreadHandle,
+    _In_ IO_PRIORITY_HINT IoPriority
+    )
+{
+    NTSTATUS status;
+
+    status = NtSetInformationThread(
+        ThreadHandle,
+        ThreadIoPriority,
+        &IoPriority,
+        sizeof(IO_PRIORITY_HINT)
+        );
+
+    if ((status == STATUS_ACCESS_DENIED) && (KphLevel() == KphLevelMax))
+    {
+        status = KphSetInformationThread(
+            ThreadHandle,
+            KphThreadIoPriority,
+            &IoPriority,
+            sizeof(IO_PRIORITY_HINT)
+            );
+    }
+
+    return status;
+}
+
+NTSTATUS PhSetThreadPagePriority(
+    _In_ HANDLE ThreadHandle,
+    _In_ ULONG PagePriority
+    )
+{
+    NTSTATUS status;
+    PAGE_PRIORITY_INFORMATION pagePriorityInfo;
+
+    pagePriorityInfo.PagePriority = PagePriority;
+
+    status = NtSetInformationThread(
+        ThreadHandle,
+        ThreadPagePriority,
+        &pagePriorityInfo,
+        sizeof(PAGE_PRIORITY_INFORMATION)
+        );
+
+    if ((status == STATUS_ACCESS_DENIED) && (KphLevel() == KphLevelMax))
+    {
+        status = KphSetInformationThread(
+            ThreadHandle,
+            KphThreadPagePriority,
+            &pagePriorityInfo,
+            sizeof(PAGE_PRIORITY_INFORMATION)
+            );
+    }
+
+    return status;
+}
+
+NTSTATUS PhSetThreadPriorityBoost(
+    _In_ HANDLE ThreadHandle,
+    _In_ BOOLEAN PriorityBoost
+    )
+{
+    NTSTATUS status;
+    ULONG priorityBoost;
+
+    priorityBoost = PriorityBoost ? 1 : 0;
+
+    status = NtSetInformationThread(
+        ThreadHandle,
+        ThreadPriorityBoost,
+        &priorityBoost,
+        sizeof(ULONG)
+        );
+
+    if ((status == STATUS_ACCESS_DENIED) && (KphLevel() == KphLevelMax))
+    {
+        status = KphSetInformationThread(
+            ThreadHandle,
+            KphThreadPriorityBoost,
+            &priorityBoost,
+            sizeof(ULONG)
+            );
+    }
+
+    return status;
+}
+
+NTSTATUS PhSetThreadIdealProcessor(
+    _In_ HANDLE ThreadHandle,
+    _In_ PPROCESSOR_NUMBER ProcessorNumber,
+    _Out_opt_ PPROCESSOR_NUMBER PreviousIdealProcessor
+    )
+{
+    NTSTATUS status;
+    PROCESSOR_NUMBER processorNumber;
+
+    processorNumber = *ProcessorNumber;
+    status = NtSetInformationThread(
+        ThreadHandle,
+        ThreadIdealProcessorEx,
+        &processorNumber,
+        sizeof(PROCESSOR_NUMBER)
+        );
+
+    if ((status == STATUS_ACCESS_DENIED) && (KphLevel() == KphLevelMax))
+    {
+        status = KphSetInformationThread(
+            ThreadHandle,
+            KphThreadIdealProcessorEx,
+            &processorNumber,
+            sizeof(PROCESSOR_NUMBER)
+            );
+    }
+
+    if (PreviousIdealProcessor)
+        *PreviousIdealProcessor = processorNumber;
+
+    return status;
+}
+
+NTSTATUS PhSetThreadGroupAffinity(
+    _In_ HANDLE ThreadHandle,
+    _In_ GROUP_AFFINITY GroupAffinity
+    )
+{
+    NTSTATUS status;
+
+    status = NtSetInformationThread(
+        ThreadHandle,
+        ThreadGroupInformation,
+        &GroupAffinity,
+        sizeof(GROUP_AFFINITY)
+        );
+
+    if ((status == STATUS_ACCESS_DENIED) && (KphLevel() == KphLevelMax))
+    {
+        status = KphSetInformationThread(
+            ThreadHandle,
+            KphThreadGroupInformation,
+            &GroupAffinity,
+            sizeof(GROUP_AFFINITY)
+            );
+    }
+
+    return status;
+}
+
 
 NTSTATUS PhImpersonateToken(
     _In_ HANDLE ThreadHandle,

--- a/phlib/workqueue.c
+++ b/phlib/workqueue.c
@@ -14,6 +14,7 @@
 
 #include <phintrnl.h>
 #include <phnativeinl.h>
+#include <phnative.h>
 
 #include <workqueuep.h>
 

--- a/phnt/include/ntpsapi.h
+++ b/phnt/include/ntpsapi.h
@@ -148,7 +148,7 @@ typedef enum _PROCESSINFOCLASS
     ProcessCookie, // q: ULONG
     ProcessImageInformation, // q: SECTION_IMAGE_INFORMATION
     ProcessCycleTime, // q: PROCESS_CYCLE_TIME_INFORMATION // since VISTA
-    ProcessPagePriority, // q: PAGE_PRIORITY_INFORMATION
+    ProcessPagePriority, // qs: PAGE_PRIORITY_INFORMATION
     ProcessInstrumentationCallback, // s: PVOID or PROCESS_INSTRUMENTATION_CALLBACK_INFORMATION // 40
     ProcessThreadStackAllocation, // s: PROCESS_STACK_ALLOCATION_INFORMATION, PROCESS_STACK_ALLOCATION_INFORMATION_EX
     ProcessWorkingSetWatchEx, // q: PROCESS_WS_WATCH_INFORMATION_EX[]
@@ -217,10 +217,10 @@ typedef enum _PROCESSINFOCLASS
     ProcessEnableOptionalXStateFeatures,
     ProcessAltPrefetchParam, // since 22H1
     ProcessAssignCpuPartitions,
-    ProcessPriorityClassEx,
+    ProcessPriorityClassEx, // s: PROCESS_PRIORITY_CLASS_EX
     ProcessMembershipInformation,
-    ProcessEffectiveIoPriority,
-    ProcessEffectivePagePriority,
+    ProcessEffectiveIoPriority, // q: IO_PRIORITY_HINT
+    ProcessEffectivePagePriority, // q: ULONG
     MaxProcessInfoClass
 } PROCESSINFOCLASS;
 #endif
@@ -252,7 +252,7 @@ typedef enum _THREADINFOCLASS
     ThreadLastSystemCall, // q: THREAD_LAST_SYSCALL_INFORMATION
     ThreadIoPriority, // qs: IO_PRIORITY_HINT (requires SeIncreaseBasePriorityPrivilege)
     ThreadCycleTime, // q: THREAD_CYCLE_TIME_INFORMATION
-    ThreadPagePriority, // q: ULONG
+    ThreadPagePriority, // qs: PAGE_PRIORITY_INFORMATION
     ThreadActualBasePriority, // s: LONG (requires SeIncreaseBasePriorityPrivilege)
     ThreadTebInformation, // q: THREAD_TEB_INFORMATION (requires THREAD_GET_CONTEXT + THREAD_SET_CONTEXT)
     ThreadCSwitchMon,
@@ -282,8 +282,8 @@ typedef enum _THREADINFOCLASS
     ThreadCreateStateChange, // since WIN11
     ThreadApplyStateChange,
     ThreadStrongerBadHandleChecks, // since 22H1
-    ThreadEffectiveIoPriority,
-    ThreadEffectivePagePriority,
+    ThreadEffectiveIoPriority, // q: IO_PRIORITY_HINT
+    ThreadEffectivePagePriority, // q: ULONG
     MaxThreadInfoClass
 } THREADINFOCLASS;
 #endif
@@ -449,6 +449,21 @@ typedef struct _PROCESS_PRIORITY_CLASS
     BOOLEAN Foreground;
     UCHAR PriorityClass;
 } PROCESS_PRIORITY_CLASS, *PPROCESS_PRIORITY_CLASS;
+
+typedef struct _PROCESS_PRIORITY_CLASS_EX
+{
+    union
+    {
+        struct
+        {
+            USHORT ForegroundValid : 1;
+            USHORT PriorityClassValid : 1;
+        };
+        USHORT AllFlags;
+    };
+    UCHAR PriorityClass;
+    BOOLEAN Foreground;
+} PROCESS_PRIORITY_CLASS_EX, *PPROCESS_PRIORITY_CLASS_EX;
 
 typedef struct _PROCESS_FOREGROUND_BACKGROUND
 {


### PR DESCRIPTION
Implements a limited number process executive set APIs through driver. These APIs are restricted to clients with maximum state and do not permit manipulation across a protected process domination boundary. This enables a client, when connected to the driver, to manipulate a small set of performance related properties about a thread or process when handle stripping may have otherwise prevented it.