### PR TITLE
Fix bug in network tab related to hash table.

### DIFF
--- a/SystemInformer/netprv.c
+++ b/SystemInformer/netprv.c
@@ -110,7 +110,7 @@ BOOLEAN PhNetworkProviderInitialization(
     RtlInitializeSListHead(&PhNetworkItemQueryListHead);
 
     PhpResolveCacheHashtable = PhCreateHashtable(
-        sizeof(PHP_RESOLVE_CACHE_ITEM),
+        sizeof(PPHP_RESOLVE_CACHE_ITEM),
         PhpResolveCacheHashtableEqualFunction,
         PhpResolveCacheHashtableHashFunction,
         20


### PR DESCRIPTION
Hash table in network tab is configured to accept items of type PHP_RESOLVE_CACHE_ITEM in its constructor, but every other operation on it (except the constructor) is using element type of PPHP_RESOLVE_CACHE_ITEM instead. This causes stack overflow read when adding new item into it. The table is reading 32 bytes out of the stack, where only 8 bytes are prepared for it by its user.