### PR TITLE
Cleanup process state and power request objects on process exit

### DIFF
--- a/SystemInformer/procprv.c
+++ b/SystemInformer/procprv.c
@@ -408,6 +408,9 @@ VOID PhpProcessItemDeleteProcedure(
     if (processItem->PackageFullName) PhDereferenceObject(processItem->PackageFullName);
     if (processItem->UserName) PhDereferenceObject(processItem->UserName);
 
+    if (PhIsProcessStateFrozen(processItem->ProcessId)) PhThawProcess(processItem->ProcessId);
+    if (PhIsProcessExecutionRequired(processItem->ProcessId)) PhProcessExecutionRequiredDisable(processItem->ProcessId);
+
     if (processItem->QueryHandle) NtClose(processItem->QueryHandle);
 
     if (processItem->Record) PhDereferenceProcessRecord(processItem->Record);


### PR DESCRIPTION
If the user freezes of requests execution for a process and then the process terminates, System Informer doesn't free up the process state and the power requests object. This pull requests fixes this issue.