### PR TITLE
WindowExplorer: fix premature context freeing in WepResolveSymbolFunction

### DIFF
--- a/plugins/WindowExplorer/wndprp.c
+++ b/plugins/WindowExplorer/wndprp.c
@@ -417,7 +417,6 @@ NTSTATUS WepResolveSymbolFunction(
     PostMessage(context->NotifyWindow, WEM_RESOLVE_DONE, 0, (LPARAM)context);
 
     PhDereferenceObject(context->Context);
-    PhFree(context);
     return STATUS_SUCCESS;
 }
 


### PR DESCRIPTION
Context was inserted to `ResolveListHead` list already. It will be freed when removed from the list.

This regression was introduced in b5c8ece .