### PR TITLE
Set process Control Flow Guard (CFG ) policy

### DIFF
--- a/SystemInformer/main.c
+++ b/SystemInformer/main.c
@@ -107,6 +107,11 @@ INT WINAPI wWinMain(
     _In_ INT CmdShow
     )
 {
+    PROCESS_MITIGATION_CONTROL_FLOW_GUARD_POLICY controlFlowGuardPolicy;
+    controlFlowGuardPolicy.Flags = 0;
+    controlFlowGuardPolicy.StrictMode = 1;
+    SetProcessMitigationPolicy(ProcessControlFlowGuardPolicy, &controlFlowGuardPolicy, sizeof(controlFlowGuardPolicy));
+    
     LONG result;
 #ifdef DEBUG
     PHP_BASE_THREAD_DBG dbg;


### PR DESCRIPTION
Set process Control Flow Guard (CFG ) policy in order to prevent the process from loading a DLL that does not enable CFG.

The process can be hackjacked by some third-party security softwares. As show in the call stack below, MozartBreathCore.dll is a third-party DLL loaded by the process, which cause the process breaks. By setting the CFG policy,  it can prevent the DLL from being loaded.

 	ntdll.dll!00007ff91bdbc1d2()	Unknown
 	ntdll.dll!00007ff91bdc52aa()	Unknown
 	ntdll.dll!00007ff91bdc558a()	Unknown
 	ntdll.dll!00007ff91bdd1585()	Unknown
 	ntdll.dll!00007ff91bd6c6f7()	Unknown
 	ntdll.dll!00007ff91bcec126()	Unknown
 	ntdll.dll!00007ff91bceb2ce()	Unknown
 	ntdll.dll!00007ff91bceb1fd()	Unknown
 	msvcrt.dll!00007ff919adcadc()	Unknown
 	MozartBreathCore.dll!00007ff8e4f21fe6()	Unknown
 	MozartBreathCore.dll!00007ff8e4f21dd8()	Unknown
 	MozartBreathCore.dll!00007ff8e5143914()	Unknown
 	MozartBreathBolo2.dll!00007ff8e49d5362()	Unknown
 	MozartBreathCore.dll!00007ff8e5111f2f()	Unknown
 	MozartBreathCore.dll!00007ff8e50cffc0()	Unknown
>	SystemInformer.exe!PhCreateFile(void * * FileHandle, _PH_STRINGREF * FileName, unsigned long DesiredAccess, unsigned long FileAttributes, unsigned long ShareAccess, unsigned long CreateDisposition, unsigned long CreateOptions) Line 9506	C
 	SystemInformer.exe!PhVerifyFileCached(_PH_STRING * FileName, _PH_STRING * PackageFullName, _PH_STRING * * SignerName, unsigned char NativeFileName, unsigned char CachedOnly) Line 991	C
 	SystemInformer.exe!PhpProcessQueryStage2(_PH_PROCESS_QUERY_S2_DATA * Data) Line 943	C
 	SystemInformer.exe!PhpProcessQueryStage2Worker(void * Parameter) Line 1062	C
 	SystemInformer.exe!PhpExecuteWorkQueueItem(_PH_WORK_QUEUE_ITEM * WorkQueueItem) Line 322	C
 	SystemInformer.exe!PhpWorkQueueThreadStart(void * Parameter) Line 460	C
 	SystemInformer.exe!PhpBaseThreadStart(void * Parameter) Line 200	C
 	kernel32.dll!BaseThreadInitThunk()	Unknown
 	ntdll.dll!00007ff91bd0dfb8()	Unknown