### PR TITLE
Update ntexapi.h: NtDelayExecution sal fix

### DIFF
--- a/phnt/include/ntexapi.h
+++ b/phnt/include/ntexapi.h
@@ -18,7 +18,7 @@ NTSTATUS
 NTAPI
 NtDelayExecution(
     _In_ BOOLEAN Alertable,
-    _In_opt_ PLARGE_INTEGER DelayInterval
+    _In_ PLARGE_INTEGER DelayInterval
     );
 
 // Environment values


### PR DESCRIPTION
NtDelayExecution `DelayInterval` argument is not actually optional, as can be seen in disasm in current kernels of ws2022, w11. I've also confirmed it being non-optional in disasm of win10 RTM.