### PR TITLE
Fix a typo

### DIFF
--- a/tools/peview/ldprp.c
+++ b/tools/peview/ldprp.c
@@ -347,7 +347,7 @@ INT_PTR CALLBACK PvPeLoadConfigDlgProc(
                 { \
                     ADD_VALUE(L"CFG guard flags", PH_AUTO_T(PH_STRING, PvpGetPeGuardFlagsText((Config)->GuardFlags))->Buffer); \
                     ADD_VALUE(L"CFG check-function pointer", PhaFormatString(L"0x%Ix", (Config)->GuardCFCheckFunctionPointer)->Buffer); \
-                    ADD_VALUE(L"CFG check-function pointer", PhaFormatString(L"0x%Ix", (Config)->GuardCFDispatchFunctionPointer)->Buffer); \
+                    ADD_VALUE(L"CFG dispatch-function pointer", PhaFormatString(L"0x%Ix", (Config)->GuardCFDispatchFunctionPointer)->Buffer); \
                     ADD_VALUE(L"CFG function table", PhaFormatString(L"0x%Ix", (Config)->GuardCFFunctionTable)->Buffer); \
                     ADD_VALUE(L"CFG function table count", PhaFormatUInt64((Config)->GuardCFFunctionCount, TRUE)->Buffer); \
                     if (RTL_CONTAINS_FIELD((Config), (Config)->Size, GuardAddressTakenIatEntryTable)) \


### PR DESCRIPTION
According to the \`\`[PE Format](https://docs.microsoft.com/en-us/windows/win32/debug/pe-format#load-configuration-layout)'' article published on MSDN, the `GuardCFDispatchFunctionPointer` field of the load configuration structure is "the VA where Control Flow Guard **dispatch**-function pointer is stored".  Just like the `GuardXFGDispatchFunctionPointer` field below is a "**dispatch**-function".  I believe "*check*-function" was a typo in ldprp.c.
