### PR TITLE
phnt: Fix `BcdCopyObjects` declaration

### DIFF
--- a/phnt/include/ntbcd.h
+++ b/phnt/include/ntbcd.h
@@ -571,7 +571,7 @@ NTSTATUS
 NTAPI
 BcdCopyObjects(
     _In_ HANDLE BcdStoreHandle,
-    _In_ BCD_OBJECT_DESCRIPTION Characteristics,
+    _In_ PBCD_OBJECT_DESCRIPTION Characteristics,
     _In_ BCD_COPY_FLAGS BcdCopyFlags,
     _In_ HANDLE TargetStoreHandle
     );


### PR DESCRIPTION
This parameter should be a pointer.