### PR TITLE
objmgr don't show bogus handles

### DIFF
--- a/plugins/ExtendedTools/objprp.c
+++ b/plugins/ExtendedTools/objprp.c
@@ -1438,7 +1438,7 @@ VOID EtpEnumObjectHandles(
                     }
                 }
 
-                if (handleInfo->Object == Context->HandleItem->Object || objectNameMatched)
+                if ((handleInfo->Object && handleInfo->Object == Context->HandleItem->Object) || objectNameMatched)
                 {
                     if (useWorkQueue) PhAcquireQueuedLockExclusive(&searchResultsLock);
                     PhAddItemList(searchResults, handleInfo);


### PR DESCRIPTION
In case of non-admin we don't have object address for handle and thus we cannot match handles that point to the same object.