### PR TITLE
Fix for #1881, could not open PE viewer.

### DIFF
--- a/SystemInformer/prpggen.c
+++ b/SystemInformer/prpggen.c
@@ -603,6 +603,13 @@ INT_PTR CALLBACK PhpProcessGeneralDlgProc(
                         PPH_STRING fileNameWin32 = processItem->FileName ? PH_AUTO(PhGetFileName(processItem->FileName)) : NULL;
 
                         if (
+                            PhIsNullOrEmptyString(fileNameWin32) ||
+                            !PhDoesFileExistWin32(PhGetString(fileNameWin32))
+                            )
+                        {
+                            fileNameWin32 = processItem->FileNameWin32;
+                        }
+                        if (
                             !PhIsNullOrEmptyString(fileNameWin32) &&
                             PhDoesFileExistWin32(PhGetString(fileNameWin32))
                             )


### PR DESCRIPTION
Use Win32 name from ProcessImageFileNameWin32 instead of NT name from SystemProcessIdInformation in case NT to Win32 name conversion fails.