### PR TITLE
Add filter manager definitions

### DIFF
--- a/phnt/include/ntioapi.h
+++ b/phnt/include/ntioapi.h
@@ -2959,6 +2959,127 @@ typedef struct _MOUNTMGR_VOLUME_PATHS
      (s)->Length == 98 && \
      (s)->Buffer[1] == '?')
 
+// Filter manager
+
+// rev
+#define FLT_SYMLINK_NAME     L"\\Global??\\FltMgr"
+#define FLT_MSG_SYMLINK_NAME L"\\Global??\\FltMgrMsg"
+#define FLT_DEVICE_NAME      L"\\FileSystem\\Filters\\FltMgr"
+#define FLT_MSG_DEVICE_NAME  L"\\FileSystem\\Filters\\FltMgrMsg"
+
+// private
+typedef struct _FLT_CONNECT_CONTEXT
+{
+    PUNICODE_STRING PortName;
+    PUNICODE_STRING64 PortName64;
+    USHORT SizeOfContext;
+    UCHAR Padding[6]; // unused
+    _Field_size_bytes_(SizeOfContext) UCHAR Context[ANYSIZE_ARRAY];
+} FLT_CONNECT_CONTEXT, *PFLT_CONNECT_CONTEXT;
+
+// rev
+#define FLT_PORT_EA_NAME "FLTPORT"
+#define FLT_PORT_CONTEXT_MAX 0xFFE8
+
+// combined FILE_FULL_EA_INFORMATION and FLT_CONNECT_CONTEXT
+typedef struct _FLT_PORT_FULL_EA
+{
+    ULONG NextEntryOffset; // 0
+    UCHAR Flags;           // 0
+    UCHAR EaNameLength;    // sizeof(FLT_PORT_EA_NAME) - sizeof(ANSI_NULL)
+    USHORT EaValueLength;  // RTL_SIZEOF_THROUGH_FIELD(FLT_CONNECT_CONTEXT, Padding) + SizeOfContext
+    CHAR EaName[8];        // FLTPORT\0
+    FLT_CONNECT_CONTEXT EaValue;
+} FLT_PORT_FULL_EA, *PFLT_PORT_FULL_EA;
+
+#define FLT_PORT_FULL_EA_SIZE \
+    (sizeof(FILE_FULL_EA_INFORMATION) + (sizeof(FLT_PORT_EA_NAME) - sizeof(ANSI_NULL)))
+#define FLT_PORT_FULL_EA_VALUE_SIZE \
+    RTL_SIZEOF_THROUGH_FIELD(FLT_CONNECT_CONTEXT, Padding)
+
+// rev
+#define FLT_CTL_LOAD                CTL_CODE(FILE_DEVICE_DISK_FILE_SYSTEM, 1, METHOD_BUFFERED, FILE_WRITE_ACCESS) // in: FLT_LOAD_PARAMETERS // requires SeLoadDriverPrivilege
+#define FLT_CTL_UNLOAD              CTL_CODE(FILE_DEVICE_DISK_FILE_SYSTEM, 2, METHOD_BUFFERED, FILE_WRITE_ACCESS) // in: FLT_LOAD_PARAMETERS // requires SeLoadDriverPrivilege
+#define FLT_CTL_LINK_HANDLE         CTL_CODE(FILE_DEVICE_DISK_FILE_SYSTEM, 3, METHOD_BUFFERED, FILE_READ_ACCESS)  // in: FLT_LINK
+#define FLT_CTL_ATTACH              CTL_CODE(FILE_DEVICE_DISK_FILE_SYSTEM, 4, METHOD_BUFFERED, FILE_WRITE_ACCESS) // in: FLT_ATTACH
+#define FLT_CTL_DETATCH             CTL_CODE(FILE_DEVICE_DISK_FILE_SYSTEM, 5, METHOD_BUFFERED, FILE_WRITE_ACCESS) // in: FLT_INSTANCE_PARAMETERS
+#define FLT_CTL_SEND_MESSAGE        CTL_CODE(FILE_DEVICE_DISK_FILE_SYSTEM, 6, METHOD_NEITHER, FILE_WRITE_ACCESS)  // in, out: filter-specific
+#define FLT_CTL_GET_MESSAGE         CTL_CODE(FILE_DEVICE_DISK_FILE_SYSTEM, 7, METHOD_NEITHER, FILE_READ_ACCESS)   // out: filter-specific
+#define FLT_CTL_REPLY_MESSAGE       CTL_CODE(FILE_DEVICE_DISK_FILE_SYSTEM, 8, METHOD_NEITHER, FILE_WRITE_ACCESS)  // in: filter-specific
+#define FLT_CTL_FIND_FIRST          CTL_CODE(FILE_DEVICE_DISK_FILE_SYSTEM, 9, METHOD_BUFFERED, FILE_READ_ACCESS)  // in: *_INFORMATION_CLASS, out: *_INFORMATION (from fltUserStructures.h)
+#define FLT_CTL_FIND_NEXT           CTL_CODE(FILE_DEVICE_DISK_FILE_SYSTEM, 10, METHOD_BUFFERED, FILE_READ_ACCESS) // in: *_INFORMATION_CLASS, out: *_INFORMATION (from fltUserStructures.h)
+#define FLT_CTL_GET_INFORMATION     CTL_CODE(FILE_DEVICE_DISK_FILE_SYSTEM, 11, METHOD_BUFFERED, FILE_READ_ACCESS) // in: *_INFORMATION_CLASS, out: *_INFORMATION (from fltUserStructures.h)
+
+// private
+typedef struct _FLT_LOAD_PARAMETERS
+{
+    USHORT FilterNameSize;
+    _Field_size_bytes_(FilterNameSize) WCHAR FilterName[ANYSIZE_ARRAY];
+} FLT_LOAD_PARAMETERS, *PFLT_LOAD_PARAMETERS;
+
+// private
+typedef enum _FLT_LINK_TYPE
+{
+    FILTER = 0,                // FLT_FILTER_PARAMETERS
+    FILTER_INSTANCE = 1,       // FLT_INSTANCE_PARAMETERS
+    FILTER_VOLUME = 2,         // FLT_VOLUME_PARAMETERS
+    FILTER_MANAGER = 3,        // nothing
+    FILTER_MANAGER_VOLUME = 4, // nothing
+} FLT_LINK_TYPE, *PFLT_LINK_TYPE;
+
+// private
+typedef struct _FLT_LINK
+{
+    FLT_LINK_TYPE Type;
+    ULONG ParametersOffset;
+} FLT_LINK, *PFLT_LINK;
+
+// rev
+typedef struct _FLT_FILTER_PARAMETERS
+{
+    USHORT FilterNameSize;
+    USHORT FilterNameOffset; // to WCHAR[] from this struct
+} FLT_FILTER_PARAMETERS, *PFLT_FILTER_PARAMETERS;
+
+// private
+typedef struct _FLT_INSTANCE_PARAMETERS
+{
+    USHORT FilterNameSize;
+    USHORT FilterNameOffset; // to WCHAR[] from this struct
+    USHORT VolumeNameSize;
+    USHORT VolumeNameOffset; // to WCHAR[] from this struct
+    USHORT InstanceNameSize;
+    USHORT InstanceNameOffset; // to WCHAR[] from this struct
+} FLT_INSTANCE_PARAMETERS, *PFLT_INSTANCE_PARAMETERS;
+
+// rev
+typedef struct _FLT_VOLUME_PARAMETERS
+{
+    USHORT VolumeNameSize;
+    USHORT VolumeNameOffset; // to WCHAR[] from this struct
+} FLT_VOLUME_PARAMETERS, *PFLT_VOLUME_PARAMETERS;
+
+// private
+typedef enum _ATTACH_TYPE
+{
+    AltitudeBased = 0,
+    InstanceNameBased = 1,
+} ATTACH_TYPE, *PATTACH_TYPE;
+
+// private
+typedef struct _FLT_ATTACH
+{
+    USHORT FilterNameSize;
+    USHORT FilterNameOffset; // to WCHAR[] from this struct
+    USHORT VolumeNameSize;
+    USHORT VolumeNameOffset; // to WCHAR[] from this struct
+    ATTACH_TYPE Type;
+    USHORT InstanceNameSize;
+    USHORT InstanceNameOffset; // to WCHAR[] from this struct
+    USHORT AltitudeSize;
+    USHORT AltitudeOffset; // to WCHAR[] from this struct
+} FLT_ATTACH, *PFLT_ATTACH;
+
 #if (PHNT_MODE != PHNT_MODE_KERNEL)
 
 //

--- a/phnt/include/ntioapi.h
+++ b/phnt/include/ntioapi.h
@@ -2997,18 +2997,37 @@ typedef struct _FLT_PORT_FULL_EA
 #define FLT_PORT_FULL_EA_VALUE_SIZE \
     RTL_SIZEOF_THROUGH_FIELD(FLT_CONNECT_CONTEXT, Padding)
 
-// rev
+// begin_rev
+
+// IOCTLs for unlinked FltMgr handles
 #define FLT_CTL_LOAD                CTL_CODE(FILE_DEVICE_DISK_FILE_SYSTEM, 1, METHOD_BUFFERED, FILE_WRITE_ACCESS) // in: FLT_LOAD_PARAMETERS // requires SeLoadDriverPrivilege
 #define FLT_CTL_UNLOAD              CTL_CODE(FILE_DEVICE_DISK_FILE_SYSTEM, 2, METHOD_BUFFERED, FILE_WRITE_ACCESS) // in: FLT_LOAD_PARAMETERS // requires SeLoadDriverPrivilege
-#define FLT_CTL_LINK_HANDLE         CTL_CODE(FILE_DEVICE_DISK_FILE_SYSTEM, 3, METHOD_BUFFERED, FILE_READ_ACCESS)  // in: FLT_LINK
+#define FLT_CTL_LINK_HANDLE         CTL_CODE(FILE_DEVICE_DISK_FILE_SYSTEM, 3, METHOD_BUFFERED, FILE_READ_ACCESS)  // in: FLT_LINK // specializes the handle
 #define FLT_CTL_ATTACH              CTL_CODE(FILE_DEVICE_DISK_FILE_SYSTEM, 4, METHOD_BUFFERED, FILE_WRITE_ACCESS) // in: FLT_ATTACH
 #define FLT_CTL_DETATCH             CTL_CODE(FILE_DEVICE_DISK_FILE_SYSTEM, 5, METHOD_BUFFERED, FILE_WRITE_ACCESS) // in: FLT_INSTANCE_PARAMETERS
+
+// IOCTLs for port-specific FltMgrMsg handles (opened using the extended attribute)
 #define FLT_CTL_SEND_MESSAGE        CTL_CODE(FILE_DEVICE_DISK_FILE_SYSTEM, 6, METHOD_NEITHER, FILE_WRITE_ACCESS)  // in, out: filter-specific
 #define FLT_CTL_GET_MESSAGE         CTL_CODE(FILE_DEVICE_DISK_FILE_SYSTEM, 7, METHOD_NEITHER, FILE_READ_ACCESS)   // out: filter-specific
 #define FLT_CTL_REPLY_MESSAGE       CTL_CODE(FILE_DEVICE_DISK_FILE_SYSTEM, 8, METHOD_NEITHER, FILE_WRITE_ACCESS)  // in: filter-specific
+
+// IOCTLs for linked FltMgr handles; depend on previously used FLT_LINK_TYPE
+//
+// Find first/next:
+//   FILTER                - enumerates nested instances; in: INSTANCE_INFORMATION_CLASS
+//   FILTER_VOLUME         - enumerates nested instances; in: INSTANCE_INFORMATION_CLASS
+//   FILTER_MANAGER        - enumerates all filters;      in: FILTER_INFORMATION_CLASS
+//   FILTER_MANAGER_VOLUME - enumerates all volumes;      in: FILTER_VOLUME_INFORMATION_CLASS
+//
+// Get information:
+//   FILTER                - queries filter;              in: FILTER_INFORMATION_CLASS
+//   FILTER_INSTANCE       - queries instance;            in: INSTANCE_INFORMATION_CLASS
+//
 #define FLT_CTL_FIND_FIRST          CTL_CODE(FILE_DEVICE_DISK_FILE_SYSTEM, 9, METHOD_BUFFERED, FILE_READ_ACCESS)  // in: *_INFORMATION_CLASS, out: *_INFORMATION (from fltUserStructures.h)
 #define FLT_CTL_FIND_NEXT           CTL_CODE(FILE_DEVICE_DISK_FILE_SYSTEM, 10, METHOD_BUFFERED, FILE_READ_ACCESS) // in: *_INFORMATION_CLASS, out: *_INFORMATION (from fltUserStructures.h)
 #define FLT_CTL_GET_INFORMATION     CTL_CODE(FILE_DEVICE_DISK_FILE_SYSTEM, 11, METHOD_BUFFERED, FILE_READ_ACCESS) // in: *_INFORMATION_CLASS, out: *_INFORMATION (from fltUserStructures.h)
+
+// end_rev
 
 // private
 typedef struct _FLT_LOAD_PARAMETERS
@@ -3031,7 +3050,7 @@ typedef enum _FLT_LINK_TYPE
 typedef struct _FLT_LINK
 {
     FLT_LINK_TYPE Type;
-    ULONG ParametersOffset;
+    ULONG ParametersOffset; // from this struct
 } FLT_LINK, *PFLT_LINK;
 
 // rev


### PR DESCRIPTION
This pull requests updates existing and adds missing definitions for interacting with the filter manager (FltMgr). This allows querying and enumerating minifilters and their instances via IOCTLs. Here is a brief explanation:

#### To query/enumerate:
1. Open `\Global??\FltMgr` device for read access.
2. Use `FLT_CTL_LINK_HANDLE` with `FLT_LINK_TYPE` of 
    - `FILTER` - to open a specific filter (by name) for querying its information and enumerating its instances.
    - `FILTER_INSTANCE` - to open a specific filter instance (by filter name and volume path) for querying its information.
    - `FILTER_VOLUME` - to open a specific volume (by path) for enumerating attached instances.
    - `FILTER_MANAGER` - to open the filter manager for enumerating all filters.
    - `FILTER_MANAGER_VOLUME` - to open the volume manager for enumerating all volumes.
3. Use `FLT_CTL_GET_INFORMATION`, `FLT_CTL_FIND_FIRST`, or `FLT_CTL_FIND_NEXT`. Each IOCTL takes an info class on input and returns the corresponding buffer on output. Their types are available in `fltUserStructures.h` in SDK.

#### To load/unload/attach/detach filters:
1. Open `\Global??\FltMgr` device for write access.
2. Use `FLT_CTL_LOAD`, `FLT_CTL_UNLOAD`, `FLT_CTL_ATTACH`, `FLT_CTL_DETATCH`.

#### To communicate with a filter:
1. Open `\Global??\FltMgrMsg` device with extended attribute "FLTPORT" specifying the port name via `FLT_CONNECT_CONTEXT`.
2. Use `FLT_CTL_SEND_MESSAGE`, `FLT_CTL_GET_MESSAGE`, or `FLT_CTL_REPLY_MESSAGE`.