### PR TITLE
Unconditionally include ntkeapi.h in phnt.h

### DIFF
--- a/phnt/include/phnt.h
+++ b/phnt/include/phnt.h
@@ -74,9 +74,9 @@ extern "C" {
 #if (PHNT_MODE != PHNT_MODE_KERNEL)
 #include <phnt_ntdef.h>
 #include <ntnls.h>
-#include <ntkeapi.h>
 #endif
 
+#include <ntkeapi.h>
 #include <ntldr.h>
 #include <ntexapi.h>
 


### PR DESCRIPTION
Without this the following definitions are missing in kernel mode:
- KTHREAD_STATE
- KHETERO_CPU_POLICY
- LDR_*

The `ntkeapi.h` already does checks on the `PHNT_MODE`, so this should work in all cases.

I tested this locally in user mode by doing:

```c
#include <phnt_windows.h>
#include <phnt.h>
```

And kernel mode:

```cpp
extern "C"
{
#include <ntifs.h>
#include <ntddstor.h>
#include <mountdev.h>
#include <ntddvol.h>
#include <ntstrsafe.h>
#include <ntimage.h>
#include <wdm.h>
}

#include <phnt.h>
```