### PR TITLE
Recognize use for more memory regions

### DIFF
--- a/SystemInformer/include/memprv.h
+++ b/SystemInformer/include/memprv.h
@@ -42,8 +42,17 @@ typedef enum _PH_MEMORY_REGION_TYPE
     GdiSharedHandleTableRegion,
     ShimDataRegion,
     ActivationContextDataRegion,
-    SystemDefaultActivationContextDataRegion
+    WerRegistrationDataRegion,
+    SiloSharedDataRegion,
+    TelemetryCoverageRegion
 } PH_MEMORY_REGION_TYPE;
+
+typedef enum _PH_ACTIVATION_CONTEXT_DATA_TYPE
+{
+    CustomActivationContext,
+    ProcessActivationContext,
+    SystemActivationContext
+} PH_ACTIVATION_CONTEXT_DATA_TYPE;
 
 typedef struct _PH_MEMORY_ITEM
 {
@@ -146,6 +155,10 @@ typedef struct _PH_MEMORY_ITEM
         {
             struct _PH_MEMORY_ITEM *HeapItem;
         } HeapSegment;
+        struct
+        {
+            PH_ACTIVATION_CONTEXT_DATA_TYPE Type;
+        } ActivationContextData;
     } u;
 } PH_MEMORY_ITEM, *PPH_MEMORY_ITEM;
 

--- a/SystemInformer/memlist.c
+++ b/SystemInformer/memlist.c
@@ -597,9 +597,21 @@ PPH_STRING PhGetMemoryRegionUseText(
     case ShimDataRegion:
         return PhFormatString(L"Shim data");
     case ActivationContextDataRegion:
-        return PhFormatString(L"Activation context data");
-    case SystemDefaultActivationContextDataRegion:
-        return PhFormatString(L"Default activation context data");
+        switch (MemoryItem->u.ActivationContextData.Type)
+        {
+        case ProcessActivationContext:
+            return PhFormatString(L"Process activation context data");
+        case SystemActivationContext:
+            return PhFormatString(L"System activation context data");
+        default:
+            return PhFormatString(L"Activation context data");
+        }
+    case WerRegistrationDataRegion:
+        return PhFormatString(L"WER registration data");
+    case SiloSharedDataRegion:
+        return PhFormatString(L"Silo shared data");
+    case TelemetryCoverageRegion:
+        return PhFormatString(L"Telemetry coverage map");
     default:
         return NULL;
     }

--- a/phnt/include/ntwow64.h
+++ b/phnt/include/ntwow64.h
@@ -302,7 +302,7 @@ typedef struct _PEB32
     WOW64_POINTER(PVOID) TlsBitmap;
     ULONG TlsBitmapBits[2];
     WOW64_POINTER(PVOID) ReadOnlySharedMemoryBase;
-    WOW64_POINTER(PVOID) HotpatchInformation;
+    WOW64_POINTER(PVOID) SharedData;
     WOW64_POINTER(PVOID *) ReadOnlyStaticServerData;
     WOW64_POINTER(PVOID) AnsiCodePageData;
     WOW64_POINTER(PVOID) OemCodePageData;


### PR DESCRIPTION
This pull request allows the memory page to recognize more regions with known purpose, such as:
 - WER registration data - for applications that rely on `RegisterApplicationRestart` and similar Windows Error Reporting APIs.
 - Silo shared data - overrides for some `USER_SHARED_DATA` fields for applications in silos.
 - Telemetry coverage map - ETW settings cached by `ProcessTelemetryCoverage`.
 - Activation context data - in addition to the default ones linked in PEB, is now also recognized based on the magic value