### PR TITLE
Fix use of incorrect variable in peview

### DIFF
--- a/tools/peview/pechpeprp.c
+++ b/tools/peview/pechpeprp.c
@@ -148,7 +148,7 @@ INT_PTR CALLBACK PvpPeCHPEDlgProc(
                     PvpCHPAddValue(
                         lvHandle,
                         L"Code address range count",
-                        PhFormatString(L"%lu", chpe32->CHPECodeAddressRangeOffset),
+                        PhFormatString(L"%lu", chpe32->CHPECodeAddressRangeCount),
                         NULL
                         );
                     PvpCHPAddValue(


### PR DESCRIPTION
Fixes a very minor peview issue where the address range offset is being displayed, rather than the intended range count.