### PR TITLE
fixes the workflow "notify" escaping \/"

### DIFF
--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -96,7 +96,7 @@ jobs:
                     },
                     {
                       "name": "Message",
-                      "value": "${{ github.event.head_commit.message }}"
+                      "value": ${{ toJSON(github.event.head_commit.message) }}
                     }
                   ]
                 }


### PR DESCRIPTION
Here are some strings that should be handled
Escape the \ in the string
Escape the / in the string
Escape the " in the string