### PR TITLE
Add SAL to `RtlNtStatusToDosError` like `RtlNtStatusToDosErrorNoTeb`

### DIFF
--- a/phnt/include/ntrtl.h
+++ b/phnt/include/ntrtl.h
@@ -6053,6 +6053,8 @@ RtlLoadString(
 
 // Errors
 
+_When_(Status < 0, _Out_range_(>, 0))
+_When_(Status >= 0, _Out_range_(==, 0))
 NTSYSAPI
 ULONG
 NTAPI


### PR DESCRIPTION
They should have the same SAL.