### PR TITLE
ToolStatus: Fix process search cancelling

### DIFF
--- a/plugins/ToolStatus/main.c
+++ b/plugins/ToolStatus/main.c
@@ -685,13 +685,10 @@ LRESULT CALLBACK MainWndSubclassProc(
                         // Cache the current search text for our callback.
                         PhSwapReference(&SearchboxText, newSearchboxText);
 
-                        if (!PhIsNullOrEmptyString(SearchboxText))
-                        {
-                            // Expand the nodes to ensure that they will be visible to the user.
-                            PhExpandAllProcessNodes(TRUE);
-                            PhDeselectAllProcessNodes();
-                            PhDeselectAllServiceNodes();
-                        }
+                        // Expand the nodes to ensure that they will be visible to the user.
+                        PhExpandAllProcessNodes(TRUE);
+                        PhDeselectAllProcessNodes();
+                        PhDeselectAllServiceNodes();
 
                         PhApplyTreeNewFilters(PhGetFilterSupportProcessTreeList());
                         PhApplyTreeNewFilters(PhGetFilterSupportServiceTreeList());


### PR DESCRIPTION
Properly deselect process nodes also if process search was cancelled (either by clicking 'x' button or providing empty string).

Otherwise it could happen that process that is part of collapsed tree will remain selected and that will cause various issues. For example properties for different process may be displayed, because SI thinks some other process is selected (than the one user clicked on).