### PR TITLE
Few improvements

### DIFF
--- a/SystemInformer/findobj.c
+++ b/SystemInformer/findobj.c
@@ -428,10 +428,6 @@ BOOLEAN NTAPI PhpHandleObjectTreeNewCallback(
                 if (GetKeyState(VK_CONTROL) < 0)
                     SendMessage(context->WindowHandle, WM_COMMAND, ID_OBJECT_COPY, 0);
                 break;
-            case 'A':
-                if (GetKeyState(VK_CONTROL) < 0)
-                    TreeNew_SelectRange(context->TreeNewHandle, 0, -1);
-                break;
             case VK_DELETE:
                 SendMessage(context->WindowHandle, WM_COMMAND, ID_OBJECT_CLOSE, 0);
                 break;

--- a/SystemInformer/hndllist.c
+++ b/SystemInformer/hndllist.c
@@ -638,10 +638,6 @@ BOOLEAN NTAPI PhpHandleTreeNewCallback(
                 if (GetKeyState(VK_CONTROL) < 0)
                     SendMessage(context->ParentWindowHandle, WM_COMMAND, ID_HANDLE_COPY, 0);
                 break;
-            case 'A':
-                if (GetKeyState(VK_CONTROL) < 0)
-                    TreeNew_SelectRange(context->TreeNewHandle, 0, -1);
-                break;
             case VK_DELETE:
                 // Pass a 1 in lParam to indicate that warnings should be enabled.
                 SendMessage(context->ParentWindowHandle, WM_COMMAND, ID_HANDLE_CLOSE, 1);

--- a/SystemInformer/memlist.c
+++ b/SystemInformer/memlist.c
@@ -1127,10 +1127,6 @@ BOOLEAN NTAPI PhpMemoryTreeNewCallback(
                 if (GetKeyState(VK_CONTROL) < 0)
                     SendMessage(context->ParentWindowHandle, WM_COMMAND, ID_MEMORY_COPY, 0);
                 break;
-            case 'A':
-                if (GetKeyState(VK_CONTROL) < 0)
-                    TreeNew_SelectRange(context->TreeNewHandle, 0, -1);
-                break;
             case VK_RETURN:
                 SendMessage(context->ParentWindowHandle, WM_COMMAND, ID_MEMORY_READWRITEMEMORY, 0);
                 break;

--- a/SystemInformer/memsrch.c
+++ b/SystemInformer/memsrch.c
@@ -1324,10 +1324,6 @@ BOOLEAN NTAPI PhpMemoryStringsTreeNewCallback(
                     }
                 }
                 break;
-            case 'A':
-                if (GetKeyState(VK_CONTROL) < 0)
-                    TreeNew_SelectRange(context->TreeNewHandle, 0, -1);
-                break;
             }
         }
         return TRUE;

--- a/SystemInformer/modlist.c
+++ b/SystemInformer/modlist.c
@@ -1414,10 +1414,6 @@ BOOLEAN NTAPI PhpModuleTreeNewCallback(
                 if (GetKeyState(VK_CONTROL) < 0)
                     SendMessage(context->ParentWindowHandle, WM_COMMAND, ID_MODULE_COPY, 0);
                 break;
-            case 'A':
-                if (GetKeyState(VK_CONTROL) < 0)
-                    TreeNew_SelectRange(context->TreeNewHandle, 0, -1);
-                break;
             case VK_DELETE:
                 SendMessage(context->ParentWindowHandle, WM_COMMAND, ID_MODULE_UNLOAD, 0);
                 break;

--- a/SystemInformer/netlist.c
+++ b/SystemInformer/netlist.c
@@ -833,10 +833,6 @@ BOOLEAN NTAPI PhpNetworkTreeNewCallback(
                 if (GetKeyState(VK_CONTROL) < 0)
                     SendMessage(PhMainWndHandle, WM_COMMAND, ID_NETWORK_COPY, 0);
                 break;
-            case 'A':
-                if (GetKeyState(VK_CONTROL) < 0)
-                    TreeNew_SelectRange(NetworkTreeListHandle, 0, -1);
-                break;
             case VK_RETURN:
                 SendMessage(PhMainWndHandle, WM_COMMAND, ID_NETWORK_GOTOPROCESS, 0);
                 break;

--- a/SystemInformer/options.c
+++ b/SystemInformer/options.c
@@ -2771,10 +2771,6 @@ BOOLEAN NTAPI OptionsAdvancedTreeNewCallback(
                 if (GetKeyState(VK_CONTROL) < 0)
                     SendMessage(context->WindowHandle, WM_COMMAND, IDC_COPY, 0);
                 break;
-            case 'A':
-                if (GetKeyState(VK_CONTROL) < 0)
-                    TreeNew_SelectRange(context->TreeNewHandle, 0, -1);
-                break;
             }
         }
         return TRUE;

--- a/SystemInformer/plugman.c
+++ b/SystemInformer/plugman.c
@@ -360,10 +360,6 @@ BOOLEAN NTAPI PluginsTreeNewCallback(
                 if (GetKeyState(VK_CONTROL) < 0)
                     SendMessage(context->WindowHandle, WM_COMMAND, ID_OBJECT_COPY, 0);
                 break;
-            case 'A':
-                if (GetKeyState(VK_CONTROL) < 0)
-                    TreeNew_SelectRange(context->TreeNewHandle, 0, -1);
-                break;
             case VK_DELETE:
                 SendMessage(context->WindowHandle, WM_COMMAND, ID_OBJECT_CLOSE, 0);
                 break;

--- a/SystemInformer/proctree.c
+++ b/SystemInformer/proctree.c
@@ -4550,10 +4550,6 @@ BOOLEAN NTAPI PhpProcessTreeNewCallback(
                 if (GetKeyState(VK_CONTROL) < 0)
                     SendMessage(PhMainWndHandle, WM_COMMAND, ID_PROCESS_COPY, 0);
                 break;
-            case 'A':
-                if (GetKeyState(VK_CONTROL) < 0)
-                    TreeNew_SelectRange(ProcessTreeListHandle, 0, -1);
-                break;
             case VK_DELETE:
                 if (GetKeyState(VK_SHIFT) >= 0)
                     SendMessage(PhMainWndHandle, WM_COMMAND, ID_PROCESS_TERMINATE, 0);

--- a/SystemInformer/prpgenv.c
+++ b/SystemInformer/prpgenv.c
@@ -1172,10 +1172,6 @@ BOOLEAN NTAPI PhpEnvironmentTreeNewCallback(
                 if (GetKeyState(VK_CONTROL) < 0)
                     SendMessage(context->WindowHandle, WM_COMMAND, ID_ENV_COPY, 0);
                 break;
-            case 'A':
-                if (GetKeyState(VK_CONTROL) < 0)
-                    TreeNew_SelectRange(context->TreeNewHandle, 0, -1);
-                break;
             case VK_DELETE:
                 SendMessage(context->WindowHandle, WM_COMMAND, ID_ENV_DELETE, 0);
                 break;

--- a/SystemInformer/prpgwmi.c
+++ b/SystemInformer/prpgwmi.c
@@ -1563,10 +1563,6 @@ BOOLEAN NTAPI PhpWmiProviderTreeNewCallback(
                 if (GetKeyState(VK_CONTROL) < 0)
                     SendMessage(context->WindowHandle, WM_COMMAND, IDC_COPY, 0);
                 break;
-            case 'A':
-                if (GetKeyState(VK_CONTROL) < 0)
-                    TreeNew_SelectRange(context->TreeNewHandle, 0, -1);
-                break;
             }
         }
         return TRUE;

--- a/SystemInformer/runas.c
+++ b/SystemInformer/runas.c
@@ -2867,10 +2867,6 @@ BOOLEAN NTAPI PhRunAsPackageTreeNewCallback(
                 if (GetKeyState(VK_CONTROL) < 0)
                     SendMessage(context->WindowHandle, WM_COMMAND, ID_OBJECT_COPY, 0);
                 break;
-            case 'A':
-                if (GetKeyState(VK_CONTROL) < 0)
-                    TreeNew_SelectRange(context->TreeNewHandle, 0, -1);
-                break;
             case VK_DELETE:
                 SendMessage(context->WindowHandle, WM_COMMAND, ID_OBJECT_CLOSE, 0);
                 break;

--- a/SystemInformer/srvlist.c
+++ b/SystemInformer/srvlist.c
@@ -952,10 +952,6 @@ BOOLEAN NTAPI PhpServiceTreeNewCallback(
                 if (GetKeyState(VK_CONTROL) < 0)
                     SendMessage(PhMainWndHandle, WM_COMMAND, ID_SERVICE_COPY, 0);
                 break;
-            case 'A':
-                if (GetKeyState(VK_CONTROL) < 0)
-                    TreeNew_SelectRange(ServiceTreeListHandle, 0, -1);
-                break;
             case VK_DELETE:
                 SendMessage(PhMainWndHandle, WM_COMMAND, ID_SERVICE_DELETE, 0);
                 break;

--- a/SystemInformer/thrdlist.c
+++ b/SystemInformer/thrdlist.c
@@ -2126,10 +2126,6 @@ BOOLEAN NTAPI PhpThreadTreeNewCallback(
                 if (GetKeyState(VK_CONTROL) < 0)
                     SendMessage(context->ParentWindowHandle, WM_COMMAND, ID_THREAD_COPY, 0);
                 break;
-            case 'A':
-                if (GetKeyState(VK_CONTROL) < 0)
-                    TreeNew_SelectRange(context->TreeNewHandle, 0, -1);
-                break;
             case VK_DELETE:
                 SendMessage(context->ParentWindowHandle, WM_COMMAND, ID_THREAD_TERMINATE, 0);
                 break;

--- a/SystemInformer/thrdstk.c
+++ b/SystemInformer/thrdstk.c
@@ -582,10 +582,6 @@ BOOLEAN NTAPI ThreadStackTreeNewCallback(
                 if (GetKeyState(VK_CONTROL) < 0)
                     SendMessage(context->WindowHandle, WM_COMMAND, IDC_COPY, 0);
                 break;
-            case 'A':
-                if (GetKeyState(VK_CONTROL) < 0)
-                    TreeNew_SelectRange(context->TreeNewHandle, 0, -1);
-                break;
             }
         }
         return TRUE;

--- a/phlib/treenew.c
+++ b/phlib/treenew.c
@@ -1258,6 +1258,9 @@ VOID PhTnpOnKeyDown(
         return;
     if (PhTnpProcessNodeKey(Context, VirtualKey))
         return;
+
+    // pass unhandled key presses to parent
+    SendMessage(GetParent(hwnd), WM_KEYDOWN, VirtualKey, Data);
 }
 
 VOID PhTnpOnChar(

--- a/phlib/treenew.c
+++ b/phlib/treenew.c
@@ -1259,6 +1259,15 @@ VOID PhTnpOnKeyDown(
     if (PhTnpProcessNodeKey(Context, VirtualKey))
         return;
 
+    // handle standard key presses
+    switch (VirtualKey)
+    {
+    case 'A':
+        if (GetKeyState(VK_CONTROL) < 0)
+            TreeNew_SelectRange(hwnd, 0, -1);
+        return;
+    }
+
     // pass unhandled key presses to parent
     SendMessage(GetParent(hwnd), WM_KEYDOWN, VirtualKey, Data);
 }

--- a/plugins/ExtendedTools/disktab.c
+++ b/plugins/ExtendedTools/disktab.c
@@ -788,10 +788,6 @@ BOOLEAN NTAPI EtpDiskTreeNewCallback(
                 if (GetKeyState(VK_CONTROL) < 0)
                     EtHandleDiskCommand(WindowHandle, ID_DISK_COPY);
                 break;
-            case 'A':
-                if (GetKeyState(VK_CONTROL) < 0)
-                    TreeNew_SelectRange(DiskTreeNewHandle, 0, -1);
-                break;
             case VK_RETURN:
                 EtHandleDiskCommand(WindowHandle, ID_DISK_OPENFILELOCATION);
                 break;

--- a/plugins/ExtendedTools/fwtab.c
+++ b/plugins/ExtendedTools/fwtab.c
@@ -1384,9 +1384,6 @@ BOOLEAN NTAPI FwTreeNewCallback(
                 if (GetKeyState(VK_CONTROL) < 0)
                     EtFwHandleFwCommand(WindowHandle, ID_DISK_COPY);
                 break;
-            case 'A':
-                TreeNew_SelectRange(FwTreeNewHandle, 0, -1);
-                break;
             }
         }
         return TRUE;

--- a/plugins/ExtendedTools/pooldialog.c
+++ b/plugins/ExtendedTools/pooldialog.c
@@ -337,6 +337,18 @@ INT_PTR CALLBACK EtPoolMonDlgProc(
         return HANDLE_WM_CTLCOLORDLG(hwndDlg, wParam, lParam, PhWindowThemeControlColor);
     case WM_CTLCOLORSTATIC:
         return HANDLE_WM_CTLCOLORSTATIC(hwndDlg, wParam, lParam, PhWindowThemeControlColor);
+    case WM_KEYDOWN:
+        {
+            if (LOWORD(wParam) == 'K')
+            {
+                if (GetKeyState(VK_CONTROL) < 0)
+                {
+                    SetFocus(context->SearchboxHandle);
+                    return TRUE;
+                }
+            }
+        }
+        break;
     }
 
     return FALSE;

--- a/plugins/WindowExplorer/wnddlg.c
+++ b/plugins/WindowExplorer/wnddlg.c
@@ -1379,6 +1379,18 @@ INT_PTR CALLBACK WepWindowsDlgProc(
             }
         }
         break;
+    case WM_KEYDOWN:
+        {
+            if (LOWORD(wParam) == 'K')
+            {
+                if (GetKeyState(VK_CONTROL) < 0)
+                {
+                    SetFocus(context->SearchBoxHandle);
+                    return TRUE;
+                }
+            }
+        }
+        break;
     case WM_TIMER:
         {
             switch (wParam)
@@ -2106,7 +2118,7 @@ INT_PTR CALLBACK WepWindowsPageProc(
             switch (header->code)
             {
             case PSN_QUERYINITIALFOCUS:
-                SetWindowLongPtr(hwndDlg, DWLP_MSGRESULT, (LPARAM)GetDlgItem(hwndDlg, IDC_REFRESH));
+                SetWindowLongPtr(hwndDlg, DWLP_MSGRESULT, (LPARAM)context->TreeNewHandle);
                 return TRUE;
             }
         }

--- a/plugins/WindowExplorer/wndtree.c
+++ b/plugins/WindowExplorer/wndtree.c
@@ -517,10 +517,6 @@ BOOLEAN NTAPI WepWindowTreeNewCallback(
                 if (GetKeyState(VK_CONTROL) < 0)
                     SendMessage(context->ParentWindowHandle, WM_COMMAND, ID_WINDOW_COPY, 0);
                 break;
-            case 'A':
-                if (GetKeyState(VK_CONTROL) < 0)
-                    TreeNew_SelectRange(context->TreeNewHandle, 0, -1);
-                break;
             }
         }
         return TRUE;

--- a/tools/peview/expprp.c
+++ b/tools/peview/expprp.c
@@ -927,10 +927,6 @@ BOOLEAN NTAPI PvExportTreeNewCallback(
                     }
                 }
                 break;
-            case 'A':
-                if (GetKeyState(VK_CONTROL) < 0)
-                    TreeNew_SelectRange(context->TreeNewHandle, 0, -1);
-                break;
             }
         }
         return TRUE;

--- a/tools/peview/impprp.c
+++ b/tools/peview/impprp.c
@@ -930,10 +930,6 @@ BOOLEAN NTAPI PvImportTreeNewCallback(
                     }
                 }
                 break;
-            case 'A':
-                if (GetKeyState(VK_CONTROL) < 0)
-                    TreeNew_SelectRange(context->TreeNewHandle, 0, -1);
-                break;
             }
         }
         return TRUE;

--- a/tools/peview/pdbprp.c
+++ b/tools/peview/pdbprp.c
@@ -496,14 +496,6 @@ BOOLEAN NTAPI PvSymbolTreeNewCallback(
                     }
                 }
                 break;
-            case 'A':
-                {
-                    if (GetKeyState(VK_CONTROL) < 0)
-                    {
-                        TreeNew_SelectRange(hwnd, 0, -1);
-                    }
-                }
-                break;
             }
         }
         return TRUE;

--- a/tools/peview/strings.c
+++ b/tools/peview/strings.c
@@ -548,10 +548,6 @@ BOOLEAN NTAPI PvpStringsTreeNewCallback(
                     }
                 }
                 break;
-            case 'A':
-                if (GetKeyState(VK_CONTROL) < 0)
-                    TreeNew_SelectRange(context->TreeNewHandle, 0, -1);
-                break;
             }
         }
         return TRUE;


### PR DESCRIPTION
- fix Ctrl+K (search box) handling
  - tree view didn't pass keypresses to parent window so it was not possible to handle the keyboard combo
  - some plugins didn't handle Ctrl+K at all
- treenew handle Ctrl+A in common code
- searchbox pressing escape will abandon search

  Current search is abandoned and focus is returned to window that previously had it, instead of closing whole dialog.