### PR TITLE
Fix SourceLink

### DIFF
--- a/tools/CustomBuildTool/Build.cs
+++ b/tools/CustomBuildTool/Build.cs
@@ -1327,10 +1327,10 @@ namespace CustomBuildTool
                     string directory = Build.BuildWorkingFolder.Replace("\\", "\\\\", StringComparison.OrdinalIgnoreCase);
 
                     StringBuilder sb = new StringBuilder(260);
-                    sb.Append("{{ \"documents\": {{ ");
+                    sb.Append("{ \"documents\": { ");
                     sb.Append($"\"\\\\*\": \"https://raw.githubusercontent.com/winsiderss/systeminformer/{Build.BuildCommitHash}/*\", ");
-                    sb.Append($"\"{directory}\\\\*\": \"https://raw.githubusercontent.com/winsiderss/systeminformer/{Build.BuildCommitHash}/*\", ");
-                    sb.Append("}} }}");
+                    sb.Append($"\"{directory}\\\\*\": \"https://raw.githubusercontent.com/winsiderss/systeminformer/{Build.BuildCommitHash}/*\" ");
+                    sb.Append("} }");
 
                     Utils.WriteAllText(Build.BuildSourceLink, sb.ToString());
                 }


### PR DESCRIPTION
`SourceLink` used to work at some point, but doesn't work with recent SI builds.

The reason is that SourceLink stream in PDBs isn't valid json anymore.
It contains _doubled_ `{{` / `}}` instead of `{` / `}`.
Also there shouldn't be coma after the last item in dictionary.