### PR TITLE
phnt: Mark some non syscall functions as NTSYSAPI instead of NTSYSCALLAPI

### DIFF
--- a/phnt/include/ntmmapi.h
+++ b/phnt/include/ntmmapi.h
@@ -774,7 +774,7 @@ NtReadVirtualMemory(
     );
 
 // rev
-NTSYSCALLAPI
+NTSYSAPI
 NTSTATUS
 NTAPI
 NtWow64ReadVirtualMemory64(
@@ -842,7 +842,7 @@ NtWriteVirtualMemory(
  * @param NumberOfBytesWritten A pointer to a variable that receives the number of bytes transferred into the specified buffer.
  * @return NTSTATUS Successful or errant status.
  */
-NTSYSCALLAPI
+NTSYSAPI
 NTSTATUS
 NTAPI
 NtWow64WriteVirtualMemory64(
@@ -909,7 +909,7 @@ NtQueryVirtualMemory(
  * @param ReturnLength A pointer to a variable that receives the number of bytes returned in the MemoryInformation buffer.
  * @return NTSTATUS Successful or errant status.
  */
-NTSYSCALLAPI
+NTSYSAPI
 NTSTATUS
 NTAPI
 NtWow64QueryVirtualMemory64(

--- a/phnt/include/ntpsapi.h
+++ b/phnt/include/ntpsapi.h
@@ -1959,7 +1959,7 @@ NtQueryInformationProcess(
     );
 
 // rev
-NTSYSCALLAPI
+NTSYSAPI
 NTSTATUS
 NTAPI
 NtWow64QueryInformationProcess64(

--- a/phnt/include/ntrtl.h
+++ b/phnt/include/ntrtl.h
@@ -8980,7 +8980,7 @@ LdrInitializeThunk(
 // Thread execution
 //
 
-NTSYSCALLAPI
+NTSYSAPI
 NTSTATUS
 NTAPI
 RtlDelayExecution(

--- a/phnt/include/ntuser.h
+++ b/phnt/include/ntuser.h
@@ -157,7 +157,7 @@ NtUserConsoleControl(
  * @param ConsoleInformationLength The size of the structure pointed to by the ConsoleInformation parameter.
  * @return Successful or errant status.
  */
-NTSYSCALLAPI
+NTSYSAPI
 NTSTATUS
 NTAPI
 ConsoleControl(
@@ -303,7 +303,7 @@ NtUserSetChildWindowNoActivate(
     );
 
 // User32 ordinal 2005
-NTSYSCALLAPI
+NTSYSAPI
 LOGICAL
 NTAPI
 SetChildWindowNoActivate(
@@ -953,7 +953,7 @@ NtUserSetInformationThread(
     _In_ ULONG ThreadInformationLength
     );
 
-NTSYSCALLAPI
+NTSYSAPI
 BOOL
 NTAPI
 QuerySendMessage(


### PR DESCRIPTION
I think only functions directly trigger a `syscall/int 80` should be considered a syscall

## NtWow64ReadVirtualMemory64, NtWow64WriteVirtualMemory64, NtWow64QueryVirtualMemory64 and NtWow64QueryInformationProcess64
They are handled by `wow64.dll`, just like calling other Nt-syscall functions under wow64. It's `wow64.dll` that translates the 32-bit arguments into native, then passes them into real Nt-syscalls.
Though NtWow64* are special because they take 64-bit addresses instead of 32-bit ones. But they should not be considered a real syscall. They only exists in `%windir%\SysWoW64\ntdll.dll`, not in native 32-bit or 64-bit `ntdll.dll`s.

## RtlDelayExecution
It should be a typo. All other Rtl* are NTSYSAPI.

## ConsoleControl, SetChildWindowNoActivate, QuerySendMessage
Should be typos. They are user32 APIs.