### PR TITLE
fix SourceLink

### DIFF
--- a/tools/CustomBuildTool/Build.cs
+++ b/tools/CustomBuildTool/Build.cs
@@ -1356,8 +1356,8 @@ namespace CustomBuildTool
                     {
                         ["documents"] = new JsonObject
                         {
-                            ["\\*"] = $"https://raw.githubusercontent.com/winsiderss/systeminformer/{Build.BuildCommitHash}*",
-                            [$"{Path.Join([Build.BuildWorkingFolder, "\\"])}*"] = $"https://raw.githubusercontent.com/winsiderss/systeminformer/{Build.BuildCommitHash}*"
+                            ["*"] = $"https://raw.githubusercontent.com/winsiderss/systeminformer/{Build.BuildCommitHash}/*",
+                            [$"{Path.Join([Build.BuildWorkingFolder, "\\"])}*"] = $"https://raw.githubusercontent.com/winsiderss/systeminformer/{Build.BuildCommitHash}/*"
                         }
                     };
 


### PR DESCRIPTION
This fixes regression introduced in f1516d655652afd066c2b41328d5dd6f0bc57f33 .

Current _sourcelink_ stream looks like this:
```
{
  "documents": {
    "\\*": "https://raw.githubusercontent.com/winsiderss/systeminformer/609ffb2547bd54741d49a4ed50efe7e6fe2922ed*",
    "D:\\a\\1\\s\\*": "https://raw.githubusercontent.com/winsiderss/systeminformer/609ffb2547bd54741d49a4ed50efe7e6fe2922ed*"
  }
}
```
Note that `/` is missing before `*` wildcard in URL part. That's obvious mistake.

Then there seems to be problem with source path matching.
In PDBs they look like `SystemInformer\main.c`, `phlib\native.c` (due to deterministic builds).
So they don't match `\\*` pattern.
With `*` as path pattern everything works nicely.