### PR TITLE
replace all NtReadVirtualMemory occurrances with safe variant

### DIFF
--- a/SystemInformer/anawait.c
+++ b/SystemInformer/anawait.c
@@ -303,7 +303,7 @@ BOOLEAN NTAPI PhpWalkThreadStackAnalyzeCallback(
         PVOID timeoutAddress = StackFrame->Params[1];
         LARGE_INTEGER timeout;
 
-        if (NT_SUCCESS(NtReadVirtualMemory(
+        if (NT_SUCCESS(PhSafeReadVirtualMemory(
             context->ProcessHandle,
             timeoutAddress,
             &timeout,
@@ -893,7 +893,7 @@ VOID PhpGetWfmoInformation(
         {
             ULONG handles32[MAXIMUM_WAIT_OBJECTS];
 
-            if (NT_SUCCESS(status = NtReadVirtualMemory(
+            if (NT_SUCCESS(status = PhSafeReadVirtualMemory(
                 ProcessHandle,
                 AddressOfHandles,
                 handles32,
@@ -908,7 +908,7 @@ VOID PhpGetWfmoInformation(
         else
         {
 #endif
-            status = NtReadVirtualMemory(
+            status = PhSafeReadVirtualMemory(
                 ProcessHandle,
                 AddressOfHandles,
                 handles,

--- a/SystemInformer/appsup.c
+++ b/SystemInformer/appsup.c
@@ -165,7 +165,7 @@ NTSTATUS PhGetProcessSwitchContext(
     {
         if (WindowsVersion >= WINDOWS_8)
         {
-            if (!NT_SUCCESS(status = NtReadVirtualMemory(
+            if (!NT_SUCCESS(status = PhSafeReadVirtualMemory(
                 ProcessHandle,
                 PTR_ADD_OFFSET(peb32, FIELD_OFFSET(PEB32, pShimData)),
                 &data32,
@@ -176,7 +176,7 @@ NTSTATUS PhGetProcessSwitchContext(
         }
         else
         {
-            if (!NT_SUCCESS(status = NtReadVirtualMemory(
+            if (!NT_SUCCESS(status = PhSafeReadVirtualMemory(
                 ProcessHandle,
                 PTR_ADD_OFFSET(peb32, FIELD_OFFSET(PEB32, pContextData)),
                 &data32,
@@ -196,7 +196,7 @@ NTSTATUS PhGetProcessSwitchContext(
 
         if (WindowsVersion >= WINDOWS_8)
         {
-            if (!NT_SUCCESS(status = NtReadVirtualMemory(
+            if (!NT_SUCCESS(status = PhSafeReadVirtualMemory(
                 ProcessHandle,
                 PTR_ADD_OFFSET(basicInfo.PebBaseAddress, FIELD_OFFSET(PEB, pShimData)),
                 &data,
@@ -207,7 +207,7 @@ NTSTATUS PhGetProcessSwitchContext(
         }
         else
         {
-            if (!NT_SUCCESS(status = NtReadVirtualMemory(
+            if (!NT_SUCCESS(status = PhSafeReadVirtualMemory(
                 ProcessHandle,
                 PTR_ADD_OFFSET(basicInfo.PebBaseAddress, FIELD_OFFSET(PEB, pContextData)),
                 &data,
@@ -225,7 +225,7 @@ NTSTATUS PhGetProcessSwitchContext(
 
     if (WindowsVersion >= WINDOWS_10_RS5)
     {
-        if (!NT_SUCCESS(status = NtReadVirtualMemory(
+        if (!NT_SUCCESS(status = PhSafeReadVirtualMemory(
             ProcessHandle,
             PTR_ADD_OFFSET(data, 2040 + 24), // Magic value from SbReadProcContextByHandle
             Guid,
@@ -236,7 +236,7 @@ NTSTATUS PhGetProcessSwitchContext(
     }
     else if (WindowsVersion >= WINDOWS_10_RS2)
     {
-        if (!NT_SUCCESS(status = NtReadVirtualMemory(
+        if (!NT_SUCCESS(status = PhSafeReadVirtualMemory(
             ProcessHandle,
             PTR_ADD_OFFSET(data, 1544),
             Guid,
@@ -247,7 +247,7 @@ NTSTATUS PhGetProcessSwitchContext(
     }
     else if (WindowsVersion >= WINDOWS_10)
     {
-        if (!NT_SUCCESS(status = NtReadVirtualMemory(
+        if (!NT_SUCCESS(status = PhSafeReadVirtualMemory(
             ProcessHandle,
             PTR_ADD_OFFSET(data, 2040 + 24), // Magic value from SbReadProcContextByHandle
             Guid,
@@ -258,7 +258,7 @@ NTSTATUS PhGetProcessSwitchContext(
     }
     else if (WindowsVersion >= WINDOWS_8_1)
     {
-        if (!NT_SUCCESS(status = NtReadVirtualMemory(
+        if (!NT_SUCCESS(status = PhSafeReadVirtualMemory(
             ProcessHandle,
             PTR_ADD_OFFSET(data, 2040 + 16), // Magic value from SbReadProcContextByHandle
             Guid,
@@ -269,7 +269,7 @@ NTSTATUS PhGetProcessSwitchContext(
     }
     else if (WindowsVersion >= WINDOWS_8)
     {
-        if (!NT_SUCCESS(status = NtReadVirtualMemory(
+        if (!NT_SUCCESS(status = PhSafeReadVirtualMemory(
             ProcessHandle,
             PTR_ADD_OFFSET(data, 2040), // Magic value from SbReadProcContextByHandle
             Guid,
@@ -280,7 +280,7 @@ NTSTATUS PhGetProcessSwitchContext(
     }
     else
     {
-        if (!NT_SUCCESS(status = NtReadVirtualMemory(
+        if (!NT_SUCCESS(status = PhSafeReadVirtualMemory(
             ProcessHandle,
             PTR_ADD_OFFSET(data, 32), // Magic value from WdcGetProcessSwitchContext
             Guid,

--- a/SystemInformer/heapinfo.c
+++ b/SystemInformer/heapinfo.c
@@ -949,7 +949,7 @@ NTSTATUS PhGetProcessDefaultHeap(
         if (!NT_SUCCESS(status))
             return status;
 
-        status = NtReadVirtualMemory(
+        status = PhSafeReadVirtualMemory(
             ProcessHandle,
             PTR_ADD_OFFSET(peb32, UFIELD_OFFSET(PEB32, ProcessHeap)),
             &processHeapsPtr32,
@@ -981,7 +981,7 @@ NTSTATUS PhGetProcessDefaultHeap(
         if (!NT_SUCCESS(status))
             return status;
 
-        status = NtReadVirtualMemory(
+        status = PhSafeReadVirtualMemory(
             ProcessHandle,
             PTR_ADD_OFFSET(basicInfo.PebBaseAddress, UFIELD_OFFSET(PEB, ProcessHeap)),
             &processHeapsPtr,
@@ -1015,7 +1015,7 @@ NTSTATUS PhGetProcessDefaultHeap(
 //
 //    if (WindowsVersion >= WINDOWS_10_20H1)
 //    {
-//        status = NtReadVirtualMemory(
+//        status = PhSafeReadVirtualMemory(
 //            ProcessHandle,
 //            PTR_ADD_OFFSET(HeapAddress, IsWow64 ? 0xEA : 0x1A2),
 //            &frontEndHeapType,
@@ -1054,7 +1054,7 @@ NTSTATUS PhGetProcessDefaultHeap(
 //
 //    if (WindowsVersion >= WINDOWS_10_20H1)
 //    {
-//        status = NtReadVirtualMemory(
+//        status = PhSafeReadVirtualMemory(
 //            ProcessHandle,
 //            PTR_ADD_OFFSET(HeapAddress, IsWow64 ? 0x1F4 : 0x238),
 //            heapCounters,
@@ -1095,7 +1095,7 @@ NTSTATUS PhGetProcessDefaultHeap(
 //
 //    if (WindowsVersion >= WINDOWS_10_20H1)
 //    {
-//        status = NtReadVirtualMemory(
+//        status = PhSafeReadVirtualMemory(
 //            ProcessHandle,
 //            PTR_ADD_OFFSET(HeapAddress, IsWow64 ? 0x80 : 0x80),
 //            heapCounters,
@@ -1131,7 +1131,7 @@ NTSTATUS PhGetProcessDefaultHeap(
 //
 //    if (NT_SUCCESS(PhGetProcessBasicInformation(ProcessHandle, &basicInfo)) && basicInfo.PebBaseAddress != 0)
 //    {
-//        if (NT_SUCCESS(NtReadVirtualMemory(
+//        if (NT_SUCCESS(PhSafeReadVirtualMemory(
 //            ProcessHandle,
 //            PTR_ADD_OFFSET(basicInfo.PebBaseAddress, UFIELD_OFFSET(PEB, NumberOfHeaps)),
 //            &numberOfHeaps,
@@ -1142,8 +1142,8 @@ NTSTATUS PhGetProcessDefaultHeap(
 //            processHeaps = PhAllocateZero(numberOfHeaps * sizeof(PVOID));
 //
 //            if (
-//                NT_SUCCESS(NtReadVirtualMemory(ProcessHandle, PTR_ADD_OFFSET(basicInfo.PebBaseAddress, UFIELD_OFFSET(PEB, ProcessHeaps)), &processHeapsPtr, sizeof(PVOID), NULL)) &&
-//                NT_SUCCESS(NtReadVirtualMemory(ProcessHandle, processHeapsPtr, processHeaps, numberOfHeaps * sizeof(PVOID), NULL))
+//                NT_SUCCESS(PhSafeReadVirtualMemory(ProcessHandle, PTR_ADD_OFFSET(basicInfo.PebBaseAddress, UFIELD_OFFSET(PEB, ProcessHeaps)), &processHeapsPtr, sizeof(PVOID), NULL)) &&
+//                NT_SUCCESS(PhSafeReadVirtualMemory(ProcessHandle, processHeapsPtr, processHeaps, numberOfHeaps * sizeof(PVOID), NULL))
 //                )
 //            {
 //                for (ULONG i = 0; i < numberOfHeaps; i++)
@@ -1185,7 +1185,7 @@ NTSTATUS PhGetProcessDefaultHeap(
 //
 //    if (NT_SUCCESS(PhGetProcessPeb32(ProcessHandle, &peb32)) && peb32 != 0)
 //    {
-//        if (NT_SUCCESS(NtReadVirtualMemory(
+//        if (NT_SUCCESS(PhSafeReadVirtualMemory(
 //            ProcessHandle,
 //            PTR_ADD_OFFSET(peb32, UFIELD_OFFSET(PEB32, NumberOfHeaps)),
 //            &numberOfHeaps,
@@ -1196,8 +1196,8 @@ NTSTATUS PhGetProcessDefaultHeap(
 //            processHeaps32 = PhAllocateZero(numberOfHeaps * sizeof(ULONG));
 //
 //            if (
-//                NT_SUCCESS(NtReadVirtualMemory(ProcessHandle, PTR_ADD_OFFSET(peb32, UFIELD_OFFSET(PEB32, ProcessHeaps)), &processHeapsPtr32, sizeof(ULONG), NULL)) &&
-//                NT_SUCCESS(NtReadVirtualMemory(ProcessHandle, UlongToPtr(processHeapsPtr32), processHeaps32, numberOfHeaps * sizeof(ULONG), NULL))
+//                NT_SUCCESS(PhSafeReadVirtualMemory(ProcessHandle, PTR_ADD_OFFSET(peb32, UFIELD_OFFSET(PEB32, ProcessHeaps)), &processHeapsPtr32, sizeof(ULONG), NULL)) &&
+//                NT_SUCCESS(PhSafeReadVirtualMemory(ProcessHandle, UlongToPtr(processHeapsPtr32), processHeaps32, numberOfHeaps * sizeof(ULONG), NULL))
 //                )
 //            {
 //                for (ULONG i = 0; i < numberOfHeaps; i++)

--- a/SystemInformer/memedit.c
+++ b/SystemInformer/memedit.c
@@ -217,7 +217,7 @@ INT_PTR CALLBACK PhpMemoryEditorDlgProc(
                 return TRUE;
             }
 
-            if (!NT_SUCCESS(status = NtReadVirtualMemory(
+            if (!NT_SUCCESS(status = PhSafeReadVirtualMemory(
                 context->ProcessHandle,
                 context->BaseAddress,
                 context->Buffer,
@@ -494,7 +494,7 @@ INT_PTR CALLBACK PhpMemoryEditorDlgProc(
                 {
                     NTSTATUS status;
 
-                    if (!NT_SUCCESS(status = NtReadVirtualMemory(
+                    if (!NT_SUCCESS(status = PhSafeReadVirtualMemory(
                         context->ProcessHandle,
                         context->BaseAddress,
                         context->Buffer,

--- a/SystemInformer/memprv.c
+++ b/SystemInformer/memprv.c
@@ -607,7 +607,7 @@ NTSTATUS PhpUpdateMemoryRegionTypes(
             // HACK: Windows 10 RS2 and above 'added TEB/PEB sub-VAD segments' and we need to tag individual sections. (dmex)
             PhpSetMemoryRegionType(List, processPeb, WindowsVersion < WINDOWS_10_RS2 ? TRUE : FALSE, PebRegion);
 
-            if (NT_SUCCESS(NtReadVirtualMemory(
+            if (NT_SUCCESS(PhSafeReadVirtualMemory(
                 ProcessHandle,
                 PTR_ADD_OFFSET(processPeb, UFIELD_OFFSET(PEB, NumberOfHeaps)),
                 &numberOfHeaps,
@@ -618,8 +618,8 @@ NTSTATUS PhpUpdateMemoryRegionTypes(
                 processHeaps = PhAllocate(numberOfHeaps * sizeof(PVOID));
 
                 if (
-                    NT_SUCCESS(NtReadVirtualMemory(ProcessHandle, PTR_ADD_OFFSET(processPeb, UFIELD_OFFSET(PEB, ProcessHeaps)), &processHeapsPtr, sizeof(PVOID), NULL)) &&
-                    NT_SUCCESS(NtReadVirtualMemory(ProcessHandle, processHeapsPtr, processHeaps, numberOfHeaps * sizeof(PVOID), NULL))
+                    NT_SUCCESS(PhSafeReadVirtualMemory(ProcessHandle, PTR_ADD_OFFSET(processPeb, UFIELD_OFFSET(PEB, ProcessHeaps)), &processHeapsPtr, sizeof(PVOID), NULL)) &&
+                    NT_SUCCESS(PhSafeReadVirtualMemory(ProcessHandle, processHeapsPtr, processHeaps, numberOfHeaps * sizeof(PVOID), NULL))
                     )
                 {
                     for (i = 0; i < numberOfHeaps; i++)
@@ -631,7 +631,7 @@ NTSTATUS PhpUpdateMemoryRegionTypes(
                             memoryItem->u.Heap.Index = i;
 
                             // Try to read heap class from the header
-                            if (NT_SUCCESS(NtReadVirtualMemory(ProcessHandle, processHeaps[i], &buffer, sizeof(buffer), NULL)))
+                            if (NT_SUCCESS(PhSafeReadVirtualMemory(ProcessHandle, processHeaps[i], &buffer, sizeof(buffer), NULL)))
                             {
                                 if (WindowsVersion >= WINDOWS_8)
                                 {
@@ -682,7 +682,7 @@ NTSTATUS PhpUpdateMemoryRegionTypes(
             }
 
             // ApiSet schema map
-            if (NT_SUCCESS(NtReadVirtualMemory(
+            if (NT_SUCCESS(PhSafeReadVirtualMemory(
                 ProcessHandle,
                 PTR_ADD_OFFSET(processPeb, FIELD_OFFSET(PEB, ApiSetMap)),
                 &apiSetMap,
@@ -694,7 +694,7 @@ NTSTATUS PhpUpdateMemoryRegionTypes(
             }
 
             // CSR shared memory
-            if (NT_SUCCESS(NtReadVirtualMemory(
+            if (NT_SUCCESS(PhSafeReadVirtualMemory(
                 ProcessHandle,
                 PTR_ADD_OFFSET(processPeb, FIELD_OFFSET(PEB, ReadOnlySharedMemoryBase)),
                 &readOnlySharedMemory,
@@ -706,7 +706,7 @@ NTSTATUS PhpUpdateMemoryRegionTypes(
             }
 
             // CodePage data
-            if (NT_SUCCESS(NtReadVirtualMemory(
+            if (NT_SUCCESS(PhSafeReadVirtualMemory(
                 ProcessHandle,
                 PTR_ADD_OFFSET(processPeb, FIELD_OFFSET(PEB, AnsiCodePageData)),
                 &codePageData,
@@ -718,7 +718,7 @@ NTSTATUS PhpUpdateMemoryRegionTypes(
             }
 
             // GDI shared handle table
-            if (NT_SUCCESS(NtReadVirtualMemory(
+            if (NT_SUCCESS(PhSafeReadVirtualMemory(
                 ProcessHandle,
                 PTR_ADD_OFFSET(processPeb, FIELD_OFFSET(PEB, GdiSharedHandleTable)),
                 &gdiSharedHandleTable,
@@ -730,7 +730,7 @@ NTSTATUS PhpUpdateMemoryRegionTypes(
             }
 
             // Shim data
-            if (NT_SUCCESS(NtReadVirtualMemory(
+            if (NT_SUCCESS(PhSafeReadVirtualMemory(
                 ProcessHandle,
                 PTR_ADD_OFFSET(processPeb, FIELD_OFFSET(PEB, pShimData)),
                 &shimData,
@@ -742,7 +742,7 @@ NTSTATUS PhpUpdateMemoryRegionTypes(
             }
 
             // Process activation context data
-            if (NT_SUCCESS(NtReadVirtualMemory(
+            if (NT_SUCCESS(PhSafeReadVirtualMemory(
                 ProcessHandle,
                 PTR_ADD_OFFSET(processPeb, FIELD_OFFSET(PEB, ActivationContextData)),
                 &activationContextData,
@@ -757,7 +757,7 @@ NTSTATUS PhpUpdateMemoryRegionTypes(
             }
 
             // System-default activation context data
-            if (NT_SUCCESS(NtReadVirtualMemory(
+            if (NT_SUCCESS(PhSafeReadVirtualMemory(
                 ProcessHandle,
                 PTR_ADD_OFFSET(processPeb, FIELD_OFFSET(PEB, SystemDefaultActivationContextData)),
                 &defaultActivationContextData,
@@ -772,7 +772,7 @@ NTSTATUS PhpUpdateMemoryRegionTypes(
             }
 
             // WER registration data
-            if (NT_SUCCESS(NtReadVirtualMemory(
+            if (NT_SUCCESS(PhSafeReadVirtualMemory(
                 ProcessHandle,
                 PTR_ADD_OFFSET(processPeb, FIELD_OFFSET(PEB, WerRegistrationData)),
                 &werRegistrationData,
@@ -784,7 +784,7 @@ NTSTATUS PhpUpdateMemoryRegionTypes(
             }
 
             // Silo shared data
-            if (NT_SUCCESS(NtReadVirtualMemory(
+            if (NT_SUCCESS(PhSafeReadVirtualMemory(
                 ProcessHandle,
                 PTR_ADD_OFFSET(processPeb, FIELD_OFFSET(PEB, SharedData)),
                 &siloSharedData,
@@ -796,7 +796,7 @@ NTSTATUS PhpUpdateMemoryRegionTypes(
             }
 
             // Telemetry coverage map
-            if (NT_SUCCESS(NtReadVirtualMemory(
+            if (NT_SUCCESS(PhSafeReadVirtualMemory(
                 ProcessHandle,
                 PTR_ADD_OFFSET(processPeb, FIELD_OFFSET(PEB, TelemetryCoverageHeader)),
                 &telemetryCoverageData,
@@ -814,7 +814,7 @@ NTSTATUS PhpUpdateMemoryRegionTypes(
             isWow64 = TRUE;
             PhpSetMemoryRegionType(List, processPeb32, TRUE, Peb32Region);
 
-            if (NT_SUCCESS(NtReadVirtualMemory(
+            if (NT_SUCCESS(PhSafeReadVirtualMemory(
                 ProcessHandle,
                 PTR_ADD_OFFSET(processPeb32, UFIELD_OFFSET(PEB32, NumberOfHeaps)),
                 &numberOfHeaps,
@@ -825,8 +825,8 @@ NTSTATUS PhpUpdateMemoryRegionTypes(
                 processHeaps32 = PhAllocate(numberOfHeaps * sizeof(ULONG));
 
                 if (
-                    NT_SUCCESS(NtReadVirtualMemory(ProcessHandle, PTR_ADD_OFFSET(processPeb32, UFIELD_OFFSET(PEB32, ProcessHeaps)), &processHeapsPtr32, sizeof(ULONG), NULL)) &&
-                    NT_SUCCESS(NtReadVirtualMemory(ProcessHandle, UlongToPtr(processHeapsPtr32), processHeaps32, numberOfHeaps * sizeof(ULONG), NULL))
+                    NT_SUCCESS(PhSafeReadVirtualMemory(ProcessHandle, PTR_ADD_OFFSET(processPeb32, UFIELD_OFFSET(PEB32, ProcessHeaps)), &processHeapsPtr32, sizeof(ULONG), NULL)) &&
+                    NT_SUCCESS(PhSafeReadVirtualMemory(ProcessHandle, UlongToPtr(processHeapsPtr32), processHeaps32, numberOfHeaps * sizeof(ULONG), NULL))
                     )
                 {
                     for (i = 0; i < numberOfHeaps; i++)
@@ -840,7 +840,7 @@ NTSTATUS PhpUpdateMemoryRegionTypes(
             }
 
             // ApiSet schema map
-            if (NT_SUCCESS(NtReadVirtualMemory(
+            if (NT_SUCCESS(PhSafeReadVirtualMemory(
                 ProcessHandle,
                 PTR_ADD_OFFSET(processPeb32, UFIELD_OFFSET(PEB32, ApiSetMap)),
                 &apiSetMap32,
@@ -852,7 +852,7 @@ NTSTATUS PhpUpdateMemoryRegionTypes(
             }
 
             // CSR shared memory
-            if (NT_SUCCESS(NtReadVirtualMemory(
+            if (NT_SUCCESS(PhSafeReadVirtualMemory(
                 ProcessHandle,
                 PTR_ADD_OFFSET(processPeb32, UFIELD_OFFSET(PEB32, ReadOnlySharedMemoryBase)),
                 &readOnlySharedMemory32,
@@ -864,7 +864,7 @@ NTSTATUS PhpUpdateMemoryRegionTypes(
             }
 
             // CodePage data
-            if (NT_SUCCESS(NtReadVirtualMemory(
+            if (NT_SUCCESS(PhSafeReadVirtualMemory(
                 ProcessHandle,
                 PTR_ADD_OFFSET(processPeb32, UFIELD_OFFSET(PEB32, AnsiCodePageData)),
                 &codePageData32,
@@ -876,7 +876,7 @@ NTSTATUS PhpUpdateMemoryRegionTypes(
             }
 
             // GDI shared handle table
-            if (NT_SUCCESS(NtReadVirtualMemory(
+            if (NT_SUCCESS(PhSafeReadVirtualMemory(
                 ProcessHandle,
                 PTR_ADD_OFFSET(processPeb32, UFIELD_OFFSET(PEB32, GdiSharedHandleTable)),
                 &gdiSharedHandleTable32,
@@ -888,7 +888,7 @@ NTSTATUS PhpUpdateMemoryRegionTypes(
             }
 
             // Shim data
-            if (NT_SUCCESS(NtReadVirtualMemory(
+            if (NT_SUCCESS(PhSafeReadVirtualMemory(
                 ProcessHandle,
                 PTR_ADD_OFFSET(processPeb32, UFIELD_OFFSET(PEB32, pShimData)),
                 &shimData32,
@@ -900,7 +900,7 @@ NTSTATUS PhpUpdateMemoryRegionTypes(
             }
 
             // Process activation context data
-            if (NT_SUCCESS(NtReadVirtualMemory(
+            if (NT_SUCCESS(PhSafeReadVirtualMemory(
                 ProcessHandle,
                 PTR_ADD_OFFSET(processPeb32, UFIELD_OFFSET(PEB32, ActivationContextData)),
                 &activationContextData32,
@@ -915,7 +915,7 @@ NTSTATUS PhpUpdateMemoryRegionTypes(
             }
 
             // System-default activation context data
-            if (NT_SUCCESS(NtReadVirtualMemory(
+            if (NT_SUCCESS(PhSafeReadVirtualMemory(
                 ProcessHandle,
                 PTR_ADD_OFFSET(processPeb32, UFIELD_OFFSET(PEB32, SystemDefaultActivationContextData)),
                 &defaultActivationContextData32,
@@ -930,7 +930,7 @@ NTSTATUS PhpUpdateMemoryRegionTypes(
             }
 
             // WER registration data
-            if (NT_SUCCESS(NtReadVirtualMemory(
+            if (NT_SUCCESS(PhSafeReadVirtualMemory(
                 ProcessHandle,
                 PTR_ADD_OFFSET(processPeb32, UFIELD_OFFSET(PEB32, WerRegistrationData)),
                 &werRegistrationData32,
@@ -942,7 +942,7 @@ NTSTATUS PhpUpdateMemoryRegionTypes(
             }
 
             // Silo shared data
-            if (NT_SUCCESS(NtReadVirtualMemory(
+            if (NT_SUCCESS(PhSafeReadVirtualMemory(
                 ProcessHandle,
                 PTR_ADD_OFFSET(processPeb32, UFIELD_OFFSET(PEB32, SharedData)),
                 &siloSharedData32,
@@ -954,7 +954,7 @@ NTSTATUS PhpUpdateMemoryRegionTypes(
             }
 
             // Telemetry coverage map
-            if (NT_SUCCESS(NtReadVirtualMemory(
+            if (NT_SUCCESS(PhSafeReadVirtualMemory(
                 ProcessHandle,
                 PTR_ADD_OFFSET(processPeb32, UFIELD_OFFSET(PEB32, TelemetryCoverageHeader)),
                 &telemetryCoverageData32,
@@ -982,7 +982,7 @@ NTSTATUS PhpUpdateMemoryRegionTypes(
             if (memoryItem = PhpSetMemoryRegionType(List, thread->TebBase, WindowsVersion < WINDOWS_10_RS2 ? TRUE : FALSE, TebRegion))
                 memoryItem->u.Teb.ThreadId = thread->ThreadInfo.ClientId.UniqueThread;
 
-            if (NT_SUCCESS(NtReadVirtualMemory(ProcessHandle, thread->TebBase, &ntTib, sizeof(NT_TIB), &bytesRead)) &&
+            if (NT_SUCCESS(PhSafeReadVirtualMemory(ProcessHandle, thread->TebBase, &ntTib, sizeof(NT_TIB), &bytesRead)) &&
                 bytesRead == sizeof(NT_TIB))
             {
                 if ((ULONG_PTR)ntTib.StackLimit < (ULONG_PTR)ntTib.StackBase)
@@ -1000,7 +1000,7 @@ NTSTATUS PhpUpdateMemoryRegionTypes(
                     // 64-bit and 32-bit TEBs usually share the same memory region, so don't do anything for the 32-bit
                     // TEB.
 
-                    if (NT_SUCCESS(NtReadVirtualMemory(ProcessHandle, UlongToPtr(teb32), &ntTib32, sizeof(NT_TIB32), &bytesRead)) &&
+                    if (NT_SUCCESS(PhSafeReadVirtualMemory(ProcessHandle, UlongToPtr(teb32), &ntTib32, sizeof(NT_TIB32), &bytesRead)) &&
                         bytesRead == sizeof(NT_TIB32))
                     {
                         if (ntTib32.StackLimit < ntTib32.StackBase)
@@ -1054,7 +1054,7 @@ NTSTATUS PhpUpdateMemoryRegionTypes(
         {
             UCHAR buffer[HEAP_SEGMENT_MAX_SIZE];
 
-            if (NT_SUCCESS(NtReadVirtualMemory(ProcessHandle, memoryItem->BaseAddress, buffer, sizeof(buffer), NULL)))
+            if (NT_SUCCESS(PhSafeReadVirtualMemory(ProcessHandle, memoryItem->BaseAddress, buffer, sizeof(buffer), NULL)))
             {
                 PVOID candidateHeap = NULL;
                 ULONG candidateHeap32 = 0;
@@ -1100,7 +1100,7 @@ NTSTATUS PhpUpdateMemoryRegionTypes(
         {
             ACTIVATION_CONTEXT_DATA buffer;
 
-            if (NT_SUCCESS(NtReadVirtualMemory(ProcessHandle, memoryItem->BaseAddress, &buffer, sizeof(buffer), NULL)))
+            if (NT_SUCCESS(PhSafeReadVirtualMemory(ProcessHandle, memoryItem->BaseAddress, &buffer, sizeof(buffer), NULL)))
             {
                 if (buffer.Magic == ACTIVATION_CONTEXT_DATA_MAGIC)
                 {

--- a/SystemInformer/memsrch.c
+++ b/SystemInformer/memsrch.c
@@ -274,7 +274,7 @@ VOID PhSearchMemoryString(
             BOOLEAN printable2;
             ULONG length;
 
-            if (!NT_SUCCESS(NtReadVirtualMemory(
+            if (!NT_SUCCESS(PhSafeReadVirtualMemory(
                 ProcessHandle,
                 PTR_ADD_OFFSET(baseAddress, offset),
                 buffer,

--- a/SystemInformer/modprv.c
+++ b/SystemInformer/modprv.c
@@ -439,7 +439,7 @@ NTSTATUS PhpModuleQueryWorker(
             if (moduleItem->Type == PH_MODULE_TYPE_KERNEL_MODULE)
                 readVirtualMemoryCallback = KphReadVirtualMemoryUnsafe;
             else
-                readVirtualMemoryCallback = NtReadVirtualMemory;
+                readVirtualMemoryCallback = PhSafeReadVirtualMemory;
 
             // Note:
             // On Windows 7 the LDRP_IMAGE_NOT_AT_BASE flag doesn't appear to be used

--- a/SystemInformer/prpgmem.c
+++ b/SystemInformer/prpgmem.c
@@ -727,7 +727,7 @@ INT_PTR CALLBACK PhpProcessMemoryDlgProc(
 
                                         for (offset = 0; offset < memoryItem->RegionSize; offset += PAGE_SIZE)
                                         {
-                                            if (NT_SUCCESS(NtReadVirtualMemory(
+                                            if (NT_SUCCESS(PhSafeReadVirtualMemory(
                                                 processHandle,
                                                 PTR_ADD_OFFSET(memoryItem->BaseAddress, offset),
                                                 buffer,

--- a/SystemInformer/settings.c
+++ b/SystemInformer/settings.c
@@ -201,6 +201,7 @@ VOID PhAddDefaultSettings(
     PhpAddScalableIntegerPairSetting(L"PageFileWindowSize", L"@96|500,300");
     PhpAddStringSetting(L"PageFileListViewColumns", L"");
     PhpAddStringSetting(L"PluginManagerTreeListColumns", L"");
+    PhpAddIntegerSetting(L"ProcessMemorySafeRead", L"0"); // bool 1 or 0
     PhpAddStringSetting(L"ProcessServiceListViewColumns", L"");
     PhpAddStringSetting(L"ProcessTreeColumnSetConfig", L"");
     PhpAddStringSetting(L"ProcessTreeListColumns", L"");

--- a/phlib/imgcoherency.c
+++ b/phlib/imgcoherency.c
@@ -1293,7 +1293,7 @@ NTSTATUS PhpGetModuleCoherency(
             RemoteImageBase,
             RemoteImageSize,
             RemoteImageBaseStatus,
-            IsKernelModule ? KphReadVirtualMemoryUnsafe : NtReadVirtualMemory
+            IsKernelModule ? KphReadVirtualMemoryUnsafe : PhSafeReadVirtualMemory
             );
 
         status = PhpInspectForImageCoherency(ProcessHandle, context, ImageCoherency);

--- a/phlib/include/phnative.h
+++ b/phlib/include/phnative.h
@@ -3316,6 +3316,17 @@ PhPrefetchVirtualMemory(
 PHLIBAPI
 NTSTATUS
 NTAPI
+PhSafeReadVirtualMemory(
+    _In_ HANDLE ProcessHandle,
+    _In_opt_ PVOID BaseAddress,
+    _Out_writes_bytes_(BufferSize) PVOID Buffer,
+    _In_ SIZE_T BufferSize,
+    _Out_opt_ PSIZE_T NumberOfBytesRead
+    );
+
+PHLIBAPI
+NTSTATUS
+NTAPI
 PhGuardGrantSuppressedCallAccess(
     _In_ HANDLE ProcessHandle,
     _In_ PVOID VirtualAddress

--- a/phlib/mapimg.c
+++ b/phlib/mapimg.c
@@ -769,7 +769,7 @@ NTSTATUS PhLoadRemoteMappedImage(
     _Out_ PPH_REMOTE_MAPPED_IMAGE RemoteMappedImage
     )
 {
-    return PhLoadRemoteMappedImageEx(ProcessHandle, ViewBase, ViewSize, NtReadVirtualMemory, RemoteMappedImage);
+    return PhLoadRemoteMappedImageEx(ProcessHandle, ViewBase, ViewSize, PhSafeReadVirtualMemory, RemoteMappedImage);
 }
 
 NTSTATUS PhLoadRemoteMappedImagePageSize(
@@ -1152,7 +1152,7 @@ NTSTATUS PhGetRemoteMappedImageDebugEntryByType(
     _Out_ PPVOID DataBuffer
     )
 {
-    return PhGetRemoteMappedImageDebugEntryByTypeEx(RemoteMappedImage, Type, NtReadVirtualMemory, DataLength, DataBuffer);
+    return PhGetRemoteMappedImageDebugEntryByTypeEx(RemoteMappedImage, Type, PhSafeReadVirtualMemory, DataLength, DataBuffer);
 }
 
 NTSTATUS PhGetRemoteMappedImageDebugEntryByTypeEx(
@@ -1238,7 +1238,7 @@ NTSTATUS PhGetRemoteMappedImageGuardFlags(
     _Out_ PULONG GuardFlags
     )
 {
-    return PhGetRemoteMappedImageGuardFlagsEx(RemoteMappedImage, NtReadVirtualMemory, GuardFlags);
+    return PhGetRemoteMappedImageGuardFlagsEx(RemoteMappedImage, PhSafeReadVirtualMemory, GuardFlags);
 }
 
 NTSTATUS PhGetRemoteMappedImageGuardFlagsEx(
@@ -5503,7 +5503,7 @@ NTSTATUS PhGetRemoteMappedImageCHPEVersion(
     _Out_ PULONG CHPEVersion
     )
 {
-    return PhGetRemoteMappedImageCHPEVersionEx(RemoteMappedImage, NtReadVirtualMemory, CHPEVersion);
+    return PhGetRemoteMappedImageCHPEVersionEx(RemoteMappedImage, PhSafeReadVirtualMemory, CHPEVersion);
 }
 
 NTSTATUS PhGetRemoteMappedImageCHPEVersionEx(

--- a/phlib/native.c
+++ b/phlib/native.c
@@ -15,6 +15,7 @@
 #include <kphuser.h>
 #include <lsasup.h>
 #include <mapldr.h>
+#include <settings.h>
 
 #define PH_DEVICE_PREFIX_LENGTH 64
 #define PH_DEVICE_MUP_PREFIX_MAX_COUNT 16
@@ -1156,7 +1157,7 @@ NTSTATUS PhGetProcessPebString(
             return status;
 
         // Read the address of the process parameters.
-        if (!NT_SUCCESS(status = NtReadVirtualMemory(
+        if (!NT_SUCCESS(status = PhSafeReadVirtualMemory(
             ProcessHandle,
             PTR_ADD_OFFSET(pebBaseAddress, FIELD_OFFSET(PEB, ProcessParameters)),
             &processParameters,
@@ -1166,7 +1167,7 @@ NTSTATUS PhGetProcessPebString(
             return status;
 
         // Read the string structure.
-        if (!NT_SUCCESS(status = NtReadVirtualMemory(
+        if (!NT_SUCCESS(status = PhSafeReadVirtualMemory(
             ProcessHandle,
             PTR_ADD_OFFSET(processParameters, offset),
             &unicodeString,
@@ -1184,7 +1185,7 @@ NTSTATUS PhGetProcessPebString(
         string = PhCreateStringEx(NULL, unicodeString.Length);
 
         // Read the string contents.
-        if (!NT_SUCCESS(status = NtReadVirtualMemory(
+        if (!NT_SUCCESS(status = PhSafeReadVirtualMemory(
             ProcessHandle,
             unicodeString.Buffer,
             string->Buffer,
@@ -1205,7 +1206,7 @@ NTSTATUS PhGetProcessPebString(
         if (!NT_SUCCESS(status = PhGetProcessPeb32(ProcessHandle, &pebBaseAddress32)))
             return status;
 
-        if (!NT_SUCCESS(status = NtReadVirtualMemory(
+        if (!NT_SUCCESS(status = PhSafeReadVirtualMemory(
             ProcessHandle,
             PTR_ADD_OFFSET(pebBaseAddress32, FIELD_OFFSET(PEB32, ProcessParameters)),
             &processParameters32,
@@ -1214,7 +1215,7 @@ NTSTATUS PhGetProcessPebString(
             )))
             return status;
 
-        if (!NT_SUCCESS(status = NtReadVirtualMemory(
+        if (!NT_SUCCESS(status = PhSafeReadVirtualMemory(
             ProcessHandle,
             PTR_ADD_OFFSET(processParameters32, offset),
             &unicodeString32,
@@ -1232,7 +1233,7 @@ NTSTATUS PhGetProcessPebString(
         string = PhCreateStringEx(NULL, unicodeString32.Length);
 
         // Read the string contents.
-        if (!NT_SUCCESS(status = NtReadVirtualMemory(
+        if (!NT_SUCCESS(status = PhSafeReadVirtualMemory(
             ProcessHandle,
             UlongToPtr(unicodeString32.Buffer),
             string->Buffer,
@@ -1409,7 +1410,7 @@ NTSTATUS PhGetProcessWindowTitle(
             return status;
 
         // Read the address of the process parameters.
-        if (!NT_SUCCESS(status = NtReadVirtualMemory(
+        if (!NT_SUCCESS(status = PhSafeReadVirtualMemory(
             ProcessHandle,
             PTR_ADD_OFFSET(pebBaseAddress, FIELD_OFFSET(PEB, ProcessParameters)),
             &processParameters,
@@ -1419,7 +1420,7 @@ NTSTATUS PhGetProcessWindowTitle(
             return status;
 
         // Read the window flags.
-        if (!NT_SUCCESS(status = NtReadVirtualMemory(
+        if (!NT_SUCCESS(status = PhSafeReadVirtualMemory(
             ProcessHandle,
             PTR_ADD_OFFSET(processParameters, FIELD_OFFSET(RTL_USER_PROCESS_PARAMETERS, WindowFlags)),
             &windowFlags,
@@ -1437,7 +1438,7 @@ NTSTATUS PhGetProcessWindowTitle(
         if (!NT_SUCCESS(status = PhGetProcessPeb32(ProcessHandle, &pebBaseAddress32)))
             return status;
 
-        if (!NT_SUCCESS(status = NtReadVirtualMemory(
+        if (!NT_SUCCESS(status = PhSafeReadVirtualMemory(
             ProcessHandle,
             PTR_ADD_OFFSET(pebBaseAddress32, FIELD_OFFSET(PEB32, ProcessParameters)),
             &processParameters32,
@@ -1446,7 +1447,7 @@ NTSTATUS PhGetProcessWindowTitle(
             )))
             return status;
 
-        if (!NT_SUCCESS(status = NtReadVirtualMemory(
+        if (!NT_SUCCESS(status = PhSafeReadVirtualMemory(
             ProcessHandle,
             PTR_ADD_OFFSET(processParameters32, FIELD_OFFSET(RTL_USER_PROCESS_PARAMETERS32, WindowFlags)),
             &windowFlags,
@@ -1535,7 +1536,7 @@ NTSTATUS PhGetProcessEnvironment(
         if (!NT_SUCCESS(status))
             return status;
 
-        if (!NT_SUCCESS(status = NtReadVirtualMemory(
+        if (!NT_SUCCESS(status = PhSafeReadVirtualMemory(
             ProcessHandle,
             PTR_ADD_OFFSET(pebBaseAddress, UFIELD_OFFSET(PEB, ProcessParameters)),
             &processParameters,
@@ -1544,7 +1545,7 @@ NTSTATUS PhGetProcessEnvironment(
             )))
             return status;
 
-        if (!NT_SUCCESS(status = NtReadVirtualMemory(
+        if (!NT_SUCCESS(status = PhSafeReadVirtualMemory(
             ProcessHandle,
             PTR_ADD_OFFSET(processParameters, UFIELD_OFFSET(RTL_USER_PROCESS_PARAMETERS, Environment)),
             &environmentRemote,
@@ -1564,7 +1565,7 @@ NTSTATUS PhGetProcessEnvironment(
         if (!NT_SUCCESS(status))
             return status;
 
-        if (!NT_SUCCESS(status = NtReadVirtualMemory(
+        if (!NT_SUCCESS(status = PhSafeReadVirtualMemory(
             ProcessHandle,
             PTR_ADD_OFFSET(pebBaseAddress32, UFIELD_OFFSET(PEB32, ProcessParameters)),
             &processParameters32,
@@ -1573,7 +1574,7 @@ NTSTATUS PhGetProcessEnvironment(
             )))
             return status;
 
-        if (!NT_SUCCESS(status = NtReadVirtualMemory(
+        if (!NT_SUCCESS(status = PhSafeReadVirtualMemory(
             ProcessHandle,
             PTR_ADD_OFFSET(processParameters32, UFIELD_OFFSET(RTL_USER_PROCESS_PARAMETERS32, Environment)),
             &environmentRemote32,
@@ -1605,7 +1606,7 @@ NTSTATUS PhGetProcessEnvironment(
     if (!environment)
         return STATUS_NO_MEMORY;
 
-    if (!NT_SUCCESS(status = NtReadVirtualMemory(
+    if (!NT_SUCCESS(status = PhSafeReadVirtualMemory(
         ProcessHandle,
         environmentRemote,
         environment,
@@ -2132,7 +2133,7 @@ NTSTATUS PhGetProcessUnloadedDlls(
     // Since ntdll is loaded at the same base address across all processes,
     // we can read the information in.
 
-    if (!NT_SUCCESS(status = NtReadVirtualMemory(
+    if (!NT_SUCCESS(status = PhSafeReadVirtualMemory(
         processHandle,
         elementSize,
         &capturedElementSize,
@@ -2141,7 +2142,7 @@ NTSTATUS PhGetProcessUnloadedDlls(
         )))
         goto CleanupExit;
 
-    if (!NT_SUCCESS(status = NtReadVirtualMemory(
+    if (!NT_SUCCESS(status = PhSafeReadVirtualMemory(
         processHandle,
         elementCount,
         &capturedElementCount,
@@ -2150,7 +2151,7 @@ NTSTATUS PhGetProcessUnloadedDlls(
         )))
         goto CleanupExit;
 
-    if (!NT_SUCCESS(status = NtReadVirtualMemory(
+    if (!NT_SUCCESS(status = PhSafeReadVirtualMemory(
         processHandle,
         eventTrace,
         &capturedEventTracePointer,
@@ -2177,7 +2178,7 @@ NTSTATUS PhGetProcessUnloadedDlls(
         goto CleanupExit;
     }
 
-    if (!NT_SUCCESS(status = NtReadVirtualMemory(
+    if (!NT_SUCCESS(status = PhSafeReadVirtualMemory(
         processHandle,
         capturedEventTracePointer,
         capturedEventTrace,
@@ -5753,7 +5754,7 @@ NTSTATUS PhpEnumProcessModules(
         return status;
 
     // Read the address of the loader data.
-    status = NtReadVirtualMemory(
+    status = PhSafeReadVirtualMemory(
         ProcessHandle,
         PTR_ADD_OFFSET(peb, FIELD_OFFSET(PEB, Ldr)),
         &ldr,
@@ -5769,7 +5770,7 @@ NTSTATUS PhpEnumProcessModules(
         return STATUS_UNSUCCESSFUL;
 
     // Read the loader data.
-    status = NtReadVirtualMemory(
+    status = PhSafeReadVirtualMemory(
         ProcessHandle,
         ldr,
         &pebLdrData,
@@ -5802,7 +5803,7 @@ NTSTATUS PhpEnumProcessModules(
         PVOID addressOfEntry;
 
         addressOfEntry = CONTAINING_RECORD(currentLink, LDR_DATA_TABLE_ENTRY, InLoadOrderLinks);
-        status = NtReadVirtualMemory(
+        status = PhSafeReadVirtualMemory(
             ProcessHandle,
             addressOfEntry,
             &currentEntry,
@@ -5882,7 +5883,7 @@ BOOLEAN NTAPI PhpEnumProcessModulesCallback(
         fullDllNameBuffer = PhAllocate(Entry->FullDllName.Length + sizeof(UNICODE_NULL));
         Entry->FullDllName.Buffer = fullDllNameBuffer;
 
-        if (NT_SUCCESS(status = NtReadVirtualMemory(
+        if (NT_SUCCESS(status = PhSafeReadVirtualMemory(
             ProcessHandle,
             fullDllNameOriginal,
             fullDllNameBuffer,
@@ -5919,7 +5920,7 @@ BOOLEAN NTAPI PhpEnumProcessModulesCallback(
             baseDllNameBuffer = PhAllocate(Entry->BaseDllName.Length + sizeof(UNICODE_NULL));
             Entry->BaseDllName.Buffer = baseDllNameBuffer;
 
-            if (NT_SUCCESS(NtReadVirtualMemory(
+            if (NT_SUCCESS(PhSafeReadVirtualMemory(
                 ProcessHandle,
                 baseDllNameOriginal,
                 baseDllNameBuffer,
@@ -5943,7 +5944,7 @@ BOOLEAN NTAPI PhpEnumProcessModulesCallback(
 
         memset(&ldrDagNode, 0, sizeof(LDR_DDAG_NODE));
 
-        if (NT_SUCCESS(NtReadVirtualMemory(
+        if (NT_SUCCESS(PhSafeReadVirtualMemory(
             ProcessHandle,
             Entry->DdagNode,
             &ldrDagNode,
@@ -6112,7 +6113,7 @@ NTSTATUS PhpEnumProcessModules32(
         return status;
 
     // Read the address of the loader data.
-    status = NtReadVirtualMemory(
+    status = PhSafeReadVirtualMemory(
         ProcessHandle,
         PTR_ADD_OFFSET(peb, FIELD_OFFSET(PEB32, Ldr)),
         &ldr,
@@ -6128,7 +6129,7 @@ NTSTATUS PhpEnumProcessModules32(
         return STATUS_UNSUCCESSFUL;
 
     // Read the loader data.
-    status = NtReadVirtualMemory(
+    status = PhSafeReadVirtualMemory(
         ProcessHandle,
         UlongToPtr(ldr),
         &pebLdrData,
@@ -6161,7 +6162,7 @@ NTSTATUS PhpEnumProcessModules32(
         ULONG addressOfEntry;
 
         addressOfEntry = PtrToUlong(CONTAINING_RECORD(UlongToPtr(currentLink), LDR_DATA_TABLE_ENTRY32, InLoadOrderLinks));
-        status = NtReadVirtualMemory(
+        status = PhSafeReadVirtualMemory(
             ProcessHandle,
             UlongToPtr(addressOfEntry),
             &currentEntry,
@@ -6260,7 +6261,7 @@ BOOLEAN NTAPI PhpEnumProcessModules32Callback(
 
         baseDllNameBuffer = PhAllocate(nativeEntry.BaseDllName.Length + sizeof(UNICODE_NULL));
 
-        if (NT_SUCCESS(NtReadVirtualMemory(
+        if (NT_SUCCESS(PhSafeReadVirtualMemory(
             ProcessHandle,
             nativeEntry.BaseDllName.Buffer,
             baseDllNameBuffer,
@@ -6282,7 +6283,7 @@ BOOLEAN NTAPI PhpEnumProcessModules32Callback(
 
         fullDllNameBuffer = PhAllocate(nativeEntry.FullDllName.Length + sizeof(UNICODE_NULL));
 
-        if (NT_SUCCESS(NtReadVirtualMemory(
+        if (NT_SUCCESS(PhSafeReadVirtualMemory(
             ProcessHandle,
             nativeEntry.FullDllName.Buffer,
             fullDllNameBuffer,
@@ -6361,7 +6362,7 @@ BOOLEAN NTAPI PhpEnumProcessModules32Callback(
     {
         LDR_DDAG_NODE32 ldrDagNode32 = { 0 };
 
-        if (NT_SUCCESS(NtReadVirtualMemory(
+        if (NT_SUCCESS(PhSafeReadVirtualMemory(
             ProcessHandle,
             UlongToPtr(Entry->DdagNode),
             &ldrDagNode32,
@@ -14374,7 +14375,7 @@ NTSTATUS PhGetProcessHeapSignature(
     if (WindowsVersion >= WINDOWS_7)
     {
         // dt _HEAP SegmentSignature
-        status = NtReadVirtualMemory(
+        status = PhSafeReadVirtualMemory(
             ProcessHandle,
             PTR_ADD_OFFSET(HeapAddress, IsWow64 ? 0x8 : 0x10),
             &heapSignature,
@@ -14405,7 +14406,7 @@ NTSTATUS PhGetProcessHeapFrontEndType(
     if (WindowsVersion >= WINDOWS_10)
     {
         // dt _HEAP FrontEndHeapType
-        status = NtReadVirtualMemory(
+        status = PhSafeReadVirtualMemory(
             ProcessHandle,
             PTR_ADD_OFFSET(HeapAddress, IsWow64 ? 0x0ea : 0x1a2),
             &heapFrontEndType,
@@ -14415,7 +14416,7 @@ NTSTATUS PhGetProcessHeapFrontEndType(
     }
     else if (WindowsVersion >= WINDOWS_8_1)
     {
-        status = NtReadVirtualMemory(
+        status = PhSafeReadVirtualMemory(
             ProcessHandle,
             PTR_ADD_OFFSET(HeapAddress, IsWow64 ? 0x0d6 : 0x17a),
             &heapFrontEndType,
@@ -14425,7 +14426,7 @@ NTSTATUS PhGetProcessHeapFrontEndType(
     }
     else if (WindowsVersion >= WINDOWS_7)
     {
-        status = NtReadVirtualMemory(
+        status = PhSafeReadVirtualMemory(
             ProcessHandle,
             PTR_ADD_OFFSET(HeapAddress, IsWow64 ? 0x0da : 0x182),
             &heapFrontEndType,
@@ -14714,7 +14715,7 @@ NTSTATUS PhGetProcessImageBaseAddress(
         if (!NT_SUCCESS(status))
             return status;
 
-        status = NtReadVirtualMemory(
+        status = PhSafeReadVirtualMemory(
             ProcessHandle,
             PTR_ADD_OFFSET(pebAddress, UFIELD_OFFSET(PEB32, ImageBaseAddress)),
             &imageBaseAddress32,
@@ -14737,7 +14738,7 @@ NTSTATUS PhGetProcessImageBaseAddress(
         if (!NT_SUCCESS(status))
             return status;
 
-        status = NtReadVirtualMemory(
+        status = PhSafeReadVirtualMemory(
             ProcessHandle,
             PTR_ADD_OFFSET(pebAddress, UFIELD_OFFSET(PEB, ImageBaseAddress)),
             &imageBaseAddress,
@@ -14782,7 +14783,7 @@ NTSTATUS PhGetProcessCodePage(
             if (!NT_SUCCESS(status))
                 goto CleanupExit;
 
-            status = NtReadVirtualMemory(
+            status = PhSafeReadVirtualMemory(
                 ProcessHandle,
                 PTR_ADD_OFFSET(pebBaseAddress, UFIELD_OFFSET(PEB32, ActiveCodePage)),
                 &codePage,
@@ -14798,7 +14799,7 @@ NTSTATUS PhGetProcessCodePage(
             if (!NT_SUCCESS(status))
                 goto CleanupExit;
 
-            status = NtReadVirtualMemory(
+            status = PhSafeReadVirtualMemory(
                 ProcessHandle,
                 PTR_ADD_OFFSET(pebBaseAddress, UFIELD_OFFSET(PEB, ActiveCodePage)),
                 &codePage,
@@ -14833,7 +14834,7 @@ NTSTATUS PhGetProcessCodePage(
         if (!NT_SUCCESS(status))
             goto CleanupExit;
 
-        status = NtReadVirtualMemory(
+        status = PhSafeReadVirtualMemory(
             ProcessHandle,
             nlsAnsiCodePage,
             &codePage,
@@ -15122,7 +15123,7 @@ NTSTATUS PhGetProcessSystemDllInitBlock(
     ldrInitBlock = PhAllocate(sizeof(PS_SYSTEM_DLL_INIT_BLOCK));
     memset(ldrInitBlock, 0, sizeof(PS_SYSTEM_DLL_INIT_BLOCK));
 
-    status = NtReadVirtualMemory(
+    status = PhSafeReadVirtualMemory(
         ProcessHandle,
         ldrInitBlockAddress,
         ldrInitBlock,
@@ -15209,7 +15210,7 @@ NTSTATUS PhGetProcessTlsBitMapCounters(
         if (!NT_SUCCESS(status))
             goto CleanupExit;
 
-        status = NtReadVirtualMemory(
+        status = PhSafeReadVirtualMemory(
             ProcessHandle,
             PTR_ADD_OFFSET(pebBaseAddress, UFIELD_OFFSET(PEB32, TlsBitmapBits)),
             bitmapBits,
@@ -15220,7 +15221,7 @@ NTSTATUS PhGetProcessTlsBitMapCounters(
         if (!NT_SUCCESS(status))
             goto CleanupExit;
 
-        status = NtReadVirtualMemory(
+        status = PhSafeReadVirtualMemory(
             ProcessHandle,
             PTR_ADD_OFFSET(pebBaseAddress, UFIELD_OFFSET(PEB32, TlsExpansionBitmapBits)),
             bitmapExpansionBits,
@@ -15239,7 +15240,7 @@ NTSTATUS PhGetProcessTlsBitMapCounters(
         if (!NT_SUCCESS(status))
             goto CleanupExit;
 
-        status = NtReadVirtualMemory(
+        status = PhSafeReadVirtualMemory(
             ProcessHandle,
             PTR_ADD_OFFSET(pebBaseAddress, UFIELD_OFFSET(PEB, TlsBitmapBits)),
             bitmapBits,
@@ -15250,7 +15251,7 @@ NTSTATUS PhGetProcessTlsBitMapCounters(
         if (!NT_SUCCESS(status))
             goto CleanupExit;
 
-        status = NtReadVirtualMemory(
+        status = PhSafeReadVirtualMemory(
             ProcessHandle,
             PTR_ADD_OFFSET(pebBaseAddress, UFIELD_OFFSET(PEB, TlsExpansionBitmapBits)),
             bitmapExpansionBits,
@@ -15310,7 +15311,7 @@ NTSTATUS PhGetProcessIsPosix(
         if (!NT_SUCCESS(status))
             return status;
 
-        status = NtReadVirtualMemory(
+        status = PhSafeReadVirtualMemory(
             ProcessHandle,
             PTR_ADD_OFFSET(pebBaseAddress, UFIELD_OFFSET(PEB32, ImageSubsystem)),
             &imageSubsystem,
@@ -15326,7 +15327,7 @@ NTSTATUS PhGetProcessIsPosix(
         if (!NT_SUCCESS(status))
             return status;
 
-        status = NtReadVirtualMemory(
+        status = PhSafeReadVirtualMemory(
             ProcessHandle,
             PTR_ADD_OFFSET(pebBaseAddress, UFIELD_OFFSET(PEB, ImageSubsystem)),
             &imageSubsystem,
@@ -15376,7 +15377,7 @@ NTSTATUS PhGetThreadLastStatusValue(
 
     if (isWow64)
     {
-        status = NtReadVirtualMemory(
+        status = PhSafeReadVirtualMemory(
             ProcessHandle,
             PTR_ADD_OFFSET(WOW64_GET_TEB32(basicInfo.TebBaseAddress), UFIELD_OFFSET(TEB32, LastStatusValue)),
             LastStatusValue,
@@ -15387,7 +15388,7 @@ NTSTATUS PhGetThreadLastStatusValue(
     else
 #endif
     {
-        status = NtReadVirtualMemory(
+        status = PhSafeReadVirtualMemory(
             ProcessHandle,
             PTR_ADD_OFFSET(basicInfo.TebBaseAddress, UFIELD_OFFSET(TEB, LastStatusValue)), // LastErrorValue/ExceptionCode
             LastStatusValue,
@@ -15436,7 +15437,7 @@ NTSTATUS PhGetThreadApartmentState(
 
     if (isWow64)
     {
-        status = NtReadVirtualMemory(
+        status = PhSafeReadVirtualMemory(
             ProcessHandle,
             PTR_ADD_OFFSET(WOW64_GET_TEB32(basicInfo.TebBaseAddress), UFIELD_OFFSET(TEB32, ReservedForOle)),
             &oletlsDataAddress,
@@ -15447,7 +15448,7 @@ NTSTATUS PhGetThreadApartmentState(
     else
 #endif
     {
-        status = NtReadVirtualMemory(
+        status = PhSafeReadVirtualMemory(
             ProcessHandle,
             PTR_ADD_OFFSET(basicInfo.TebBaseAddress, UFIELD_OFFSET(TEB, ReservedForOle)),
             &oletlsDataAddress,
@@ -15472,7 +15473,7 @@ NTSTATUS PhGetThreadApartmentState(
         apartmentStateOffset = PTR_ADD_OFFSET(oletlsDataAddress, 0xC);
 #endif
 
-        status = NtReadVirtualMemory(
+        status = PhSafeReadVirtualMemory(
             ProcessHandle,
             apartmentStateOffset,
             ApartmentState,
@@ -15535,7 +15536,7 @@ NTSTATUS PhGetThreadApartmentCallState(
 
     if (isWow64)
     {
-        status = NtReadVirtualMemory(
+        status = PhSafeReadVirtualMemory(
             ProcessHandle,
             PTR_ADD_OFFSET(WOW64_GET_TEB32(basicInfo.TebBaseAddress), UFIELD_OFFSET(TEB32, ReservedForOle)),
             &oletlsDataAddress,
@@ -15546,7 +15547,7 @@ NTSTATUS PhGetThreadApartmentCallState(
     else
 #endif
     {
-        status = NtReadVirtualMemory(
+        status = PhSafeReadVirtualMemory(
             ProcessHandle,
             PTR_ADD_OFFSET(basicInfo.TebBaseAddress, UFIELD_OFFSET(TEB, ReservedForOle)),
             &oletlsDataAddress,
@@ -15612,7 +15613,7 @@ NTSTATUS PhGetThreadApartmentCallState(
 
         if (HR_SUCCESS(CoGetCallState_I(CALL_STATE_TYPE_OUTGOING, &outgoingCallDataOffset)) && outgoingCallDataOffset)
         {
-            NtReadVirtualMemory(
+            PhSafeReadVirtualMemory(
                 ProcessHandle,
                 PTR_ADD_OFFSET(oletlsDataAddress, outgoingCallDataOffset),
                 &outgoingCallData,
@@ -15623,7 +15624,7 @@ NTSTATUS PhGetThreadApartmentCallState(
 
         if (HR_SUCCESS(CoGetCallState_I(CALL_STATE_TYPE_INCOMING, &incomingCallDataOffset)) && incomingCallDataOffset)
         {
-            NtReadVirtualMemory(
+            PhSafeReadVirtualMemory(
                 ProcessHandle,
                 PTR_ADD_OFFSET(oletlsDataAddress, incomingCallDataOffset),
                 &incomingCallData,
@@ -15634,7 +15635,7 @@ NTSTATUS PhGetThreadApartmentCallState(
 
         if (HR_SUCCESS(CoGetCallState_I(CALL_STATE_TYPE_ACTIVATION, &outgoingActivationDataOffset)) && outgoingActivationDataOffset)
         {
-            NtReadVirtualMemory(
+            PhSafeReadVirtualMemory(
                 ProcessHandle,
                 PTR_ADD_OFFSET(oletlsDataAddress, outgoingActivationDataOffset),
                 &outgoingActivationData,
@@ -15758,7 +15759,7 @@ NTSTATUS PhGetThreadSocketState(
     {
         ULONG winsockDataAddress = 0;
 
-        status = NtReadVirtualMemory(
+        status = PhSafeReadVirtualMemory(
             ProcessHandle,
             PTR_ADD_OFFSET(WOW64_GET_TEB32(basicInfo.TebBaseAddress), UFIELD_OFFSET(TEB32, WinSockData)),
             &winsockDataAddress,
@@ -15773,7 +15774,7 @@ NTSTATUS PhGetThreadSocketState(
     {
         ULONG_PTR winsockDataAddress = 0;
 
-        status = NtReadVirtualMemory(
+        status = PhSafeReadVirtualMemory(
             ProcessHandle,
             PTR_ADD_OFFSET(basicInfo.TebBaseAddress, UFIELD_OFFSET(TEB, WinSockData)),
             &winsockDataAddress,
@@ -15949,7 +15950,7 @@ NTSTATUS PhGetThreadStackLimits(
 
     if (isWow64)
     {
-        status = NtReadVirtualMemory(
+        status = PhSafeReadVirtualMemory(
             ProcessHandle,
             PTR_ADD_OFFSET(WOW64_GET_TEB32(basicInfo.TebBaseAddress), UFIELD_OFFSET(TEB32, NtTib)),
             &ntTib,
@@ -15960,7 +15961,7 @@ NTSTATUS PhGetThreadStackLimits(
     else
 #endif
     {
-        status = NtReadVirtualMemory(
+        status = PhSafeReadVirtualMemory(
             ProcessHandle,
             PTR_ADD_OFFSET(basicInfo.TebBaseAddress, UFIELD_OFFSET(TEB, NtTib)),
             &ntTib,
@@ -16016,7 +16017,7 @@ NTSTATUS PhGetThreadStackSize(
 
     if (isWow64)
     {
-        status = NtReadVirtualMemory(
+        status = PhSafeReadVirtualMemory(
             ProcessHandle,
             PTR_ADD_OFFSET(WOW64_GET_TEB32(basicInfo.TebBaseAddress), UFIELD_OFFSET(TEB32, NtTib)),
             &ntTib,
@@ -16027,7 +16028,7 @@ NTSTATUS PhGetThreadStackSize(
     else
 #endif
     {
-        status = NtReadVirtualMemory(
+        status = PhSafeReadVirtualMemory(
             ProcessHandle,
             PTR_ADD_OFFSET(basicInfo.TebBaseAddress, UFIELD_OFFSET(TEB, NtTib)),
             &ntTib,
@@ -16114,7 +16115,7 @@ NTSTATUS PhGetThreadIsFiber(
 
     if (isWow64)
     {
-        status = NtReadVirtualMemory(
+        status = PhSafeReadVirtualMemory(
             ProcessHandle,
             PTR_ADD_OFFSET(WOW64_GET_TEB32(basicInfo.TebBaseAddress), UFIELD_OFFSET(TEB32, SameTebFlags)),
             &flags,
@@ -16125,7 +16126,7 @@ NTSTATUS PhGetThreadIsFiber(
     else
 #endif
     {
-        status = NtReadVirtualMemory(
+        status = PhSafeReadVirtualMemory(
             ProcessHandle,
             PTR_ADD_OFFSET(basicInfo.TebBaseAddress, UFIELD_OFFSET(TEB, SameTebFlags)),
             &flags,
@@ -17244,6 +17245,74 @@ NTSTATUS PhPrefetchVirtualMemory(
     return status;
 }
 
+NTSTATUS PhSafeReadVirtualMemory(
+    _In_ HANDLE ProcessHandle,
+    _In_opt_ PVOID BaseAddress,
+    _Out_writes_bytes_(BufferSize) PVOID Buffer,
+    _In_ SIZE_T BufferSize,
+    _Out_opt_ PSIZE_T NumberOfBytesRead
+    )
+{
+    NTSTATUS status = STATUS_SUCCESS;
+    SIZE_T bytesRead = 0;
+    SIZE_T bytesToRead = BufferSize;
+    PCHAR writeBuffer = (PCHAR)Buffer;
+    PCHAR baseAddress = (PCHAR)BaseAddress;
+    SIZE_T iteration;
+
+    static SYSTEM_BASIC_INFORMATION sbi;
+    MEMORY_WORKING_SET_EX_INFORMATION wsi;
+
+    static BOOL runOnceFlag = FALSE;
+    static BOOL doSafeRead = FALSE;
+    if (!runOnceFlag)
+    {
+        doSafeRead = PhGetIntegerSetting(L"ProcessMemorySafeRead");
+        if (!NT_SUCCESS(status = NtQuerySystemInformation(SystemBasicInformation, &sbi, sizeof(sbi), NULL)))
+        {
+            return status;
+        }
+        runOnceFlag = TRUE;
+    }
+
+    if (!doSafeRead)
+    {
+        return NtReadVirtualMemory(ProcessHandle, BaseAddress, Buffer, BufferSize, NumberOfBytesRead);
+    }
+
+    iteration = (UINT_PTR)baseAddress % sbi.PageSize;
+    if (!iteration)
+        iteration = sbi.PageSize;
+
+    do
+    {
+        wsi.VirtualAddress = baseAddress;
+        if (!NT_SUCCESS(status = NtQueryVirtualMemory(ProcessHandle, baseAddress, MemoryWorkingSetExInformation, &wsi, sizeof(wsi), NULL)))
+        {
+            goto WSIFAIL;
+        }
+        if (!wsi.u1.VirtualAttributes.Valid || wsi.u1.VirtualAttributes.Bad)
+        {
+            goto WSIFAIL;
+        }
+
+        NtReadVirtualMemory(ProcessHandle, baseAddress, writeBuffer, iteration > bytesToRead ? bytesToRead : iteration, NULL);
+    WSIFAIL:
+        bytesToRead -= iteration > bytesToRead ? bytesToRead : iteration;
+        writeBuffer += iteration;
+        baseAddress += iteration;
+
+        if (iteration != sbi.PageSize)
+            iteration = sbi.PageSize;
+
+    } while (bytesToRead != 0);
+
+    if (NumberOfBytesRead)
+        *NumberOfBytesRead = BufferSize;
+
+    return status;
+}
+
 // rev from OfferVirtualMemory (dmex)
 //NTSTATUS PhOfferVirtualMemory(
 //    _In_ HANDLE ProcessHandle,
@@ -18269,7 +18338,7 @@ NTSTATUS PhEnumProcessEnclaves(
     LIST_ENTRY enclaveList;
     LDR_SOFTWARE_ENCLAVE enclave;
 
-    status = NtReadVirtualMemory(
+    status = PhSafeReadVirtualMemory(
         ProcessHandle,
         LdrEnclaveList,
         &enclaveList,
@@ -18287,7 +18356,7 @@ NTSTATUS PhEnumProcessEnclaves(
 
         enclaveAddress = CONTAINING_RECORD(link, LDR_SOFTWARE_ENCLAVE, Links);
 
-        status = NtReadVirtualMemory(
+        status = PhSafeReadVirtualMemory(
             ProcessHandle,
             link,
             &enclave,
@@ -18328,7 +18397,7 @@ NTSTATUS PhEnumProcessEnclaveModules(
 
         entryAddress = CONTAINING_RECORD(link, LDR_DATA_TABLE_ENTRY, InLoadOrderLinks);
 
-        status = NtReadVirtualMemory(
+        status = PhSafeReadVirtualMemory(
             ProcessHandle,
             entryAddress,
             &entry,
@@ -18372,7 +18441,7 @@ NTSTATUS PhGetProcessLdrTableEntryNames(
     {
         fullDllName = PhAllocate(Entry->FullDllName.Length);
 
-        status = NtReadVirtualMemory(
+        status = PhSafeReadVirtualMemory(
             ProcessHandle,
             Entry->FullDllName.Buffer,
             fullDllName,
@@ -18718,7 +18787,7 @@ NTSTATUS PhIsEcCode(
     if (!NT_SUCCESS(status = PhGetProcessPeb(ProcessHandle, &pebBaseAddress)))
         return status;
 
-    if (!NT_SUCCESS(status = NtReadVirtualMemory(
+    if (!NT_SUCCESS(status = PhSafeReadVirtualMemory(
         ProcessHandle,
         PTR_ADD_OFFSET(pebBaseAddress, FIELD_OFFSET(PEB, EcCodeBitMap)),
         &ecCodeBitMap,
@@ -18733,7 +18802,7 @@ NTSTATUS PhIsEcCode(
     // each byte of bitmap indexes 8*4K = 2^15 byte span
     ecCodeBitMap = PTR_ADD_OFFSET(ecCodeBitMap, CodePointer >> 15);
 
-    if (!NT_SUCCESS(status = NtReadVirtualMemory(
+    if (!NT_SUCCESS(status = PhSafeReadVirtualMemory(
         ProcessHandle,
         ecCodeBitMap,
         &bitmap,

--- a/phlib/settings.c
+++ b/phlib/settings.c
@@ -730,7 +730,7 @@ PSTR PhpSettingsSaveCallback(
 #define MXML_WS_AFTER_CLOSE 3
 
     PSTR elementName;
-
+    
     if (!(elementName = PhGetXmlNodeElementText(node)))
         return NULL;
 

--- a/phlib/svcsup.c
+++ b/phlib/svcsup.c
@@ -1139,7 +1139,7 @@ NTSTATUS PhGetThreadServiceTag(
         openedProcessHandle = TRUE;
     }
 
-    status = NtReadVirtualMemory(
+    status = PhSafeReadVirtualMemory(
         ProcessHandle,
         PTR_ADD_OFFSET(basicInfo.TebBaseAddress, FIELD_OFFSET(TEB, SubProcessTag)),
         ServiceTag,

--- a/phlib/symprv.c
+++ b/phlib/symprv.c
@@ -367,7 +367,7 @@ BOOL CALLBACK PhpSymbolCallbackFunction(
 
             if (symbolProvider->IsRealHandle)
             {
-                if (NT_SUCCESS(NtReadVirtualMemory(
+                if (NT_SUCCESS(PhSafeReadVirtualMemory(
                     ProcessHandle,
                     (PVOID)callbackData->addr,
                     callbackData->buf,
@@ -1448,7 +1448,7 @@ NTSTATUS PhpLookupDynamicFunctionTable(
 
     // Find the function table entry for this address.
 
-    if (!NT_SUCCESS(status = NtReadVirtualMemory(
+    if (!NT_SUCCESS(status = PhSafeReadVirtualMemory(
         ProcessHandle,
         tableListHead,
         &tableListHeadEntry,
@@ -1464,7 +1464,7 @@ NTSTATUS PhpLookupDynamicFunctionTable(
     {
         functionTableAddress = CONTAINING_RECORD(tableListEntry, DYNAMIC_FUNCTION_TABLE, ListEntry);
 
-        if (!NT_SUCCESS(status = NtReadVirtualMemory(
+        if (!NT_SUCCESS(status = PhSafeReadVirtualMemory(
             ProcessHandle,
             functionTableAddress,
             &functionTable,
@@ -1483,7 +1483,7 @@ NTSTATUS PhpLookupDynamicFunctionTable(
                     // just have to read as much as possible.
 
                     memset(OutOfProcessCallbackDllBuffer, 0xff, OutOfProcessCallbackDllBufferSize);
-                    status = NtReadVirtualMemory(
+                    status = PhSafeReadVirtualMemory(
                         ProcessHandle,
                         functionTable.OutOfProcessCallbackDll,
                         OutOfProcessCallbackDllBuffer,
@@ -1691,7 +1691,7 @@ NTSTATUS PhpAccessNormalFunctionTable(
     if (!functions)
         return STATUS_NO_MEMORY;
 
-    status = NtReadVirtualMemory(ProcessHandle, FunctionTable->FunctionTable, functions, bufferSize, NULL);
+    status = PhSafeReadVirtualMemory(ProcessHandle, FunctionTable->FunctionTable, functions, bufferSize, NULL);
 
     if (NT_SUCCESS(status))
     {


### PR DESCRIPTION
Hi, I've ran into issues with a new and innovative anticheat method where an anticheat will posit pages that will never be read by the game and therefore purposefully invalidate the page, and if a function like `NtReadVirtualMemory` is called it causes the page to be marked as valid, which the anticheat detects by doing `QueryWorkingSetEx` or `NtQueryVirtualMemory` otherwise.

The new function I've created has a new setting that is off by default because I have found in testing that Windows naturally invalidates pages and causes random regions of memory to not be read. However it seems to have not caused problems within core functionality thus far and the user just notices missing pages scattered about.

I've marked this PR as a draft for feedback. I am considering adding a UI element to toggle this setting so users can be safe or unsafe easily.