### PR TITLE
Enable theme support for settings windows

### DIFF
--- a/SystemInformer/options.c
+++ b/SystemInformer/options.c
@@ -2240,6 +2240,8 @@ static INT_PTR CALLBACK PhpOptionsAdvancedEditDlgProc(
             EnableWindow(GetDlgItem(hwndDlg, IDC_NAME), FALSE);
 
             PhSetDialogFocus(hwndDlg, GetDlgItem(hwndDlg, IDCANCEL));
+
+            PhInitializeWindowTheme(hwndDlg, PhEnableThemeSupport);
         }
         break;
     case WM_DESTROY:


### PR DESCRIPTION
Settings window doesn't support Dark theme

![image](https://user-images.githubusercontent.com/5801389/203265064-5588a240-fab9-40cf-94cf-cedd02317674.png)

With this change it looks better

![image](https://user-images.githubusercontent.com/5801389/203264755-d7b4a8b8-429d-4ec1-804d-3bae322a0589.png)
