### PR TITLE
Fix bug in environment tab related to hash table.

### DIFF
--- a/SystemInformer/prpgenv.c
+++ b/SystemInformer/prpgenv.c
@@ -1280,7 +1280,7 @@ VOID PhpInitializeEnvironmentTree(
     Context->NodeList = PhCreateList(100);
     Context->NodeRootList = PhCreateList(30);
     Context->NodeHashtable = PhCreateHashtable(
-        sizeof(PHP_PROCESS_ENVIRONMENT_TREENODE),
+        sizeof(PPHP_PROCESS_ENVIRONMENT_TREENODE),
         PhpEnvironmentNodeHashtableEqualFunction,
         PhpEnvironmentNodeHashtableHashFunction,
         100


### PR DESCRIPTION
Hash table in environment tab is configured to accept items of type PHP_PROCESS_ENVIRONMENT_TREENODE in its constructor, but every other operation on it (except the constructor) is using element type of PPHP_PROCESS_ENVIRONMENT_TREENODE instead. This causes stack overflow read when adding new item into it. The table is reading 152 bytes out of the stack, where only 8 bytes are prepared for it by its user.