### PR TITLE
Window title developer verbose setting - PhMwpInitializeWindowTitle

### DIFF
--- a/SystemInformer/settings.c
+++ b/SystemInformer/settings.c
@@ -355,6 +355,7 @@ VOID PhAddDefaultSettings(
     PhpAddIntegerSetting(L"KsiDynDataNoEmbedded", L"0");
     PhpAddIntegerSetting(L"KsiClientProcessProtectionLevel", L"0");
     PhpAddStringSetting(L"KsiPreviousTemporaryDriverFile", L"");
+    PhpAddIntegerSetting(L"EnableVerboseDeveloperWindowTitle", L"0");
 }
 
 VOID PhUpdateCachedSettings(


### PR DESCRIPTION
Here's my reattempt at this PR from back in 2022, taking into account all feedback.

Feature req:
https://github.com/winsiderss/systeminformer/issues/1277

Prior commit & discussion:
https://github.com/winsiderss/systeminformer/pull/1289

PhMwpInitializeWindowTitle( method in mainwnd.c was left in tact to do exact as-is for the default behavior (new 'EnableVerboseDeveloperWindowTitle' setting defaults to 0 as suggested).

The formatting is all under // Verbose Developer Window Title ON

I tried to opt for PhAppendFormatStringBuilder (as recommended) where possible, and also used the suggested RtlEqualSid for SYSTEM user lookup.

![-- Title 1](https://github.com/winsiderss/systeminformer/assets/1288507/8f943f91-45a5-417a-b18b-9e0349394823)

![-- Title 2](https://github.com/winsiderss/systeminformer/assets/1288507/a02496b6-e7e7-4cc1-ba74-f1326c3d75fc)
