### PR TITLE
Fix begin_private comment placement

### DIFF
--- a/phnt/include/ntrtl.h
+++ b/phnt/include/ntrtl.h
@@ -8856,12 +8856,12 @@ RtlQueryValidationRunlevel(
 // Private namespaces
 //
 
+// begin_private
+
 #if (PHNT_VERSION >= PHNT_WINDOWS_VISTA)
 
 // rev
 #define BOUNDARY_DESCRIPTOR_ADD_APPCONTAINER_SID 0x0001
-
-// begin_private
 
 _Ret_maybenull_
 _Success_(return != NULL)


### PR DESCRIPTION
I'm not sure if that's the correct fix according to the `// begin_*` comments convention. Currently, the code looks as following:
```cpp
#if (PHNT_VERSION >= PHNT_WINDOWS_VISTA)
// ...
// begin_private
// ...
#endif // PHNT_VERSION >= PHNT_WINDOWS_VISTA
// ...
// end_private
```
Which doesn't follow proper nesting unlike in other places. This confuses one of my scripts that parses the headers.