### PR TITLE
Added clean commands to the build_thirdparty.cmd file.

### DIFF
--- a/build/build_thirdparty.cmd
+++ b/build/build_thirdparty.cmd
@@ -17,6 +17,11 @@ if exist "%VSINSTALLPATH%\VC\Auxiliary\Build\vcvarsall.bat" (
    goto end
 )
 
+msbuild /m tools\thirdparty\thirdparty.sln -property:Configuration=Debug -property:Platform=x86 /t:Clean -verbosity:normal
+msbuild /m tools\thirdparty\thirdparty.sln -property:Configuration=Release -property:Platform=x86 /t:Clean -verbosity:normal
+msbuild /m tools\thirdparty\thirdparty.sln -property:Configuration=Debug -property:Platform=x64 /t:Clean -verbosity:normal
+msbuild /m tools\thirdparty\thirdparty.sln -property:Configuration=Release -property:Platform=x64 /t:Clean -verbosity:normal
+
 msbuild /m tools\thirdparty\thirdparty.sln -property:Configuration=Debug -property:Platform=x86 -verbosity:normal
 if %ERRORLEVEL% neq 0 goto end
 


### PR DESCRIPTION
Added clean commands to the build_thirdparty.cmd file to fix situations where "fatal error C1047" might occur. Simply building the third-party lib files isn't enough, you have to do a clean operation first.