### PR TITLE
Fixed compile issue.

### DIFF
--- a/SystemInformer/phsvc/svcapiport.c
+++ b/SystemInformer/phsvc/svcapiport.c
@@ -285,6 +285,7 @@ VOID PhSvcHandleConnectionRequest(
 #endif // DEBUG
 #if defined(PH_BUILD_API)
         remoteFileName = NULL;
+        clientId = message->h.ClientId;
         PhGetProcessImageFileNameByProcessId(clientId.UniqueProcess, &remoteFileName);
         PH_AUTO(remoteFileName);
 


### PR DESCRIPTION
Fixed... [ERROR] (1) SystemInformer\phsvc\svcapiport.c(288): error C4700: uninitialized local variable 'clientId' used [C:\Source\SystemInformer\SystemInformer.vcxproj]
LINK : fatal error LNK1257: code generation failed [C:\Source\SystemInformer\SystemInformer.vcxproj]