### PR TITLE
fix: version range of ntseapi.h

### DIFF
--- a/phnt/include/ntseapi.h
+++ b/phnt/include/ntseapi.h
@@ -522,7 +522,7 @@ NtAccessCheckByTypeResultList(
 
 // Signing
 
-#if (PHNT_VERSION >= PHNT_THRESHOLD)
+#if (PHNT_VERSION >= PHNT_WIN8)
 
 NTSYSCALLAPI
 NTSTATUS
@@ -546,6 +546,10 @@ NtGetCachedSigningLevel(
     _Inout_opt_ PULONG ThumbprintSize,
     _Out_opt_ PULONG ThumbprintAlgorithm
     );
+
+#endif
+
+#if (PHNT_VERSION >= PHNT_REDSTONE2)
 
 // rev
 NTSYSCALLAPI


### PR DESCRIPTION
NtCompareSigningLevels:
![image](https://github.com/winsiderss/systeminformer/assets/50670906/e2c1cc0b-567e-4478-bf4b-9a37b1402257)

NtSetCachedSigningLevel/NtGetCachedSigningLevel:
![image](https://github.com/winsiderss/systeminformer/assets/50670906/b53ec63b-8f97-489d-a156-21344e2e6df2)

>/
>/ Module ref [Nt-Modules](https://github.com/MiroKaku/Nt-Modules)
>/