### PR TITLE
fix PhOpenDriver regression from 95bc2fe

### DIFF
--- a/phlib/native.c
+++ b/phlib/native.c
@@ -5618,7 +5618,7 @@ NTSTATUS PhOpenDriverByBaseAddress(
     InitializeObjectAttributes(
         &objectAttributes,
         &objectDirectoryName,
-        OBJ_EXCLUSIVE,
+        0,
         NULL,
         NULL
         );
@@ -5669,7 +5669,7 @@ NTSTATUS PhOpenDriver(
         InitializeObjectAttributes(
             &objectAttributes,
             &objectName,
-            OBJ_EXCLUSIVE | OBJ_CASE_INSENSITIVE,
+            OBJ_CASE_INSENSITIVE,
             RootDirectory,
             NULL
             );


### PR DESCRIPTION
Directory and Driver objects cannot be opened with OBJ_EXCLUSIVE, system calls returns STATUS_INVALID_PARAMETER even currently is zero opened handles for this object. This breaks both PhOpenDriver and PhOpenDriverByBaseAddress.
https://github.com/winsiderss/systeminformer/commit/95bc2fe8c1a077aeb2103c076e3991683294d4fc#diff-7b1df2858b7dc31ac554743937d5e518d03d6957113a83969968d4b1626096c1R5621