### PR TITLE
Display AppContainer integrity and not Low for AppContainers

### DIFF
--- a/phlib/native.c
+++ b/phlib/native.c
@@ -3018,6 +3018,7 @@ NTSTATUS PhGetTokenIntegrityLevelRID(
     ULONG subAuthoritiesCount;
     ULONG subAuthority;
     PWSTR integrityString;
+    BOOLEAN isAppContainer;
 
     status = PhpQueryTokenVariableSize(TokenHandle, TokenIntegrityLevel, &mandatoryLabel);
 
@@ -3039,32 +3040,42 @@ NTSTATUS PhGetTokenIntegrityLevelRID(
 
     if (IntegrityString)
     {
-        switch (subAuthority)
+        isAppContainer = FALSE;
+        PhGetTokenIsAppContainer(TokenHandle, &isAppContainer);
+
+        if (isAppContainer)
         {
-        case SECURITY_MANDATORY_UNTRUSTED_RID:
-            integrityString = L"Untrusted";
-            break;
-        case SECURITY_MANDATORY_LOW_RID:
-            integrityString = L"Low";
-            break;
-        case SECURITY_MANDATORY_MEDIUM_RID:
-            integrityString = L"Medium";
-            break;
-        case SECURITY_MANDATORY_MEDIUM_PLUS_RID:
-            integrityString = L"Medium +";
-            break;
-        case SECURITY_MANDATORY_HIGH_RID:
-            integrityString = L"High";
-            break;
-        case SECURITY_MANDATORY_SYSTEM_RID:
-            integrityString = L"System";
-            break;
-        case SECURITY_MANDATORY_PROTECTED_PROCESS_RID:
-            integrityString = L"Protected";
-            break;
-        default:
-            integrityString = L"Other";
-            break;
+            integrityString = L"AppContainer";
+        }
+        else
+        {
+            switch (subAuthority)
+            {
+            case SECURITY_MANDATORY_UNTRUSTED_RID:
+                integrityString = L"Untrusted";
+                break;
+            case SECURITY_MANDATORY_LOW_RID:
+                integrityString = L"Low";
+                break;
+            case SECURITY_MANDATORY_MEDIUM_RID:
+                integrityString = L"Medium";
+                break;
+            case SECURITY_MANDATORY_MEDIUM_PLUS_RID:
+                integrityString = L"Medium +";
+                break;
+            case SECURITY_MANDATORY_HIGH_RID:
+                integrityString = L"High";
+                break;
+            case SECURITY_MANDATORY_SYSTEM_RID:
+                integrityString = L"System";
+                break;
+            case SECURITY_MANDATORY_PROTECTED_PROCESS_RID:
+                integrityString = L"Protected";
+                break;
+            default:
+                integrityString = L"Other";
+                break;
+            }
         }
 
         *IntegrityString = integrityString;


### PR DESCRIPTION
This is just an idea and feel free to close the PR if you don't like it, but it makes more sense to display integrity as `AppContainer` for stuff that runs inside container like Process Explorer does rather than `Low`.

![image](https://user-images.githubusercontent.com/5801389/203735033-62c63b99-fc95-4dd1-8108-b1f5cee541b8.png)

