### PR TITLE
Fix STATUS_HANDLE_NOT_CLOSABLE handle leak

### DIFF
--- a/SystemInformer/tokprp.c
+++ b/SystemInformer/tokprp.c
@@ -303,7 +303,7 @@ VOID PhCreateTokenDialog(
         &tokenHandle,
         0,
         0,
-        DUPLICATE_SAME_ACCESS | DUPLICATE_SAME_ATTRIBUTES
+        DUPLICATE_SAME_ACCESS
         )))
     {
         PhShowStatus(NULL, L"Unable to duplicate the token.", status, 0);

--- a/phlib/hndlinfo.c
+++ b/phlib/hndlinfo.c
@@ -1120,7 +1120,7 @@ NTSTATUS PhpGetBestObjectName(
             &dupHandle,
             JOB_OBJECT_QUERY,
             0,
-            DUPLICATE_SAME_ATTRIBUTES
+            0
             );
 
         if (!NT_SUCCESS(status))
@@ -1202,7 +1202,7 @@ NTSTATUS PhpGetBestObjectName(
                 &dupHandle,
                 PROCESS_QUERY_LIMITED_INFORMATION,
                 0,
-                DUPLICATE_SAME_ATTRIBUTES
+                0
                 );
 
             if (!NT_SUCCESS(status))
@@ -1275,7 +1275,7 @@ NTSTATUS PhpGetBestObjectName(
                 &dupHandle,
                 SECTION_QUERY | SECTION_MAP_READ,
                 0,
-                DUPLICATE_SAME_ATTRIBUTES
+                0
                 );
 
             if (!NT_SUCCESS(status))
@@ -1368,7 +1368,7 @@ NTSTATUS PhpGetBestObjectName(
                 &dupHandle,
                 THREAD_QUERY_LIMITED_INFORMATION,
                 0,
-                DUPLICATE_SAME_ATTRIBUTES
+                0
                 );
 
             if (!NT_SUCCESS(status))
@@ -1398,7 +1398,7 @@ NTSTATUS PhpGetBestObjectName(
             &dupHandle,
             ENLISTMENT_QUERY_INFORMATION,
             0,
-            DUPLICATE_SAME_ATTRIBUTES
+            0
             );
 
         if (!NT_SUCCESS(status))
@@ -1425,7 +1425,7 @@ NTSTATUS PhpGetBestObjectName(
             &dupHandle,
             RESOURCEMANAGER_QUERY_INFORMATION,
             0,
-            DUPLICATE_SAME_ATTRIBUTES
+            0
             );
 
         if (!NT_SUCCESS(status))
@@ -1466,7 +1466,7 @@ NTSTATUS PhpGetBestObjectName(
             &dupHandle,
             TRANSACTIONMANAGER_QUERY_INFORMATION,
             0,
-            DUPLICATE_SAME_ATTRIBUTES
+            0
             );
 
         if (!NT_SUCCESS(status))
@@ -1513,7 +1513,7 @@ NTSTATUS PhpGetBestObjectName(
             &dupHandle,
             TRANSACTION_QUERY_INFORMATION,
             0,
-            DUPLICATE_SAME_ATTRIBUTES
+            0
             );
 
         if (!NT_SUCCESS(status))
@@ -1561,7 +1561,7 @@ NTSTATUS PhpGetBestObjectName(
             &dupHandle,
             TOKEN_QUERY,
             0,
-            DUPLICATE_SAME_ATTRIBUTES
+            0
             );
 
         if (!NT_SUCCESS(status))
@@ -1848,7 +1848,7 @@ NTSTATUS PhGetHandleInformationEx(
             &objectHandle,
             0,
             0,
-            DUPLICATE_SAME_ACCESS | DUPLICATE_SAME_ATTRIBUTES
+            DUPLICATE_SAME_ACCESS
             );
 
         if (!NT_SUCCESS(status))

--- a/plugins/DotNetTools/counters.c
+++ b/plugins/DotNetTools/counters.c
@@ -128,7 +128,7 @@ PPH_LIST EnumerateAppDomainIpcBlock(
         &legacyPrivateBlockMutexHandle,
         GENERIC_ALL,
         0,
-        DUPLICATE_SAME_ACCESS | DUPLICATE_SAME_ATTRIBUTES
+        DUPLICATE_SAME_ACCESS
         )))
     {
         goto CleanupExit;
@@ -289,7 +289,7 @@ PPH_LIST EnumerateAppDomainIpcBlockWow64(
         &legacyPrivateBlockMutexHandle,
         GENERIC_ALL,
         0,
-        DUPLICATE_SAME_ACCESS | DUPLICATE_SAME_ATTRIBUTES
+        DUPLICATE_SAME_ACCESS
         )))
     {
         goto CleanupExit;


### PR DESCRIPTION
This pull request fixes handle leaks that occur when System Informer duplicates handles that have `OBJ_PROTECT_CLOSE` attribute, such as when inspecting protected handles from other processes. 

Using `DUPLICATE_SAME_ATTRIBUTES` requires careful consideration. It's usually unnecessary and often problematic because the code responsible for closing such handles must be ready to clear the `OBJ_PROTECT_CLOSE` attribute before passing the handle to `NtClose`.