### PR TITLE
CustomBuildTool: Fixed build error if a "kph.key" file doesn't exist.

### DIFF
--- a/tools/CustomBuildTool/Build.cs
+++ b/tools/CustomBuildTool/Build.cs
@@ -171,7 +171,7 @@ namespace CustomBuildTool
                     }
                 }
             }
-            catch (Exception) {  }
+            catch (Exception) { }
 
             if (
                 string.IsNullOrWhiteSpace(BuildBranch) ||
@@ -560,8 +560,7 @@ namespace CustomBuildTool
 
                                 if (BuildNightly)
                                 {
-                                    if (File.Exists(Verify.GetPath("kph.key")))
-                                        File.Delete(Verify.GetPath("kph.key"));
+                                    File.Delete(PathToKPHKeyFile);
                                 }
 
                                 return false;
@@ -617,22 +616,26 @@ namespace CustomBuildTool
 
                 File.WriteAllText(sigfile, string.Empty);
 
-                int errorcode = Win32.CreateProcess(
-                    CustomSignToolPath,
-                    $"sign -k {Verify.GetPath("kph.key")} {PluginName} -s {sigfile}",
-                    out string _
-                    );
+                string PathToKPHKeyFile = Verify.GetPath("kph.key");
 
-                if (BuildNightly)
+                if (File.Exists(PathToKPHKeyFile))
                 {
-                    if (File.Exists(Verify.GetPath("kph.key")))
-                        File.Delete(Verify.GetPath("kph.key"));
-                }
+                    int errorcode = Win32.CreateProcess(
+                        CustomSignToolPath,
+                        $"sign -k {PathToKPHKeyFile} {PluginName} -s {sigfile}",
+                        out string _
+                        );
 
-                if (errorcode != 0)
-                {
-                    Program.PrintColorMessage("[SignPlugin] (" + errorcode + ") ", ConsoleColor.Red, true, BuildFlags.BuildVerbose);
-                    return false;
+                    if (BuildNightly)
+                    {
+                        File.Delete(PathToKPHKeyFile);
+                    }
+
+                    if (errorcode != 0)
+                    {
+                        Program.PrintColorMessage("[SignPlugin] (" + errorcode + ") ", ConsoleColor.Red, true, BuildFlags.BuildVerbose);
+                        return false;
+                    }
                 }
             }
 
@@ -1317,9 +1320,9 @@ namespace CustomBuildTool
                         filename = Path.GetFileName(sourceFile);
                         //filename = filename.Replace("-build-", $"-{BuildVersion}-", StringComparison.OrdinalIgnoreCase);
 
-#pragma warning disable SYSLIB0014 // Type or member is obsolete
+                        #pragma warning disable SYSLIB0014 // Type or member is obsolete
                         request = (FtpWebRequest)WebRequest.Create(buildPostUrl + filename);
-#pragma warning restore SYSLIB0014 // Type or member is obsolete
+                        #pragma warning restore SYSLIB0014 // Type or member is obsolete
                         request.Credentials = new NetworkCredential(buildPostKey, buildPostName);
                         request.Method = WebRequestMethods.Ftp.UploadFile;
                         request.Timeout = System.Threading.Timeout.Infinite;
@@ -1468,7 +1471,7 @@ namespace CustomBuildTool
 
             if (!mirror.Valid)
             {
-                Program.PrintColorMessage("[Github-Valid]" , ConsoleColor.Red);
+                Program.PrintColorMessage("[Github-Valid]", ConsoleColor.Red);
                 return null;
             }
 

--- a/tools/CustomBuildTool/Build.cs
+++ b/tools/CustomBuildTool/Build.cs
@@ -536,31 +536,36 @@ namespace CustomBuildTool
                     }
                 }
 
-                foreach (var file in files)
+                string PathToKPHKeyFile = Verify.GetPath("kph.key");
+
+                if (File.Exists(PathToKPHKeyFile))
                 {
-                    if (File.Exists(file))
+                    foreach (var file in files)
                     {
-                        var sigfile = Path.ChangeExtension(file, ".sig");
-
-                        File.WriteAllText(sigfile, string.Empty);
-
-                        int errorcode = Win32.CreateProcess(
-                            CustomSignToolPath,
-                            $"sign -k {Verify.GetPath("kph.key")} {file} -s {sigfile}",
-                            out string _
-                            );
-
-                        if (errorcode != 0)
+                        if (File.Exists(file))
                         {
-                            Program.PrintColorMessage("[CopyKernelDriver] (" + errorcode + ") ", ConsoleColor.Red, true, BuildFlags.BuildVerbose);
+                            var sigfile = Path.ChangeExtension(file, ".sig");
 
-                            if (BuildNightly)
+                            File.WriteAllText(sigfile, string.Empty);
+
+                            int errorcode = Win32.CreateProcess(
+                                CustomSignToolPath,
+                                $"sign -k {PathToKPHKeyFile} {file} -s {sigfile}",
+                                out string _
+                                );
+
+                            if (errorcode != 0)
                             {
-                                if (File.Exists(Verify.GetPath("kph.key")))
-                                    File.Delete(Verify.GetPath("kph.key"));
-                            }
+                                Program.PrintColorMessage("[CopyKernelDriver] (" + errorcode + ") ", ConsoleColor.Red, true, BuildFlags.BuildVerbose);
 
-                            return false;
+                                if (BuildNightly)
+                                {
+                                    if (File.Exists(Verify.GetPath("kph.key")))
+                                        File.Delete(Verify.GetPath("kph.key"));
+                                }
+
+                                return false;
+                            }
                         }
                     }
                 }
@@ -574,7 +579,7 @@ namespace CustomBuildTool
 
             return true;
         }
-        
+
         public static bool SignPlugin(string PluginName)
         {
             if (!File.Exists(PluginName))
@@ -1312,9 +1317,9 @@ namespace CustomBuildTool
                         filename = Path.GetFileName(sourceFile);
                         //filename = filename.Replace("-build-", $"-{BuildVersion}-", StringComparison.OrdinalIgnoreCase);
 
-                        #pragma warning disable SYSLIB0014 // Type or member is obsolete
+#pragma warning disable SYSLIB0014 // Type or member is obsolete
                         request = (FtpWebRequest)WebRequest.Create(buildPostUrl + filename);
-                        #pragma warning restore SYSLIB0014 // Type or member is obsolete
+#pragma warning restore SYSLIB0014 // Type or member is obsolete
                         request.Credentials = new NetworkCredential(buildPostKey, buildPostName);
                         request.Method = WebRequestMethods.Ftp.UploadFile;
                         request.Timeout = System.Threading.Timeout.Infinite;


### PR DESCRIPTION
I had error "[CopyKernelDriver] (1)" during compile, I determined that the cause of the error was because the "kph.key" file didn't exist. I included code to check for the existence of a "kph.key" file.