### PR TITLE
Update silo shared data

### DIFF
--- a/phnt/include/ntpebteb.h
+++ b/phnt/include/ntpebteb.h
@@ -114,7 +114,7 @@ typedef struct _PEB
     ULONG TlsBitmapBits[2];
 
     PVOID ReadOnlySharedMemoryBase;
-    PVOID SharedData; // HotpatchInformation
+    struct _SILO_USER_SHARED_DATA *SharedData; // HotpatchInformation
     PVOID *ReadOnlyStaticServerData;
 
     PVOID AnsiCodePageData; // PCPTABLEINFO

--- a/phnt/include/ntpsapi.h
+++ b/phnt/include/ntpsapi.h
@@ -2471,15 +2471,20 @@ typedef struct _JOBOBJECT_MEMORY_USAGE_INFORMATION_V2
 // private
 typedef struct _SILO_USER_SHARED_DATA
 {
-    ULONG64 ServiceSessionId;
+    ULONG ServiceSessionId;
     ULONG ActiveConsoleId;
     LONGLONG ConsoleSessionForegroundProcessId;
     NT_PRODUCT_TYPE NtProductType;
     ULONG SuiteMask;
-    ULONG SharedUserSessionId;
+    ULONG SharedUserSessionId; // since RS2
     BOOLEAN IsMultiSessionSku;
     WCHAR NtSystemRoot[260];
     USHORT UserModeGlobalLogger[16];
+    ULONG TimeZoneId; // since 21H2
+    LONG TimeZoneBiasStamp;
+    KSYSTEM_TIME TimeZoneBias;
+    LARGE_INTEGER TimeZoneBiasEffectiveStart;
+    LARGE_INTEGER TimeZoneBiasEffectiveEnd;
 } SILO_USER_SHARED_DATA, *PSILO_USER_SHARED_DATA;
 
 // private

--- a/plugins/DotNetTools/asmpage.c
+++ b/plugins/DotNetTools/asmpage.c
@@ -6,7 +6,7 @@
  * Authors:
  *
  *     wj32    2011-2015
- *     dmex    2016-2022
+ *     dmex    2016-2023
  *
  */
 
@@ -1654,7 +1654,7 @@ NTSTATUS DotNetSosTraceQueryThreadStart(
                 PhSetReference(&childNode->u.Assembly.DisplayName, assembly->DisplayName);
                 PhSetReference(&childNode->u.Assembly.FullyQualifiedAssemblyName, assembly->ModuleName);
                 childNode->u.Assembly.BaseAddress = assembly->BaseAddress;
-                childNode->StructureText = assembly->DisplayName->sr;
+                childNode->StructureText = PhGetStringRef(assembly->DisplayName);
                 PhSetReference(&childNode->PathText, assembly->ModuleName);
                 PhSetReference(&childNode->NativePathText, assembly->NativeFileName);
                 childNode->MvidText = PhFormatGuid(&assembly->Mvid);


### PR DESCRIPTION
This pull requests updates `SILO_USER_SHARED_DATA` so it can be used inline in functions like `RtlGetNtSystemRoot`, `RtlGetActiveConsoleId`, `RtlGetNtProductType`, etc.