### PR TITLE
Fix: Stack overflow caused by parameter type error.

### DIFF
--- a/phnt/include/ntlpcapi.h
+++ b/phnt/include/ntlpcapi.h
@@ -804,7 +804,7 @@ NtAlpcConnectPort(
     _In_ ULONG Flags,
     _In_opt_ PSID RequiredServerSid,
     _Inout_updates_bytes_to_opt_(*BufferLength, *BufferLength) PPORT_MESSAGE ConnectionMessage,
-    _Inout_opt_ PULONG BufferLength,
+    _Inout_opt_ PSIZE_T BufferLength,
     _Inout_opt_ PALPC_MESSAGE_ATTRIBUTES OutMessageAttributes,
     _Inout_opt_ PALPC_MESSAGE_ATTRIBUTES InMessageAttributes,
     _In_opt_ PLARGE_INTEGER Timeout
@@ -946,7 +946,7 @@ AlpcInitializeMessageAttribute(
     _In_ ULONG AttributeFlags,
     _Out_opt_ PALPC_MESSAGE_ATTRIBUTES Buffer,
     _In_ ULONG BufferSize,
-    _Out_ PULONG RequiredBufferSize
+    _Out_ PSIZE_T RequiredBufferSize
     );
 
 NTSYSAPI


### PR DESCRIPTION
## Error
![image](https://github.com/winsiderss/systeminformer/assets/32032670/86f14949-b306-461d-b556-26c75a33532d)
## AlpcInitializeMessageAttribute
![image](https://github.com/winsiderss/systeminformer/assets/32032670/a0bf892a-1455-43b6-9040-b9079c18ca12)
## NtAlpcConnectPort
![image](https://github.com/winsiderss/systeminformer/assets/32032670/e009dd9b-6a20-421a-9a96-47bd43a457e5)
