### PR TITLE
Fixed an issue where an error crash would occur when launching from t…

### DIFF
--- a/plugins/UserNotes/db.c
+++ b/plugins/UserNotes/db.c
@@ -175,8 +175,10 @@ NTSTATUS LoadDb(
     NTSTATUS status;
     PVOID topNode;
     PVOID currentNode;
+    PH_STRINGREF sr;
 
-    status = PhLoadXmlObjectFromFile(&ObjectDbPath->sr, &topNode);
+    sr = PhGetStringRef(ObjectDbPath);
+    status = PhLoadXmlObjectFromFile(&sr, &topNode);
 
     if (!NT_SUCCESS(status))
         return status;


### PR DESCRIPTION
…he accessibility features of the login screen.
Steps to reproduce:
1.turn off windows defender
2.Run cmd as an administrator, enter in cmd:
REG ADD "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\utilman.exe" /t REG_SZ /v Debugger /d "C:\Program Files\SystemInformer\SystemInformer.exe" /f
3.lock screen.
4.Click Accessibility, and you will see the following error interface.
![image](https://github.com/winsiderss/systeminformer/assets/20564099/4be2400c-188f-4016-a18c-d28356e01fa4)

The patch provided by this PR fixes this issue.