### PR TITLE
Update ntrtl.h

### DIFF
--- a/phnt/include/ntrtl.h
+++ b/phnt/include/ntrtl.h
@@ -1257,7 +1257,7 @@ RtlWakeAddressSingle(
 
 // end_rev
 
-#if PHNT_VERSION >= PHNT_WIN11_22H2
+#if (PHNT_VERSION >= PHNT_WIN11_22H2)
 FORCEINLINE
 VOID
 RtlCopyVolatileMemory(

--- a/phnt/include/ntrtl.h
+++ b/phnt/include/ntrtl.h
@@ -1257,6 +1257,7 @@ RtlWakeAddressSingle(
 
 // end_rev
 
+#if PHNT_VERSION >= PHNT_WIN11_22H2
 FORCEINLINE
 VOID
 RtlCopyVolatileMemory(
@@ -1268,6 +1269,7 @@ RtlCopyVolatileMemory(
     RtlCopyMemory(Destination, (const VOID *)Source, Size);
     BarrierAfterRead();
 }
+#endif
 
 FORCEINLINE
 HANDLE


### PR DESCRIPTION
According to [this MSDN documentation](https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/wdm/nf-wdm-barrierafterread), `BarrierAfterRead` is not available until win11 22h2.