### PR TITLE
Fix the code refactoring in the "arm64 stack walk EC/CHIP support" su…

### DIFF
--- a/phlib/symprv.c
+++ b/phlib/symprv.c
@@ -2209,6 +2209,16 @@ NTSTATUS PhWalkThreadStack(
 
             if (!Callback(&threadStackFrame, Context))
                 goto ResumeExit;
+
+#if defined(_X86_)
+            // (x86 only) Allow the user to change Eip, Esp and Ebp.
+            u.Context.Eip = PtrToUlong(threadStackFrame.PcAddress);
+            stackFrame.AddrPC.Offset = PtrToUlong(threadStackFrame.PcAddress);
+            u.Context.Ebp = PtrToUlong(threadStackFrame.FrameAddress);
+            stackFrame.AddrFrame.Offset = PtrToUlong(threadStackFrame.FrameAddress);
+            u.Context.Esp = PtrToUlong(threadStackFrame.StackAddress);
+            stackFrame.AddrStack.Offset = PtrToUlong(threadStackFrame.StackAddress);
+#endif
         }
     }
 


### PR DESCRIPTION
…bmission, the code logic of x86 is not completely consistent with the meaning before the modification.
```cxx
            // (x86 only) Allow the user to change Eip, Esp and Ebp.
            u.Context.Eip = PtrToUlong(threadStackFrame.PcAddress);
            stackFrame.AddrPC.Offset = PtrToUlong(threadStackFrame.PcAddress);
            u.Context.Ebp = PtrToUlong(threadStackFrame.FrameAddress);
            stackFrame.AddrFrame.Offset = PtrToUlong(threadStackFrame.FrameAddress);
            u.Context.Esp = PtrToUlong(threadStackFrame.StackAddress);
            stackFrame.AddrStack.Offset = PtrToUlong(threadStackFrame.StackAddress);
```
Before the "arm64 stack walk EC/CHPE support" submission, the above code would execute both when `phlib` was compiled to x86 and x64 (used to expand the WOW64 part), but after this submission, it will only work on the x64 version of `SystemInformer.exe`, that is, the 32-bit version of `SystemInformer.exe` will not be executed, which does not meet the original intention.