### PR TITLE
Add definitions for package properties API

### DIFF
--- a/phlib/include/appresolverp.h
+++ b/phlib/include/appresolverp.h
@@ -796,4 +796,404 @@ static VOID (WINAPI* EdpFreeContext_I)(
     _In_ PEDP_CONTEXT EdpContext
     ) = NULL;
 
+// Properties
+
+// private
+typedef struct _PACKAGE_CONTEXT_REFERENCE
+{
+    void * reserved;
+} * PACKAGE_CONTEXT_REFERENCE;
+
+// private
+typedef enum PackageProperty
+{
+    PackageProperty_Name = 1,                  // q: WCHAR[]
+    PackageProperty_Version = 2,               // q: WCHAR[]
+    PackageProperty_Architecture = 3,          // q: ULONG (PROCESSOR_ARCHITECTURE_*)
+    PackageProperty_ResourceId = 4,            // q: WCHAR[]
+    PackageProperty_Publisher = 5,             // q: WCHAR[]
+    PackageProperty_PublisherId = 6,           // q: WCHAR[]
+    PackageProperty_FamilyName = 7,            // q: WCHAR[]
+    PackageProperty_FullName = 8,              // q: WCHAR[]
+    PackageProperty_Flags = 9,                 // q: ULONG
+    PackageProperty_InstalledLocation = 10,    // q: WCHAR[]
+    PackageProperty_DisplayName = 11,          // q: WCHAR[]
+    PackageProperty_PublisherDisplayName = 12, // q: WCHAR[]
+    PackageProperty_Description = 13,          // q: WCHAR[]
+    PackageProperty_Logo = 14,                 // q: WCHAR[]
+    PackageProperty_PackageOrigin = 15         // q: PackageOrigin
+} PackageProperty;
+
+// private
+typedef struct _PACKAGE_APPLICATION_CONTEXT_REFERENCE
+{
+    void * reserved;
+} * PACKAGE_APPLICATION_CONTEXT_REFERENCE;
+
+// private
+typedef enum PackageApplicationProperty
+{
+    PackageApplicationProperty_Aumid = 1,                        // q: WCHAR[]
+    PackageApplicationProperty_Praid = 2,                        // q: WCHAR[]
+    PackageApplicationProperty_DisplayName = 3,                  // q: WCHAR[]
+    PackageApplicationProperty_Description = 4,                  // q: WCHAR[]
+    PackageApplicationProperty_Logo = 5,                         // q: WCHAR[]
+    PackageApplicationProperty_SmallLogo = 6,                    // q: WCHAR[]
+    PackageApplicationProperty_ForegroundText = 7,               // q: ULONG
+    PackageApplicationProperty_ForegroundTextString = 8,         // q: WCHAR[]
+    PackageApplicationProperty_BackgroundColor = 9,              // q: ULONG
+    PackageApplicationProperty_StartPage = 10,                   // q: WCHAR[]
+    PackageApplicationProperty_ContentURIRulesCount = 11,        // q: ULONG
+    PackageApplicationProperty_ContentURIRules = 12,             // q: WCHAR[] (multi-sz)
+    PackageApplicationProperty_StaticContentURIRulesCount = 13,  // q: ULONG
+    PackageApplicationProperty_StaticContentURIRules = 14,       // q: WCHAR[] (multi-sz)
+    PackageApplicationProperty_DynamicContentURIRulesCount = 15, // q: ULONG
+    PackageApplicationProperty_DynamicContentURIRules = 16       // q: WCHAR[] (multi-sz)
+} PackageApplicationProperty;
+
+// private
+typedef struct _PACKAGE_RESOURCES_CONTEXT_REFERENCE
+{
+    void * reserved;
+} * PACKAGE_RESOURCES_CONTEXT_REFERENCE;
+
+// private
+typedef enum PackageResourcesProperty
+{
+    PackageResourcesProperty_DisplayName = 1,
+    PackageResourcesProperty_PublisherDisplayName = 2,
+    PackageResourcesProperty_Description = 3,
+    PackageResourcesProperty_Logo = 4,
+    PackageResourcesProperty_SmallLogo = 5,
+    PackageResourcesProperty_StartPage = 6
+} PackageResourcesProperty;
+
+// private
+typedef struct _PACKAGE_SECURITY_CONTEXT_REFERENCE
+{
+    void * reserved;
+} * PACKAGE_SECURITY_CONTEXT_REFERENCE;
+
+// private
+typedef enum PackageSecurityProperty
+{
+    PackageSecurityProperty_SecurityFlags = 1,     // q: ULONG
+    PackageSecurityProperty_AppContainerSID = 2,   // q: Sid
+    PackageSecurityProperty_CapabilitiesCount = 3, // q: ULONG
+    PackageSecurityProperty_Capabilities = 4       // q: Sid[]
+} PackageSecurityProperty;
+
+// private
+typedef struct _TARGET_PLATFORM_CONTEXT_REFERENCE
+{
+    void * reserved;
+} * TARGET_PLATFORM_CONTEXT_REFERENCE;
+
+// private
+typedef enum TargetPlatformProperty
+{
+    TargetPlatformProperty_Platform = 1,   // q: ULONG
+    TargetPlatformProperty_MinVersion = 2, // q: PACKAGE_VERSION
+    TargetPlatformProperty_MaxVersion = 3  // q: PACKAGE_VERSION
+} TargetPlatformProperty;
+
+// private
+typedef struct _PACKAGE_GLOBALIZATION_CONTEXT_REFERENCE
+{
+    void * reserved;
+} * PACKAGE_GLOBALIZATION_CONTEXT_REFERENCE;
+
+// private
+typedef enum PackageGlobalizationProperty
+{
+    PackageGlobalizationProperty_ForceUtf8 = 1,                // q: ULONG
+    PackageGlobalizationProperty_UseWindowsDisplayLanguage = 2 // q: ULONG
+} PackageGlobalizationProperty;
+
+#if (PHNT_VERSION >= PHNT_WINBLUE)
+
+// Package Properties
+
+// rev
+WINBASEAPI
+_Success_(return == ERROR_SUCCESS)
+LONG
+WINAPI
+GetCurrentPackageContext(
+    _In_ ULONG Index,
+    _Reserved_ ULONG_PTR Unused,
+    _Out_ PACKAGE_CONTEXT_REFERENCE *PackageContext
+    );
+
+// rev
+WINBASEAPI
+_Success_(return == ERROR_SUCCESS)
+LONG
+WINAPI
+GetPackageContext(
+    _In_ PVOID PackageInfoReference, // PACKAGE_INFO_REFERENCE
+    _In_ ULONG Index,
+    _Reserved_ ULONG_PTR Unused,
+    _Out_ PACKAGE_CONTEXT_REFERENCE *PackageContext
+    );
+
+// rev
+WINBASEAPI
+_Success_(return == ERROR_SUCCESS)
+LONG
+WINAPI
+GetPackageProperty(
+    _In_ PACKAGE_CONTEXT_REFERENCE PackageContext,
+    _In_ PackageProperty PropertyId,
+    _Inout_ PULONG BufferSize,
+    _Out_writes_bytes_(BufferSize) PVOID Buffer
+    );
+
+// rev
+WINBASEAPI
+_Success_(return == ERROR_SUCCESS)
+LONG
+WINAPI
+GetPackagePropertyString(
+    _In_ PACKAGE_CONTEXT_REFERENCE PackageContext,
+    _In_ PackageProperty PropertyId,
+    _Inout_ PULONG BufferLength,
+    _Out_writes_(BufferLength) PWSTR Buffer
+    );
+
+// rev
+WINBASEAPI
+_Success_(return == ERROR_SUCCESS)
+LONG
+WINAPI
+GetPackageOSMaxVersionTested(
+    _In_ PACKAGE_CONTEXT_REFERENCE PackageContext,
+    _Out_ ULONGLONG *OSMaxVersionTested // PACKAGE_VERSION
+    );
+
+// Package Application Properties
+
+// rev
+WINBASEAPI
+_Success_(return == ERROR_SUCCESS)
+LONG
+WINAPI
+GetCurrentPackageApplicationContext(
+    _In_ ULONG Index,
+    _Reserved_ ULONG_PTR Unused,
+    _Out_ PACKAGE_APPLICATION_CONTEXT_REFERENCE *PackageApplicationContext
+    );
+
+// rev
+WINBASEAPI
+_Success_(return == ERROR_SUCCESS)
+LONG
+WINAPI
+GetPackageApplicationContext(
+    _In_ PVOID PackageInfoReference, // PACKAGE_INFO_REFERENCE
+    _In_ ULONG Index,
+    _Reserved_ ULONG_PTR Unused,
+    _Out_ PACKAGE_APPLICATION_CONTEXT_REFERENCE *PackageApplicationContext
+    );
+
+// rev
+WINBASEAPI
+_Success_(return == ERROR_SUCCESS)
+LONG
+WINAPI
+GetPackageApplicationProperty(
+    _In_ PACKAGE_APPLICATION_CONTEXT_REFERENCE PackageApplicationContext,
+    _In_ PackageApplicationProperty PropertyId,
+    _Inout_ PULONG BufferSize,
+    _Out_writes_bytes_(BufferSize) PVOID Buffer
+    );
+
+// rev
+WINBASEAPI
+_Success_(return == ERROR_SUCCESS)
+LONG
+WINAPI
+GetPackageApplicationPropertyString(
+    _In_ PACKAGE_APPLICATION_CONTEXT_REFERENCE PackageApplicationContext,
+    _In_ PackageApplicationProperty PropertyId,
+    _Inout_ PULONG BufferLength,
+    _Out_writes_(BufferLength) PWSTR Buffer
+    );
+
+// Package Resource Properties
+
+// rev
+WINBASEAPI
+_Success_(return == ERROR_SUCCESS)
+LONG
+WINAPI
+GetCurrentPackageResourcesContext(
+    _In_ ULONG Index,
+    _Reserved_ ULONG_PTR Unused,
+    _Out_ PACKAGE_RESOURCES_CONTEXT_REFERENCE *PackageResourcesContext
+    );
+
+// rev
+WINBASEAPI
+_Success_(return == ERROR_SUCCESS)
+LONG
+WINAPI
+GetPackageResourcesContext(
+    _In_ PVOID PackageInfoReference, // PACKAGE_INFO_REFERENCE
+    _In_ ULONG Index,
+    _Reserved_ ULONG_PTR Unused,
+    _Out_ PACKAGE_RESOURCES_CONTEXT_REFERENCE *PackageResourcesContext
+    );
+
+// rev
+WINBASEAPI
+_Success_(return == ERROR_SUCCESS)
+LONG
+WINAPI
+GetCurrentPackageApplicationResourcesContext(
+    _In_ ULONG Index,
+    _Reserved_ ULONG_PTR Unused,
+    _Out_ PACKAGE_APPLICATION_CONTEXT_REFERENCE *PackageResourcesContext
+    );
+
+// rev
+WINBASEAPI
+_Success_(return == ERROR_SUCCESS)
+LONG
+WINAPI
+GetPackageApplicationResourcesContext(
+    _In_ PVOID PackageInfoReference, // PACKAGE_INFO_REFERENCE
+    _In_ ULONG Index,
+    _Reserved_ ULONG_PTR Unused,
+    _Out_ PACKAGE_APPLICATION_CONTEXT_REFERENCE *PackageResourcesContext
+    );
+
+// rev
+WINBASEAPI
+_Success_(return == ERROR_SUCCESS)
+LONG
+WINAPI
+GetPackageResourcesProperty(
+    _In_ PACKAGE_APPLICATION_CONTEXT_REFERENCE PackageResourcesContext,
+    _In_ PackageResourcesProperty PropertyId,
+    _Inout_ PULONG BufferSize,
+    _Out_writes_bytes_(BufferSize) PVOID Buffer
+    );
+
+// Package Security Properties
+
+// rev
+WINBASEAPI
+_Success_(return == ERROR_SUCCESS)
+LONG
+WINAPI
+GetCurrentPackageSecurityContext(
+    _Reserved_ ULONG_PTR Unused,
+    _Out_ PACKAGE_SECURITY_CONTEXT_REFERENCE *PackageSecurityContext
+    );
+
+// rev
+WINBASEAPI
+_Success_(return == ERROR_SUCCESS)
+LONG
+WINAPI
+GetPackageSecurityContext(
+    _In_ PVOID PackageInfoReference, // PACKAGE_INFO_REFERENCE
+    _Reserved_ ULONG_PTR Unused,
+    _Out_ PACKAGE_SECURITY_CONTEXT_REFERENCE *PackageSecurityContext
+    );
+
+// rev
+WINBASEAPI
+_Success_(return == ERROR_SUCCESS)
+LONG
+WINAPI
+GetPackageSecurityProperty(
+    _In_ PACKAGE_SECURITY_CONTEXT_REFERENCE PackageSecurityContext,
+    _In_ PackageSecurityProperty PropertyId,
+    _Inout_ PULONG BufferSize,
+    _Out_writes_bytes_(BufferSize) PVOID Buffer
+    );
+
+#endif // PHNT_VERSION >= PHNT_WINBLUE
+
+#if (PHNT_VERSION >= PHNT_THRESHOLD)
+
+// Target Platform Properties
+
+// rev
+WINBASEAPI
+_Success_(return == ERROR_SUCCESS)
+LONG
+WINAPI
+GetCurrentTargetPlatformContext(
+    _Reserved_ ULONG_PTR Unused,
+    _Out_ TARGET_PLATFORM_CONTEXT_REFERENCE *TargetPlatformContext
+    );
+
+WINBASEAPI
+_Success_(return == ERROR_SUCCESS)
+LONG
+WINAPI
+GetTargetPlatformContext(
+    _In_ PVOID PackageInfoReference, // PACKAGE_INFO_REFERENCE
+    _Reserved_ ULONG_PTR Unused,
+    _Out_ TARGET_PLATFORM_CONTEXT_REFERENCE *TargetPlatformContext
+    );
+
+// rev
+WINBASEAPI
+_Success_(return == ERROR_SUCCESS)
+LONG
+WINAPI
+GetPackageTargetPlatformProperty(
+    _In_ TARGET_PLATFORM_CONTEXT_REFERENCE TargetPlatformContext,
+    _In_ TargetPlatformProperty PropertyId,
+    _Inout_ PULONG BufferSize,
+    _Out_writes_bytes_(BufferSize) PVOID Buffer
+    );
+
+#endif // PHNT_VERSION >= PHNT_THRESHOLD
+
+#if (PHNT_VERSION >= PHNT_20H1)
+
+// Package Globalization Properties
+
+// rev
+WINBASEAPI
+_Success_(return == ERROR_SUCCESS)
+LONG
+WINAPI
+GetCurrentPackageGlobalizationContext(
+    _In_ ULONG Index,
+    _Reserved_ ULONG_PTR Unused,
+    _Out_ PACKAGE_GLOBALIZATION_CONTEXT_REFERENCE *PackageGlobalizationContext
+    );
+
+// rev
+WINBASEAPI
+_Success_(return == ERROR_SUCCESS)
+LONG
+WINAPI
+GetPackageGlobalizationContext(
+    _In_ PVOID PackageInfoReference, // PACKAGE_INFO_REFERENCE
+    _In_ ULONG Index,
+    _Reserved_ ULONG_PTR Unused,
+    _Out_ PACKAGE_GLOBALIZATION_CONTEXT_REFERENCE *PackageGlobalizationContext
+    );
+
+// rev
+WINBASEAPI
+_Success_(return == ERROR_SUCCESS)
+LONG
+WINAPI
+GetPackageGlobalizationProperty(
+    _In_ PACKAGE_GLOBALIZATION_CONTEXT_REFERENCE PackageGlobalizationContext,
+    _In_ PackageGlobalizationProperty PropertyId,
+    _Inout_ PULONG BufferSize,
+    _Out_writes_bytes_(BufferSize) PVOID Buffer
+    );
+
+#endif // PHNT_VERSION >= PHNT_20H1
+
 #endif


### PR DESCRIPTION
This PR adds definitions for querying various properties of application packages without using WinRT. For future use.