### PR TITLE
kph Don't map whole section when looking for mapped file name

### DIFF
--- a/KSystemInformer/object.c
+++ b/KSystemInformer/object.c
@@ -2021,7 +2021,7 @@ NTSTATUS KphQueryInformationObject(
             KeStackAttachProcess(PsInitialSystemProcess, &apcState);
 
             baseAddress = NULL;
-            viewSize = 0;
+            viewSize = PAGE_SIZE;
             status = ZwMapViewOfSection(sectionHandle,
                                         ZwCurrentProcess(),
                                         &baseAddress,
@@ -2056,9 +2056,9 @@ NTSTATUS KphQueryInformationObject(
                 ZwUnmapViewOfSection(ZwCurrentProcess(), baseAddress);
             }
 
-            ObCloseHandle(sectionHandle, KernelMode);
-
             KeUnstackDetachProcess(&apcState);
+
+            ObCloseHandle(sectionHandle, KernelMode);
 
             if (NT_SUCCESS(status))
             {


### PR DESCRIPTION
It is enough to map just first page of section in order to query mapped file name.
Mapping whole section may cause unnecessarily big paged pool usage in case of huge sections.

---

The issue with big pool usage can be easily demonstrated this way:

- Open some project in Visual Studio 2022
- Notice current paged pool size (either in SI or Task Manager)
- In SI press Ctrl+F, enter some string and press enter
- Paged pool size raises by ~20GB

Visual Studio has about 5 processes where each has opened handle to 2TB section (`Reserve (2 TB)`). Running search in SI will cause that each such section is mapped (which takes ~4GB of paged pool), but the memory is not freed upon section unmapping. It is freed when given section handle closes (so you need to close Visual Studio in order to reclaim that memory).

This seems to be standard Windows behavior (at least Win10/11). It seems the system caches memory that was allocated for mapping purposes (PTEs) so that it can be immediately reused when section is mapped next time.