### PR TITLE
phnt trivial improvements

### DIFF
--- a/phnt/include/ntmmapi.h
+++ b/phnt/include/ntmmapi.h
@@ -181,7 +181,7 @@ typedef struct _MEMORY_WORKING_SET_BLOCK
 typedef struct _MEMORY_WORKING_SET_INFORMATION
 {
     ULONG_PTR NumberOfEntries;
-    _Field_size_(NumberOfEntries) MEMORY_WORKING_SET_BLOCK WorkingSetInfo[1];
+    _Field_size_(NumberOfEntries) MEMORY_WORKING_SET_BLOCK WorkingSetInfo[ANYSIZE_ARRAY];
 } MEMORY_WORKING_SET_INFORMATION, *PMEMORY_WORKING_SET_INFORMATION;
 
 // private
@@ -271,7 +271,7 @@ typedef union _MEMORY_WORKING_SET_EX_BLOCK
 #endif
         } Invalid;
     };
-} MEMORY_WORKING_SET_EX_BLOCK, * PMEMORY_WORKING_SET_EX_BLOCK;
+} MEMORY_WORKING_SET_EX_BLOCK, *PMEMORY_WORKING_SET_EX_BLOCK;
 
 /**
  * The MEMORY_WORKING_SET_EX_INFORMATION structure contains extended working set information for a process.

--- a/phnt/include/ntpebteb.h
+++ b/phnt/include/ntpebteb.h
@@ -131,7 +131,7 @@ typedef struct _WER_MEMORY
 typedef struct _WER_GATHER
 {
     PVOID Next;
-    USHORT Flags;    
+    USHORT Flags;
     union
     {
       WER_FILE File;

--- a/phnt/include/ntrtl.h
+++ b/phnt/include/ntrtl.h
@@ -10208,7 +10208,7 @@ NTSTATUS
 NTAPI 
 RtlProcessFlsData(
     _In_ HANDLE ProcessHandle,
-    _Out_ PPVOID FlsData
+    _Out_ PVOID* FlsData
     );
 #endif
 

--- a/phnt/include/winsta.h
+++ b/phnt/include/winsta.h
@@ -1251,7 +1251,7 @@ WinStationQuerySessionVirtualIP(
     _In_ ADDRESS_FAMILY Family,
     _Out_ TS_SESSION_VIRTUAL_ADDRESS* SessionVirtualIP
     );
-    
+
 // rev
 NTSYSAPI
 BOOLEAN
@@ -1262,7 +1262,7 @@ WinStationGetDeviceId(
     _Out_ PCHAR* Buffer, // CHAR DeviceId[MAX_PATH + 1];
     _In_ SIZE_T BufferLength
     );
-        
+
 // rev
 NTSYSAPI
 BOOLEAN


### PR DESCRIPTION
Some trivial improvements:
- `[1]` -> `[ANYSIZE_ARRAY]`
- `PPVOID` -> `PVOID*` (seems to use Windows SDK native type is better?)
- Removed some unwanted spaces