### PR TITLE
Fix Win32 file name resolving for WSL1 processe

### DIFF
--- a/SystemInformer/mainwnd.c
+++ b/SystemInformer/mainwnd.c
@@ -1880,8 +1880,8 @@ VOID PhMwpOnCommand(
 
             if (
                 processItem &&
-                !PhIsNullOrEmptyString(processItem->FileName) &&
-                PhDoesFileExist(&processItem->FileName->sr)
+                !PhIsNullOrEmptyString(processItem->FileNameWin32) &&
+                PhDoesFileExistWin32(PhGetString(processItem->FileNameWin32))
                 )
             {
                 PhReferenceObject(processItem);

--- a/SystemInformer/procprv.c
+++ b/SystemInformer/procprv.c
@@ -1204,10 +1204,10 @@ VOID PhpFillProcessItem(
                         ProcessItem->FileNameWin32 = fileName;
                     }
 
-                    //if (ProcessItem->FileName && PhIsNullOrEmptyString(ProcessItem->FileNameWin32))
-                    //{
-                    //    PhMoveReference(&ProcessItem->FileNameWin32, PhGetFileName(ProcessItem->FileName));
-                    //}
+                    if (ProcessItem->FileName && PhIsNullOrEmptyString(ProcessItem->FileNameWin32))
+                    {
+                        PhMoveReference(&ProcessItem->FileNameWin32, PhGetFileName(ProcessItem->FileName));
+                    }
                 }
             }
         }


### PR DESCRIPTION
- Proper path check in `Open file location` handling
- Fix Win32 file name resolving for WSL1 processes