### PR TITLE
fix native filtered handle enumeration

### DIFF
--- a/SystemInformer/prpghndl.c
+++ b/SystemInformer/prpghndl.c
@@ -640,7 +640,7 @@ INT_PTR CALLBACK PhpProcessHandlesDlgProc(
 
                         PhEditSecurity(
                             PhCsForceNoParent ? NULL : hwndDlg,
-                            PhGetString(handleItem->ObjectName),
+                            PhGetStringOrEmpty(handleItem->ObjectName),
                             PhGetString(handleItem->TypeName),
                             PhpProcessHandleOpenCallback,
                             PhpProcessHandleCloseCallback,

--- a/plugins/ExtendedTools/objmgr.c
+++ b/plugins/ExtendedTools/objmgr.c
@@ -2679,7 +2679,7 @@ VOID NTAPI EtpObjectManagerSearchControlCallback(
     else
         oldSelect = PhReferenceObject(context->CurrentPath);
 
-    PhSetDialogItemText(context->WindowHandle, IDC_OBJMGR_PATH, PhGetString(oldSelect));
+    PhSetWindowText(context->PathControlHandle, PhGetString(oldSelect));
     PhDereferenceObject(oldSelect);
 
     WCHAR string[PH_INT32_STR_LEN_1];
@@ -2815,7 +2815,7 @@ VOID EtpObjectEntryDeleteProcedure(
     PhClearReference(&entry->BaseDirectory);
 }
 
-VOID EtpLoadComboBoxHistoryToSettings(
+VOID EtpLoadComboBoxHistoryFromSettings(
     _In_ PET_OBJECT_CONTEXT Context
     )
 {
@@ -3010,7 +3010,7 @@ INT_PTR CALLBACK WinObjDlgProc(
             if (PhIsNullOrEmptyString(Target))  // HACK
                 Target = PH_AUTO(PhCreateString2(&EtObjectManagerRootDirectoryObject));
 
-            EtpLoadComboBoxHistoryToSettings(context);
+            EtpLoadComboBoxHistoryFromSettings(context);
 
             context->DisableSelChanged = TRUE;
             EtpObjectManagerOpenTarget(context, Target);


### PR DESCRIPTION
PhEnumHandlesGeneric was changed in latest commits. Today I mention what SI crashed when I open handles of System (4). Driver was off.
I didn't understand that part of the code then, apparently it wasn't finished. I propose this solution for filtering handles from global dump.