### PR TITLE
calling convention fixes for better consistency

### DIFF
--- a/kphlib/include/kphdyndata.h
+++ b/kphlib/include/kphdyndata.h
@@ -14,7 +14,7 @@
 #include <kphdyn.h>
 
 _Must_inspect_result_
-NTSTATUS KphDynDataGetConfiguration(
+NTSTATUS NTAPI KphDynDataGetConfiguration(
     _In_ PKPH_DYNDATA DynData,
     _In_ ULONG DynDataLength,
     _In_ USHORT MajorVersion,

--- a/kphlib/include/kphmsg.h
+++ b/kphlib/include/kphmsg.h
@@ -412,13 +412,13 @@ C_ASSERT(KPH_MESSAGE_MIN_SIZE == FIELD_OFFSET(KPH_MESSAGE, _Dyn.Buffer));
 
 EXTERN_C_START
 
-VOID KphMsgInit(
+VOID NTAPI KphMsgInit(
     _Out_writes_bytes_(KPH_MESSAGE_MIN_SIZE) PKPH_MESSAGE Message,
     _In_ KPH_MESSAGE_ID MessageId
     );
 
 _Must_inspect_result_
-NTSTATUS KphMsgValidate(
+NTSTATUS NTAPI KphMsgValidate(
     _In_ PCKPH_MESSAGE Message
     );
 

--- a/kphlib/include/kphmsgdyn.h
+++ b/kphlib/include/kphmsgdyn.h
@@ -27,65 +27,65 @@ typedef struct _KPHM_SIZED_BUFFER
     PBYTE Buffer;
 } KPHM_SIZED_BUFFER, *PKPHM_SIZED_BUFFER;
 
-VOID KphMsgDynClear(
+VOID NTAPI KphMsgDynClear(
     _Inout_ PKPH_MESSAGE Message
     );
 
-VOID KphMsgDynClearLast(
+VOID NTAPI KphMsgDynClearLast(
     _Inout_ PKPH_MESSAGE Message
     );
 
-USHORT KphMsgDynRemaining(
+USHORT NTAPI KphMsgDynRemaining(
     _In_ PCKPH_MESSAGE Message
     );
 
 _Must_inspect_result_
-NTSTATUS KphMsgDynAddUnicodeString(
+NTSTATUS NTAPI KphMsgDynAddUnicodeString(
     _Inout_ PKPH_MESSAGE Message,
     _In_ KPH_MESSAGE_FIELD_ID FieldId,
     _In_ PCUNICODE_STRING String
     );
 
-NTSTATUS KphMsgDynGetUnicodeString(
+NTSTATUS NTAPI KphMsgDynGetUnicodeString(
     _In_ PCKPH_MESSAGE Message,
     _In_ KPH_MESSAGE_FIELD_ID FieldId,
     _Out_ PUNICODE_STRING String
     );
 
 _Must_inspect_result_
-NTSTATUS KphMsgDynAddAnsiString(
+NTSTATUS NTAPI KphMsgDynAddAnsiString(
     _Inout_ PKPH_MESSAGE Message,
     _In_ KPH_MESSAGE_FIELD_ID FieldId,
     _In_ PCANSI_STRING String
     );
 
-NTSTATUS KphMsgDynGetAnsiString(
+NTSTATUS NTAPI KphMsgDynGetAnsiString(
     _In_ PCKPH_MESSAGE Message,
     _In_ KPH_MESSAGE_FIELD_ID FieldId,
     _Out_ PANSI_STRING String
     );
 
 _Must_inspect_result_
-NTSTATUS KphMsgDynAddStackTrace(
+NTSTATUS NTAPI KphMsgDynAddStackTrace(
     _Inout_ PKPH_MESSAGE Message,
     _In_ KPH_MESSAGE_FIELD_ID FieldId,
     _In_ PKPHM_STACK_TRACE StackTrace
     );
 
-NTSTATUS KphMsgDynGetStackTrace(
+NTSTATUS NTAPI KphMsgDynGetStackTrace(
     _In_ PCKPH_MESSAGE Message,
     _In_ KPH_MESSAGE_FIELD_ID FieldId,
     _Out_ PKPHM_STACK_TRACE StackTrace
     );
 
 _Must_inspect_result_
-NTSTATUS KphMsgDynAddSizedBuffer(
+NTSTATUS NTAPI KphMsgDynAddSizedBuffer(
     _Inout_ PKPH_MESSAGE Message,
     _In_ KPH_MESSAGE_FIELD_ID FieldId,
     _In_ PKPHM_SIZED_BUFFER SizedBuffer
     );
 
-NTSTATUS KphMsgDynGetSizedBuffer(
+NTSTATUS NTAPI KphMsgDynGetSizedBuffer(
     _In_ PCKPH_MESSAGE Message,
     _In_ KPH_MESSAGE_FIELD_ID FieldId,
     _Out_ PKPHM_SIZED_BUFFER SizedBuffer

--- a/phlib/include/apiimport.h
+++ b/phlib/include/apiimport.h
@@ -229,7 +229,7 @@ typedef VOID (WINAPI* _UnsubscribeServiceChangeNotifications)(
     _In_ PSC_NOTIFICATION_REGISTRATION pSubscription
     );
 
-#define PH_DECLARE_IMPORT(Name) _##Name Name##_Import(VOID)
+#define PH_DECLARE_IMPORT(Name) _##Name NTAPI Name##_Import(VOID)
 
 PH_DECLARE_IMPORT(NtQueryInformationEnlistment);
 PH_DECLARE_IMPORT(NtQueryInformationResourceManager);

--- a/phlib/include/appresolver.h
+++ b/phlib/include/appresolver.h
@@ -14,23 +14,23 @@
 
 EXTERN_C_START
 
-HRESULT PhAppResolverGetAppIdForProcess(
+HRESULT NTAPI PhAppResolverGetAppIdForProcess(
     _In_ HANDLE ProcessId,
     _Out_ PPH_STRING *ApplicationUserModelId
     );
 
-HRESULT PhAppResolverGetAppIdForWindow(
+HRESULT NTAPI PhAppResolverGetAppIdForWindow(
     _In_ HWND WindowHandle,
     _Out_ PPH_STRING *ApplicationUserModelId
     );
 
-HRESULT PhAppResolverActivateAppId(
+HRESULT NTAPI PhAppResolverActivateAppId(
     _In_ PPH_STRING ApplicationUserModelId,
     _In_opt_ PWSTR CommandLine,
     _Out_opt_ HANDLE *ProcessId
     );
 
-HRESULT PhAppResolverPackageTerminateProcess(
+HRESULT NTAPI PhAppResolverPackageTerminateProcess(
     _In_ PPH_STRING PackageFullName
     );
 
@@ -40,36 +40,36 @@ typedef struct _PH_PACKAGE_TASK_ENTRY
     GUID TaskGuid;
 } PH_PACKAGE_TASK_ENTRY, *PPH_PACKAGE_TASK_ENTRY;
 
-PPH_LIST PhAppResolverEnumeratePackageBackgroundTasks(
+PPH_LIST NTAPI PhAppResolverEnumeratePackageBackgroundTasks(
     _In_ PPH_STRING PackageFullName
     );
 
-HRESULT PhAppResolverPackageStopSessionRedirection(
+HRESULT NTAPI PhAppResolverPackageStopSessionRedirection(
     _In_ PPH_STRING PackageFullName
     );
 
-PPH_STRING PhGetAppContainerName(
+PPH_STRING NTAPI PhGetAppContainerName(
     _In_ PSID AppContainerSid
     );
 
-PPH_STRING PhGetAppContainerSidFromName(
+PPH_STRING NTAPI PhGetAppContainerSidFromName(
     _In_ PWSTR AppContainerName
     );
 
-PPH_STRING PhGetAppContainerPackageName(
+PPH_STRING NTAPI PhGetAppContainerPackageName(
     _In_ PSID Sid
     );
 
-BOOLEAN PhIsPackageCapabilitySid(
+BOOLEAN NTAPI PhIsPackageCapabilitySid(
     _In_ PSID AppContainerSid,
     _In_ PSID Sid
     );
 
-PPH_STRING PhGetPackagePath(
+PPH_STRING NTAPI PhGetPackagePath(
     _In_ PPH_STRING PackageFullName
     );
 
-PPH_LIST PhGetPackageAssetsFromResourceFile(
+PPH_LIST NTAPI PhGetPackageAssetsFromResourceFile(
     _In_ PWSTR FilePath
     );
 
@@ -85,18 +85,18 @@ typedef struct _PH_APPUSERMODELID_ENUM_ENTRY
     PPH_STRING SmallLogoPath;
 } PH_APPUSERMODELID_ENUM_ENTRY, *PPH_APPUSERMODELID_ENUM_ENTRY;
 
-PPH_LIST PhEnumApplicationUserModelIds(
+PPH_LIST NTAPI PhEnumApplicationUserModelIds(
     VOID
     );
 
-HRESULT PhAppResolverGetPackageResourceFilePath(
+HRESULT NTAPI PhAppResolverGetPackageResourceFilePath(
     _In_ PCWSTR PackageFullName,
     _In_ PCWSTR Key,
     _Out_ PWSTR* FilePath
     );
 
 _Success_(return)
-BOOLEAN PhAppResolverGetPackageIcon(
+BOOLEAN NTAPI PhAppResolverGetPackageIcon(
     _In_ HANDLE ProcessId,
     _In_ PPH_STRING PackageFullName,
     _Out_opt_ HICON* IconLarge,
@@ -106,23 +106,23 @@ BOOLEAN PhAppResolverGetPackageIcon(
 
 // Immersive PLM task support
 
-HRESULT PhAppResolverBeginCrashDumpTask(
+HRESULT NTAPI PhAppResolverBeginCrashDumpTask(
     _In_ HANDLE ProcessId,
     _Out_ HANDLE* TaskHandle
     );
 
-HRESULT PhAppResolverBeginCrashDumpTaskByHandle(
+HRESULT NTAPI PhAppResolverBeginCrashDumpTaskByHandle(
     _In_ HANDLE ProcessHandle,
     _Out_ HANDLE* TaskHandle
     );
 
-HRESULT PhAppResolverEndCrashDumpTask(
+HRESULT NTAPI PhAppResolverEndCrashDumpTask(
     _In_ HANDLE TaskHandle
     );
 
 // Desktop Bridge
 
-HRESULT PhCreateProcessDesktopPackage(
+HRESULT NTAPI PhCreateProcessDesktopPackage(
     _In_ PWSTR ApplicationUserModelId,
     _In_ PWSTR Executable,
     _In_ PWSTR Arguments,

--- a/phlib/include/kphcomms.h
+++ b/phlib/include/kphcomms.h
@@ -14,7 +14,7 @@
 
 #include <kphmsg.h>
 
-NTSTATUS KphFilterLoadUnload(
+NTSTATUS NTAPI KphFilterLoadUnload(
     _In_ PPH_STRINGREF ServiceName,
     _In_ BOOLEAN LoadDriver
     );
@@ -40,26 +40,26 @@ BOOLEAN (NTAPI *PKPH_COMMS_CALLBACK)(
     );
 
 _Must_inspect_result_
-NTSTATUS KphCommsStart(
+NTSTATUS NTAPI KphCommsStart(
     _In_ PPH_STRINGREF PortName,
     _In_opt_ PKPH_COMMS_CALLBACK Callback
     );
 
-VOID KphCommsStop(
+VOID NTAPI KphCommsStop(
     VOID
     );
 
-BOOLEAN KphCommsIsConnected(
+BOOLEAN NTAPI KphCommsIsConnected(
     VOID
     );
 
-NTSTATUS KphCommsReplyMessage(
+NTSTATUS NTAPI KphCommsReplyMessage(
     _In_ ULONG_PTR ReplyToken,
     _In_ PKPH_MESSAGE Message
     );
 
 _Must_inspect_result_
-NTSTATUS KphCommsSendMessage(
+NTSTATUS NTAPI KphCommsSendMessage(
     _Inout_ PKPH_MESSAGE Message
     );
 

--- a/phlib/include/phutil.h
+++ b/phlib/include/phutil.h
@@ -1853,6 +1853,7 @@ PhHungWindowFromGhostWindow(
 
 PHLIBAPI
 NTSTATUS
+NTAPI
 PhGetFileData(
     _In_ HANDLE FileHandle,
     _Out_ PVOID* Buffer,

--- a/phlib/include/settings.h
+++ b/phlib/include/settings.h
@@ -65,6 +65,7 @@ typedef struct _PH_SETTING
 
 PHLIBAPI
 VOID
+NTAPI
 PhSettingsInitialization(
     VOID
     );
@@ -376,7 +377,9 @@ VOID PhResetSettings(
 // begin_phapppub
 // High-level settings creation
 
-VOID PhAddSetting(
+VOID
+NTAPI
+PhAddSetting(
     _In_ PH_SETTING_TYPE Type,
     _In_ PPH_STRINGREF Name,
     _In_ PPH_STRINGREF DefaultValue


### PR DESCRIPTION
The changes helps to compile the phlib into projects set up for different default calling conventions (like Task Explorer)