### PR TITLE
fix: phnt-rs — CI build failure; incorrectly feature-guarded ntzwapi function

### DIFF
--- a/phnt/include/ntzwapi.h
+++ b/phnt/include/ntzwapi.h
@@ -164,6 +164,8 @@ ZwAcquireCrossVmMutant(
     _In_ PLARGE_INTEGER Timeout
     );
 
+#if (PHNT_MODE != PHNT_MODE_KERNEL)
+# if (PHNT_VERSION >= PHNT_WINDOWS_8)
 NTSYSCALLAPI
 NTSTATUS
 NTAPI
@@ -172,6 +174,8 @@ ZwAcquireProcessActivityReference(
     _In_ HANDLE ParentProcessHandle,
     _Reserved_ PROCESS_ACTIVITY_TYPE Reserved
     );
+# endif // (PHNT_VERSION >= PHNT_WINDOWS_8)
+#endif // (PHNT_MODE != PHNT_MODE_KERNEL)
 
 NTSYSCALLAPI
 NTSTATUS


### PR DESCRIPTION
[phnt-rs](https://github.com/delulu-hq/phnt-rs) has experienced a [CI build failure](https://github.com/delulu-hq/phnt-rs/actions/runs/13989244790/job/39169263636) from recent changes to ntzwapi.h:
```code
  thread 'main' panicked at src\build.rs:205:11:
  Unable to generate bindings!: ClangDiagnostic("D:\\a\\phnt-rs\\phnt-rs\\deps\\phnt-nightly\\ntzwapi.h:173:16: error: unknown type name 'PROCESS_ACTIVITY_TYPE'\nD:\\a\\phnt-rs\\phnt-rs\\deps\\phnt-nightly\\ntzwapi.h:4296:33: error: unknown type name 'PMEMORY_RANGE_ENTRY'\nD:\\a\\phnt-rs\\phnt-rs\\deps\\phnt-nightly\\ntzwapi.h:4876:10: error: unknown type name 'PWORKER_FACTORY_DEFERRED_WORK'\n")
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
Error: Process completed with exit code 1.
```

Proposed is a fix that obviously has to be applied to the generating part of systeminformer.
Please ignore the actual changes and only use as a reference.
The same applies to `PMEMORY_RANGE_ENTRY` and `PWORKER_FACTORY_DEFERRED_WORK`.

Thanks!
