### PR TITLE
Show ARM64EC vs ARM64X in PEView's Target Machine

### DIFF
--- a/tools/peview/peprp.c
+++ b/tools/peview/peprp.c
@@ -867,11 +867,24 @@ VOID PvpSetPeImageMachineType(
 {
     ULONG machine;
     PWSTR type;
+    size_t sz;
+    size_t szComp = strlen(".hexpthk");
+    boolean hasA64ThunkSection = FALSE;
 
     if (PvMappedImage.Magic == IMAGE_NT_OPTIONAL_HDR32_MAGIC)
         machine = PvMappedImage.NtHeaders32->FileHeader.Machine;
     else
         machine = PvMappedImage.NtHeaders->FileHeader.Machine;
+
+    for (ULONG i = 0; i < PvMappedImage.NumberOfSections; i++)
+    {
+        sz = min(strlen(PvMappedImage.Sections[i].Name), szComp);
+        if (strncmp(PvMappedImage.Sections[i].Name, ".hexpthk", sz) == 0)
+        {
+            hasA64ThunkSection =  TRUE;
+            break;
+        }
+    }
 
     switch (machine)
     {
@@ -879,7 +892,7 @@ VOID PvpSetPeImageMachineType(
         type = L"i386";
         break;
     case IMAGE_FILE_MACHINE_AMD64:
-        type = L"AMD64";
+        type = hasA64ThunkSection ? L"ARM64EC" : L"AMD64";
         break;
     case IMAGE_FILE_MACHINE_IA64:
         type = L"IA64";
@@ -888,7 +901,7 @@ VOID PvpSetPeImageMachineType(
         type = L"ARM Thumb-2";
         break;
     case IMAGE_FILE_MACHINE_ARM64:
-        type = L"ARM64";
+        type = hasA64ThunkSection ? L"ARM64X" : L"ARM64";
         break;
     case IMAGE_FILE_MACHINE_CHPE_X86:
         type = L"Hybrid PE";


### PR DESCRIPTION
I was investigating the Image Type of Winword.exe, Excel.exe etc and I noticed that the Windows on ARM binaries were being shown as AMD64. But it's truly ARM64EC.
Using `dumpbin` on the three types of ARM64 binaries I found these outputs:

Pure ARM64:
```
FILE HEADER VALUES
            AA64 machine (ARM64)
```

ARM64EC:
```
FILE HEADER VALUES
            8664 machine (x64) (ARM64X)
```

ARM64X:
```
FILE HEADER VALUES
            AA64 machine (ARM64) (ARM64X)
```

It wouldbe nice if that ARM64X was not being repeated in the ARM64EC binaries, but I digress.

Please correct me if I'm wrong or if there's a less cheesy way to tell the three types of ARM64 binaries apart, but all I could do was to check for the presence of the `.hexpthk` in combination with the IMAGE TYPE in the PE header leading to this truth table:

| PE Header -> | AMD64 | ARM64 |
|--------------|:-----:|:-----------:|
| w/o `.hexpthk` |  AMD64 | ARM64 |
| w/ `.hexpthk` |  ARM64EC | ARM64X |
