### PR TITLE
Fixes error C2198, too few arguments for call.

### DIFF
--- a/SystemInformer/mainwnd.c
+++ b/SystemInformer/mainwnd.c
@@ -295,7 +295,7 @@ LRESULT CALLBACK PhMwpWndProc(
                 PhSetApplicationWindowIcon(PhMainWndHandle);
             }
 
-            PhProcessImageListInitialization(hWnd);
+            PhProcessImageListInitialization(hWnd, PhGetWindowDpi(hWnd));
             TreeNew_SetImageList(PhMwpProcessTreeNewHandle, PhProcessSmallImageList);
             TreeNew_SetImageList(PhMwpServiceTreeNewHandle, PhProcessSmallImageList);
             TreeNew_SetImageList(PhMwpNetworkTreeNewHandle, PhProcessSmallImageList);


### PR DESCRIPTION
Fixes error C2198, too few arguments for call.