### PR TITLE
Show signing level for mapped images

### DIFF
--- a/SystemInformer/include/memlist.h
+++ b/SystemInformer/include/memlist.h
@@ -17,8 +17,9 @@
 #define PHMMTLC_LOCKEDWS 9
 #define PHMMTLC_COMMITTED 10
 #define PHMMTLC_PRIVATE 11
+#define PHMMTLC_SIGNING_LEVEL 12
 
-#define PHMMTLC_MAXIMUM 12
+#define PHMMTLC_MAXIMUM 13
 
 // begin_phapppub
 typedef struct _PH_MEMORY_NODE

--- a/SystemInformer/include/memprv.h
+++ b/SystemInformer/include/memprv.h
@@ -89,6 +89,8 @@ typedef struct _PH_MEMORY_ITEM
         struct
         {
             PPH_STRING FileName;
+            BOOLEAN SigningLevelValid;
+            SE_SIGNING_LEVEL SigningLevel;
         } MappedFile;
         struct
         {
@@ -128,6 +130,10 @@ PWSTR PhGetMemoryStateString(
 
 PWSTR PhGetMemoryTypeString(
     _In_ ULONG Type
+    );
+
+PWSTR PhGetSigningLevelString(
+    _In_ SE_SIGNING_LEVEL SigningLevel
     );
 
 PPH_MEMORY_ITEM PhCreateMemoryItem(


### PR DESCRIPTION
This pull request adds a column for the memory page that shows the signing level of the underlying section object.