### PR TITLE
Fix setting creating thread id for process creation message

### DIFF
--- a/KSystemInformer/informer_process.c
+++ b/KSystemInformer/informer_process.c
@@ -243,7 +243,7 @@ VOID KphpCreateProcessNotifyInformer(
 
         KphMsgInit(msg, KphMsgProcessCreate);
         msg->Kernel.ProcessCreate.CreatingClientId.UniqueProcess = PsGetCurrentProcessId();
-        msg->Kernel.ProcessCreate.CreatingClientId.UniqueThread = PsGetCurrentProcessId();
+        msg->Kernel.ProcessCreate.CreatingClientId.UniqueThread = PsGetCurrentThreadId();
         msg->Kernel.ProcessCreate.ParentProcessId = CreateInfo->ParentProcessId;
         msg->Kernel.ProcessCreate.TargetProcessId = Process->ProcessId;
         msg->Kernel.ProcessCreate.IsSubsystemProcess = (CreateInfo->IsSubsystemProcess ? TRUE : FALSE);


### PR DESCRIPTION
Unless I misunderstand the code (which is possible), this looks like a bug to me