### PR TITLE
phnt Fix SAL annotations for `RtlWow64GetProcessMachines`

### DIFF
--- a/phnt/include/ntrtl.h
+++ b/phnt/include/ntrtl.h
@@ -4644,7 +4644,7 @@ NTAPI
 RtlWow64GetProcessMachines(
     _In_ HANDLE ProcessHandle,
     _Out_ PUSHORT ProcessMachine,
-    _Out_ PUSHORT NativeMachine
+    _Out_opt_ PUSHORT NativeMachine
     );
 #endif
 


### PR DESCRIPTION
It's very similar to [IsWow64Process2](https://learn.microsoft.com/en-us/windows/win32/api/wow64apiset/nf-wow64apiset-iswow64process2), `NativeMachine` can be `NULL`.