### PR TITLE
Fix crash in process token tab

### DIFF
--- a/SystemInformer/tokprp.c
+++ b/SystemInformer/tokprp.c
@@ -2128,7 +2128,8 @@ INT_PTR CALLBACK PhpTokenPageProc(
                     {
                         for (i = 0; i < numberOfItems; i++)
                         {
-                            if (FlagOn(listviewItems[i]->TokenPrivilege->Attributes, SE_PRIVILEGE_REMOVED))
+                            if (listviewItems[i]->TokenPrivilege &&
+                                FlagOn(listviewItems[i]->TokenPrivilege->Attributes, SE_PRIVILEGE_REMOVED))
                             {
                                 hasRemovedItems = TRUE;
                                 break;


### PR DESCRIPTION
Fixes https://github.com/winsiderss/systeminformer/issues/1923

The crash is a NULL dereference:
![image](https://github.com/winsiderss/systeminformer/assets/42078554/96d1e689-3f41-40c8-9322-0ab0dc86bb58)

The table arguably shouldn't mix objects with different semantics (privileges and groups), but that's a discussion for another day.  This change fixes the crash, which was my original complaint.

![image](https://github.com/winsiderss/systeminformer/assets/42078554/d2d002f7-e789-4024-9f76-5a541ac0d710)