### PR TITLE
Add non-invasive heap class querying

### DIFF
--- a/SystemInformer/SystemInformer.vcxproj
+++ b/SystemInformer/SystemInformer.vcxproj
@@ -482,6 +482,7 @@
     <ClInclude Include="include\colsetmgr.h" />
     <ClInclude Include="include\extmgr.h" />
     <ClInclude Include="include\extmgri.h" />
+    <ClInclude Include="include\heapinfo.h" />
     <ClInclude Include="include\heapstruct.h" />
     <ClInclude Include="include\hndllist.h" />
     <ClInclude Include="include\hndlmenu.h" />

--- a/SystemInformer/SystemInformer.vcxproj.filters
+++ b/SystemInformer/SystemInformer.vcxproj.filters
@@ -473,6 +473,9 @@
     <ClInclude Include="include\ksisup.h">
       <Filter>Headers</Filter>
     </ClInclude>
+    <ClInclude Include="include\heapinfo.h">
+      <Filter>Headers</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include="SystemInformer.ico">

--- a/SystemInformer/heapinfo.c
+++ b/SystemInformer/heapinfo.c
@@ -386,7 +386,7 @@ PWSTR PhGetProcessHeapClassText(
         return L"CSRSS Port Heap";
     }
 
-    return L"Unknown";
+    return L"Unknown Heap";
 }
 
 VOID PhpEnumerateProcessHeaps(

--- a/SystemInformer/include/heapinfo.h
+++ b/SystemInformer/include/heapinfo.h
@@ -1,0 +1,8 @@
+#ifndef PH_HEAPINFO_H
+#define PHHEAPINFO_H
+
+PWSTR PhGetProcessHeapClassText(
+    _In_ ULONG HeapClass
+    );
+
+#endif

--- a/SystemInformer/include/memprv.h
+++ b/SystemInformer/include/memprv.h
@@ -139,6 +139,8 @@ typedef struct _PH_MEMORY_ITEM
         struct
         {
             ULONG Index;
+            BOOLEAN ClassValid;
+            ULONG Class;
         } Heap;
         struct
         {

--- a/SystemInformer/memlist.c
+++ b/SystemInformer/memlist.c
@@ -19,6 +19,7 @@
 #include <memprv.h>
 #include <settings.h>
 #include <phsettings.h>
+#include <heapinfo.h>
 
 VOID PhpClearMemoryList(
     _Inout_ PPH_MEMORY_LIST_CONTEXT Context
@@ -570,11 +571,13 @@ PPH_STRING PhGetMemoryRegionUseText(
             type == Stack32Region ? L" 32-bit" : L"", HandleToUlong(MemoryItem->u.Stack.ThreadId));
     case HeapRegion:
     case Heap32Region:
-        return PhFormatString(L"Heap%s (ID %lu)",
+        return PhFormatString(L"%s%s (ID %lu)",
+            MemoryItem->u.Heap.ClassValid ? PhGetProcessHeapClassText(MemoryItem->u.Heap.Class) : L"Heap",
             type == Heap32Region ? L" 32-bit" : L"", (ULONG)MemoryItem->u.Heap.Index + 1);
     case HeapSegmentRegion:
     case HeapSegment32Region:
-        return PhFormatString(L"Heap segment%s (ID %lu)",
+        return PhFormatString(L"%s Segment%s (ID %lu)",
+            MemoryItem->u.HeapSegment.HeapItem->u.Heap.ClassValid ? PhGetProcessHeapClassText(MemoryItem->u.HeapSegment.HeapItem->u.Heap.Class) : L"Heap",
             type == HeapSegment32Region ? L" 32-bit" : L"", (ULONG)MemoryItem->u.HeapSegment.HeapItem->u.Heap.Index + 1);
     case CfgBitmapRegion:
     case CfgBitmap32Region:


### PR DESCRIPTION
This PR allows the memory page to display heap classes: 

![image](https://user-images.githubusercontent.com/30962924/233466985-f8a5af7d-6b56-4c8a-ba04-84b4fe9bc467.png)

As opposed to the dedicated dialog (that needs to create a remote thread), this code is non-invasive as it reads the value directly, similar to how existing heap segment detection works.