### PR TITLE
Service Tag for Informer Messages

### DIFF
--- a/KSystemInformer/include/kph.h
+++ b/KSystemInformer/include/kph.h
@@ -1159,7 +1159,7 @@ NTSTATUS KphQuerySection(
 
 _IRQL_requires_max_(PASSIVE_LEVEL)
 _Must_inspect_result_
-ULONG GetCurrentThreadServiceTag(
+UINT_PTR KphGetCurrentThreadSubProcessTag(
     VOID
     );
 

--- a/KSystemInformer/include/kph.h
+++ b/KSystemInformer/include/kph.h
@@ -1157,6 +1157,12 @@ NTSTATUS KphQuerySection(
     _In_ KPROCESSOR_MODE AccessMode
     );
 
+_IRQL_requires_max_(PASSIVE_LEVEL)
+_Must_inspect_result_
+ULONG GetCurrentThreadServiceTag(
+    VOID
+    );
+
 // hash
 
 typedef struct _KPH_HASH

--- a/KSystemInformer/informer_image.c
+++ b/KSystemInformer/informer_image.c
@@ -95,7 +95,7 @@ VOID KphpLoadImageNotifyInformer(
 
     msg->Kernel.ImageLoad.LoadingClientId.UniqueProcess = PsGetCurrentProcessId();
     msg->Kernel.ImageLoad.LoadingClientId.UniqueThread = PsGetCurrentThreadId();
-    msg->Kernel.ImageLoad.ServiceTag = GetCurrentThreadServiceTag();
+    msg->Kernel.ImageLoad.SubProcessTag = KphGetCurrentThreadSubProcessTag();
     msg->Kernel.ImageLoad.LoadingProcessStartKey = KphGetCurrentProcessStartKey();
     msg->Kernel.ImageLoad.TargetProcessId = ProcessId;
     msg->Kernel.ImageLoad.Properties = ImageInfo->ImageInfo.Properties;

--- a/KSystemInformer/informer_image.c
+++ b/KSystemInformer/informer_image.c
@@ -95,6 +95,7 @@ VOID KphpLoadImageNotifyInformer(
 
     msg->Kernel.ImageLoad.LoadingClientId.UniqueProcess = PsGetCurrentProcessId();
     msg->Kernel.ImageLoad.LoadingClientId.UniqueThread = PsGetCurrentThreadId();
+    msg->Kernel.ImageLoad.ServiceTag = GetCurrentThreadServiceTag();
     msg->Kernel.ImageLoad.LoadingProcessStartKey = KphGetCurrentProcessStartKey();
     msg->Kernel.ImageLoad.TargetProcessId = ProcessId;
     msg->Kernel.ImageLoad.Properties = ImageInfo->ImageInfo.Properties;

--- a/KSystemInformer/informer_object.c
+++ b/KSystemInformer/informer_object.c
@@ -336,7 +336,7 @@ VOID KphpObPreFillMessage(
 
     Message->Kernel.Handle.ContextClientId.UniqueProcess = PsGetCurrentProcessId();
     Message->Kernel.Handle.ContextClientId.UniqueThread = PsGetCurrentThreadId();
-    Message->Kernel.Handle.ServiceTag = GetCurrentThreadServiceTag();
+    Message->Kernel.Handle.SubProcessTag = KphGetCurrentThreadSubProcessTag();
     Message->Kernel.Handle.ContextProcessStartKey = KphGetCurrentProcessStartKey();
     Message->Kernel.Handle.Flags = Info->Flags;
     Message->Kernel.Handle.Object = Info->Object;
@@ -414,7 +414,7 @@ VOID KphpObPostFillMessage(
 
     Message->Kernel.Handle.ContextClientId.UniqueProcess = PsGetCurrentProcessId();
     Message->Kernel.Handle.ContextClientId.UniqueThread = PsGetCurrentThreadId();
-    Message->Kernel.Handle.ServiceTag = GetCurrentThreadServiceTag();
+    Message->Kernel.Handle.SubProcessTag = KphGetCurrentThreadSubProcessTag();
     Message->Kernel.Handle.ContextProcessStartKey = KphGetCurrentProcessStartKey();
     Message->Kernel.Handle.Flags = Info->Flags;
     Message->Kernel.Handle.Object = Info->Object;

--- a/KSystemInformer/informer_object.c
+++ b/KSystemInformer/informer_object.c
@@ -336,6 +336,7 @@ VOID KphpObPreFillMessage(
 
     Message->Kernel.Handle.ContextClientId.UniqueProcess = PsGetCurrentProcessId();
     Message->Kernel.Handle.ContextClientId.UniqueThread = PsGetCurrentThreadId();
+    Message->Kernel.Handle.ServiceTag = GetCurrentThreadServiceTag();
     Message->Kernel.Handle.ContextProcessStartKey = KphGetCurrentProcessStartKey();
     Message->Kernel.Handle.Flags = Info->Flags;
     Message->Kernel.Handle.Object = Info->Object;
@@ -413,6 +414,7 @@ VOID KphpObPostFillMessage(
 
     Message->Kernel.Handle.ContextClientId.UniqueProcess = PsGetCurrentProcessId();
     Message->Kernel.Handle.ContextClientId.UniqueThread = PsGetCurrentThreadId();
+    Message->Kernel.Handle.ServiceTag = GetCurrentThreadServiceTag();
     Message->Kernel.Handle.ContextProcessStartKey = KphGetCurrentProcessStartKey();
     Message->Kernel.Handle.Flags = Info->Flags;
     Message->Kernel.Handle.Object = Info->Object;

--- a/KSystemInformer/informer_process.c
+++ b/KSystemInformer/informer_process.c
@@ -220,6 +220,7 @@ VOID KphpCreateProcessNotifyInformer(
         KphMsgInit(msg, KphMsgProcessCreate);
         msg->Kernel.ProcessCreate.CreatingClientId.UniqueProcess = PsGetCurrentProcessId();
         msg->Kernel.ProcessCreate.CreatingClientId.UniqueThread = PsGetCurrentThreadId();
+        msg->Kernel.ProcessCreate.ServiceTag = GetCurrentThreadServiceTag();
         msg->Kernel.ProcessCreate.CreatingProcessStartKey = KphGetCurrentProcessStartKey();
         msg->Kernel.ProcessCreate.TargetProcessId = Process->ProcessId;
         msg->Kernel.ProcessCreate.TargetProcessStartKey = KphGetProcessStartKey(Process->EProcess);

--- a/KSystemInformer/informer_process.c
+++ b/KSystemInformer/informer_process.c
@@ -220,7 +220,7 @@ VOID KphpCreateProcessNotifyInformer(
         KphMsgInit(msg, KphMsgProcessCreate);
         msg->Kernel.ProcessCreate.CreatingClientId.UniqueProcess = PsGetCurrentProcessId();
         msg->Kernel.ProcessCreate.CreatingClientId.UniqueThread = PsGetCurrentThreadId();
-        msg->Kernel.ProcessCreate.ServiceTag = GetCurrentThreadServiceTag();
+        msg->Kernel.ProcessCreate.SubProcessTag = KphGetCurrentThreadSubProcessTag();
         msg->Kernel.ProcessCreate.CreatingProcessStartKey = KphGetCurrentProcessStartKey();
         msg->Kernel.ProcessCreate.TargetProcessId = Process->ProcessId;
         msg->Kernel.ProcessCreate.TargetProcessStartKey = KphGetProcessStartKey(Process->EProcess);

--- a/KSystemInformer/informer_registry.c
+++ b/KSystemInformer/informer_registry.c
@@ -278,7 +278,7 @@ VOID KphpRegFillCommonMessage(
 
     Message->Kernel.Reg.ClientId.UniqueProcess = PsGetCurrentProcessId();
     Message->Kernel.Reg.ClientId.UniqueThread = PsGetCurrentThreadId();
-    Message->Kernel.Reg.ServiceTag = GetCurrentThreadServiceTag();
+    Message->Kernel.Reg.SubProcessTag = KphGetCurrentThreadSubProcessTag();
     Message->Kernel.Reg.ProcessStartKey = KphGetCurrentProcessStartKey();
     Message->Kernel.Reg.PreviousMode = (ExGetPreviousMode() != KernelMode);
 

--- a/KSystemInformer/informer_registry.c
+++ b/KSystemInformer/informer_registry.c
@@ -278,6 +278,7 @@ VOID KphpRegFillCommonMessage(
 
     Message->Kernel.Reg.ClientId.UniqueProcess = PsGetCurrentProcessId();
     Message->Kernel.Reg.ClientId.UniqueThread = PsGetCurrentThreadId();
+    Message->Kernel.Reg.ServiceTag = GetCurrentThreadServiceTag();
     Message->Kernel.Reg.ProcessStartKey = KphGetCurrentProcessStartKey();
     Message->Kernel.Reg.PreviousMode = (ExGetPreviousMode() != KernelMode);
 

--- a/KSystemInformer/informer_thread.c
+++ b/KSystemInformer/informer_thread.c
@@ -142,6 +142,7 @@ VOID KphpCreateThreadNotifyInformer(
         KphMsgInit(msg, KphMsgThreadCreate);
         msg->Kernel.ThreadCreate.CreatingClientId.UniqueProcess = PsGetCurrentProcessId();
         msg->Kernel.ThreadCreate.CreatingClientId.UniqueThread = PsGetCurrentThreadId();
+        msg->Kernel.ThreadCreate.ServiceTag = GetCurrentThreadServiceTag();
         msg->Kernel.ThreadCreate.CreatingProcessStartKey = KphGetCurrentProcessStartKey();
         msg->Kernel.ThreadCreate.TargetClientId.UniqueProcess = ProcessId;
         msg->Kernel.ThreadCreate.TargetClientId.UniqueThread = ThreadId;

--- a/KSystemInformer/informer_thread.c
+++ b/KSystemInformer/informer_thread.c
@@ -142,7 +142,7 @@ VOID KphpCreateThreadNotifyInformer(
         KphMsgInit(msg, KphMsgThreadCreate);
         msg->Kernel.ThreadCreate.CreatingClientId.UniqueProcess = PsGetCurrentProcessId();
         msg->Kernel.ThreadCreate.CreatingClientId.UniqueThread = PsGetCurrentThreadId();
-        msg->Kernel.ThreadCreate.ServiceTag = GetCurrentThreadServiceTag();
+        msg->Kernel.ThreadCreate.SubProcessTag = KphGetCurrentThreadSubProcessTag();
         msg->Kernel.ThreadCreate.CreatingProcessStartKey = KphGetCurrentProcessStartKey();
         msg->Kernel.ThreadCreate.TargetClientId.UniqueProcess = ProcessId;
         msg->Kernel.ThreadCreate.TargetClientId.UniqueThread = ThreadId;

--- a/KSystemInformer/util.c
+++ b/KSystemInformer/util.c
@@ -2316,11 +2316,15 @@ UINT_PTR KphGetCurrentThreadSubProcessTag(
     ULONG_PTR SubProcessTag = 0;
 
     __try {
+
         PVOID Teb = PsGetCurrentThreadTeb();
 
-        UINT_PTR* pSubProcessTag = (UINT_PTR*)(((UINT_PTR)Teb) + FIELD_OFFSET(TEB, SubProcessTag));
+        if (Teb) {
 
-        SubProcessTag = *pSubProcessTag;
+            UINT_PTR* pSubProcessTag = (UINT_PTR*)(((UINT_PTR)Teb) + FIELD_OFFSET(TEB, SubProcessTag));
+
+            SubProcessTag = *pSubProcessTag;
+        }
     }
     __except (EXCEPTION_EXECUTE_HANDLER) {
     }

--- a/KSystemInformer/util.c
+++ b/KSystemInformer/util.c
@@ -2309,28 +2309,21 @@ NTSTATUS KphDominationAndPrivilegeCheck(
  */
 _IRQL_requires_max_(PASSIVE_LEVEL)
 _Must_inspect_result_
-ULONG GetCurrentThreadServiceTag(
+UINT_PTR KphGetCurrentThreadSubProcessTag(
     VOID
     )
 {
-    ULONG SvcTag = 0;
+    ULONG_PTR SubProcessTag = 0;
 
     __try {
-        ULONG_PTR Teb;
-#ifdef _M_ARM64
-        Teb = (*((ULONG_PTR*)(__getReg(18) + 0x30)));
-#elif _WIN64
-        Teb = (ULONG_PTR)__readgsqword(0x30);
-#else ! _WIN64
-        Teb = (ULONG_PTR)__readfsdword(0x18);
-#endif _WIN64
+        PVOID Teb = PsGetCurrentThreadTeb();
 
-        ULONG* pSvcTag = (ULONG*)((PVOID)(Teb + FIELD_OFFSET(TEB, SubProcessTag)));
+        UINT_PTR* pSubProcessTag = (UINT_PTR*)(((UINT_PTR)Teb) + FIELD_OFFSET(TEB, SubProcessTag));
 
-        SvcTag = *pSvcTag;
+        SubProcessTag = *pSubProcessTag;
     }
     __except (EXCEPTION_EXECUTE_HANDLER) {
     }
 
-    return SvcTag;
+    return SubProcessTag;
 }

--- a/kphlib/include/kphmsgdefs.h
+++ b/kphlib/include/kphmsgdefs.h
@@ -372,7 +372,7 @@ typedef struct _KPHM_STRIP_PROTECTED_PROCESS_MASKS
 typedef struct _KPHM_PROCESS_CREATE
 {
     CLIENT_ID CreatingClientId;
-    ULONG ServiceTag;
+    ULONG64 SubProcessTag;
     ULONG64 CreatingProcessStartKey;
     HANDLE TargetProcessId;
     ULONG64 TargetProcessStartKey;
@@ -415,7 +415,7 @@ typedef struct _KPHM_PROCESS_EXIT
 typedef struct _KPHM_THREAD_CREATE
 {
     CLIENT_ID CreatingClientId;
-    ULONG ServiceTag;
+    ULONG64 SubProcessTag;
     ULONG64 CreatingProcessStartKey;
     CLIENT_ID TargetClientId;
     ULONG64 TargetProcessStartKey;
@@ -437,7 +437,7 @@ typedef struct _KPHM_THREAD_EXIT
 typedef struct _KPHM_IMAGE_LOAD
 {
     CLIENT_ID LoadingClientId;
-    ULONG ServiceTag;
+    ULONG64 SubProcessTag;
     ULONG64 LoadingProcessStartKey;
     HANDLE TargetProcessId;
     ULONG64 TargetProcessStartKey;
@@ -488,7 +488,7 @@ typedef struct _KPHM_DEBUG_PRINT
 typedef struct _KPHM_HANDLE
 {
     CLIENT_ID ContextClientId;
-    ULONG ServiceTag;
+    ULONG64 SubProcessTag;
     ULONG64 ContextProcessStartKey;
 
     union
@@ -1423,7 +1423,7 @@ typedef union _KPHM_REGISTRY_PARAMETERS
 typedef struct _KPHM_REGISTRY
 {
     CLIENT_ID ClientId;
-    ULONG ServiceTag;
+    ULONG64 SubProcessTag;
     ULONG64 ProcessStartKey;
 
     union

--- a/kphlib/include/kphmsgdefs.h
+++ b/kphlib/include/kphmsgdefs.h
@@ -372,6 +372,7 @@ typedef struct _KPHM_STRIP_PROTECTED_PROCESS_MASKS
 typedef struct _KPHM_PROCESS_CREATE
 {
     CLIENT_ID CreatingClientId;
+    ULONG ServiceTag;
     ULONG64 CreatingProcessStartKey;
     HANDLE TargetProcessId;
     ULONG64 TargetProcessStartKey;
@@ -414,6 +415,7 @@ typedef struct _KPHM_PROCESS_EXIT
 typedef struct _KPHM_THREAD_CREATE
 {
     CLIENT_ID CreatingClientId;
+    ULONG ServiceTag;
     ULONG64 CreatingProcessStartKey;
     CLIENT_ID TargetClientId;
     ULONG64 TargetProcessStartKey;
@@ -435,6 +437,7 @@ typedef struct _KPHM_THREAD_EXIT
 typedef struct _KPHM_IMAGE_LOAD
 {
     CLIENT_ID LoadingClientId;
+    ULONG ServiceTag;
     ULONG64 LoadingProcessStartKey;
     HANDLE TargetProcessId;
     ULONG64 TargetProcessStartKey;
@@ -485,6 +488,7 @@ typedef struct _KPHM_DEBUG_PRINT
 typedef struct _KPHM_HANDLE
 {
     CLIENT_ID ContextClientId;
+    ULONG ServiceTag;
     ULONG64 ContextProcessStartKey;
 
     union
@@ -1419,6 +1423,7 @@ typedef union _KPHM_REGISTRY_PARAMETERS
 typedef struct _KPHM_REGISTRY
 {
     CLIENT_ID ClientId;
+    ULONG ServiceTag;
     ULONG64 ProcessStartKey;
 
     union


### PR DESCRIPTION
This change adds the acting threads service tag to informer messages, granting additional insight whom did what.