### PR TITLE
Fix typo "grated" -> granted

### DIFF
--- a/KSystemInformer/protection.c
+++ b/KSystemInformer/protection.c
@@ -193,7 +193,7 @@ BOOLEAN KphpShouldSuppressObjectProtections(
         //
         KphTracePrint(TRACE_LEVEL_VERBOSE,
                       PROTECTION,
-                      "Protected process %wZ (%lu) access grated to PPL process %wZ (%lu)",
+                      "Protected process %wZ (%lu) access granted to PPL process %wZ (%lu)",
                       &Target->ImageName,
                       HandleToULong(Target->ProcessId),
                       &Actor->ImageName,
@@ -206,7 +206,7 @@ BOOLEAN KphpShouldSuppressObjectProtections(
     {
         KphTracePrint(TRACE_LEVEL_VERBOSE,
                       PROTECTION,
-                      "Protected process %wZ (%lu) access grated to LSA process %wZ (%lu)",
+                      "Protected process %wZ (%lu) access granted to LSA process %wZ (%lu)",
                       &Target->ImageName,
                       HandleToULong(Target->ProcessId),
                       &Actor->ImageName,


### PR DESCRIPTION
Fixed a typo `grated` in
https://github.com/winsiderss/systeminformer/blob/180fe591126a8293c20073893ee575cc0b101dce/KSystemInformer/protection.c#L196