### PR TITLE
Update util.c

### DIFF
--- a/KSystemInformer/util.c
+++ b/KSystemInformer/util.c
@@ -1412,7 +1412,7 @@ NTSTATUS KphpGetKernelFileName(
     {
         KphTracePrint(TRACE_LEVEL_VERBOSE,
                       UTIL,
-                      L"ZwQuerySystemInformation failed: %!STATUS!",
+                      "ZwQuerySystemInformation failed: %!STATUS!",
                       status);
 
         return status;


### PR DESCRIPTION
every ware else we use narrow string in KphTracePrint, so lets be consistent.