### PR TITLE
Revert "Tidy up PhSetValueKeyZ"

### DIFF
--- a/phlib/include/phnative.h
+++ b/phlib/include/phnative.h
@@ -1698,23 +1698,36 @@ NTSTATUS
 NTAPI
 PhSetValueKeyZ(
     _In_ HANDLE KeyHandle,
-    _In_ PWSTR ValueName,
+    _In_opt_ PWSTR ValueName,
     _In_ ULONG ValueType,
     _In_ PVOID Buffer,
     _In_ ULONG BufferLength
     )
 {
-    PH_STRINGREF valueName;
+    if (ValueName)
+    {
+        PH_STRINGREF valueNameSr;
 
-    PhInitializeStringRef(&valueName, ValueName);
+        PhInitializeStringRef(&valueNameSr, ValueName);
 
-    return PhSetValueKey(
-        KeyHandle,
-        &valueName,
-        ValueType,
-        Buffer,
-        BufferLength
-        );
+        return PhSetValueKey(
+            KeyHandle,
+            &valueNameSr,
+            ValueType,
+            Buffer,
+            BufferLength
+            );
+    }
+    else
+    {
+        return PhSetValueKey(
+            KeyHandle,
+            NULL,
+            ValueType,
+            Buffer,
+            BufferLength
+            );
+    }
 }
 
 PHLIBAPI
@@ -1737,7 +1750,10 @@ PhDeleteValueKeyZ(
 
     PhInitializeStringRef(&valueName, ValueName);
 
-    return PhDeleteValueKey(KeyHandle, &valueName);
+    return PhDeleteValueKey(
+        KeyHandle,
+        &valueName
+        );
 }
 
 typedef BOOLEAN (NTAPI *PPH_ENUM_KEY_CALLBACK)(


### PR DESCRIPTION
This reverts commit cd886e0a399e70212da71fe433fb276e4e172d97.

Something went wrong with this commit in which any setups that are created with this commit fail at this part...
![2023-02-07 (2)](https://user-images.githubusercontent.com/32105035/217542482-d92e2a51-de57-4afe-b13d-b7fc86fd3acf.png)
and die.

Reverting this one single commit fixes things and allows for a setup to install properly.
