### PR TITLE
Delete tree functions in context menu for childless process

### DIFF
--- a/SystemInformer/mwpgproc.c
+++ b/SystemInformer/mwpgproc.c
@@ -577,6 +577,18 @@ VOID PhMwpInitializeProcessMenu(
             }
         }
 
+        // Delete tree functions if the process has no children
+        PPH_PROCESS_NODE node = PhFindProcessNode(Processes[0]->ProcessId);
+        if (!(node->Children && node->Children->Count))
+        {
+            if (item = PhFindEMenuItem(Menu, 0, NULL, ID_PROCESS_TERMINATETREE))
+                PhDestroyEMenuItem(item);
+            if (item = PhFindEMenuItem(Menu, 0, NULL, ID_PROCESS_SUSPENDTREE))
+                PhDestroyEMenuItem(item);
+            if (item = PhFindEMenuItem(Menu, 0, NULL, ID_PROCESS_RESUMETREE))
+                PhDestroyEMenuItem(item);
+        }
+
         // Eco mode
         if (WindowsVersion < WINDOWS_10_RS4)
         {


### PR DESCRIPTION
This is a fix for #1611. ~~I don't think we should remove the buttons but disable them instead.~~