### PR TITLE
Add AFD handle information

### DIFF
--- a/SystemInformer/findobj.c
+++ b/SystemInformer/findobj.c
@@ -1602,29 +1602,17 @@ INT_PTR CALLBACK PhFindObjectsDlgProc(
                         if (handleObjectNode->ResultType == HandleSearchResult)
                         {
                             PPH_HANDLE_ITEM handleItem;
-                            BOOLEAN isAlpcPort = FALSE;
 
                             handleItem = PhCreateHandleItem(&handleObjectNode->HandleInfo);
 
                             if (!PhIsNullOrEmptyString(handleObjectNode->TypeNameString))
-                            {
-                                isAlpcPort = PhEqualString2(handleObjectNode->TypeNameString, L"ALPC Port", TRUE);
-                                handleItem->TypeName = handleObjectNode->TypeNameString;
-                                PhReferenceObject(handleObjectNode->TypeNameString);
-                            }
+                                handleItem->TypeName = PhReferenceObject(handleObjectNode->TypeNameString);
 
-                            // Best object name for the ALPC port contains information about the connection
-                            // between the client and server, use the original object name string instead.
-                            if (isAlpcPort && !PhIsNullOrEmptyString(handleObjectNode->ObjectNameString))
-                            {
-                                handleItem->BestObjectName = handleItem->ObjectName = handleObjectNode->ObjectNameString;
-                                PhReferenceObjectEx(handleItem->BestObjectName, 2);
-                            }
-                            else if (!isAlpcPort && !PhIsNullOrEmptyString(handleObjectNode->BestObjectName))
-                            {
-                                handleItem->BestObjectName = handleItem->ObjectName = handleObjectNode->BestObjectName;
-                                PhReferenceObjectEx(handleItem->BestObjectName, 2);
-                            }
+                            if (!PhIsNullOrEmptyString(handleObjectNode->ObjectNameString))
+                                handleItem->ObjectName = PhReferenceObject(handleObjectNode->ObjectNameString);
+
+                            if (!PhIsNullOrEmptyString(handleObjectNode->BestObjectName))
+                                handleItem->BestObjectName = PhReferenceObject(handleObjectNode->BestObjectName);
 
                             PhShowHandleProperties(
                                 hwndDlg,

--- a/SystemInformer/hndlprp.c
+++ b/SystemInformer/hndlprp.c
@@ -21,6 +21,7 @@
 #include <hndlinfo.h>
 #include <procprv.h>
 #include <secedit.h>
+#include <phafd.h>
 
 typedef enum _PHP_HANDLE_GENERAL_CATEGORY
 {
@@ -36,6 +37,7 @@ typedef enum _PHP_HANDLE_GENERAL_CATEGORY
     PH_HANDLE_GENERAL_CATEGORY_PROCESSTHREAD,
     PH_HANDLE_GENERAL_CATEGORY_ETW,
     PH_HANDLE_GENERAL_CATEGORY_SYMBOLICLINK,
+    PH_HANDLE_GENERAL_CATEGORY_AFDSOCKET,
 
     PH_HANDLE_GENERAL_CATEGORY_MAXIMUM
 } PHP_HANDLE_GENERAL_CATEGORY;
@@ -87,6 +89,27 @@ typedef enum _PHP_HANDLE_GENERAL_INDEX
     PH_HANDLE_GENERAL_INDEX_ETWGROUPNAME,
 
     PH_HANDLE_GENERAL_INDEX_SYMBOLICLINKLINK,
+
+    PH_HANDLE_GENERAL_INDEX_AFDSOCKETRAWNAME,
+    PH_HANDLE_GENERAL_INDEX_AFDSOCKETTDIADDRESSDEVICE,
+    PH_HANDLE_GENERAL_INDEX_AFDSOCKETTDICONNECTIONDEVICE,
+    PH_HANDLE_GENERAL_INDEX_AFDSOCKETSTATE,
+    PH_HANDLE_GENERAL_INDEX_AFDSOCKETTYPE,
+    PH_HANDLE_GENERAL_INDEX_AFDSOCKETADDRESSFAMILY,
+    PH_HANDLE_GENERAL_INDEX_AFDSOCKETPROTOCOL,
+    PH_HANDLE_GENERAL_INDEX_AFDSOCKETCATALOGENTRYID,
+    PH_HANDLE_GENERAL_INDEX_AFDSOCKETPROVIDERID,
+    PH_HANDLE_GENERAL_INDEX_AFDSOCKETPROVIDERFLAGS,
+    PH_HANDLE_GENERAL_INDEX_AFDSOCKETSERVICEFLAGS,
+    PH_HANDLE_GENERAL_INDEX_AFDSOCKETSENDTIMEOUT,
+    PH_HANDLE_GENERAL_INDEX_AFDSOCKETRECEIVETIMEOUT,
+    PH_HANDLE_GENERAL_INDEX_AFDSOCKETSENDBUFFERSIZE,
+    PH_HANDLE_GENERAL_INDEX_AFDSOCKETRECEIVEBUFFERSIZE,
+    PH_HANDLE_GENERAL_INDEX_AFDSOCKETCREATIONFLAGS,
+    PH_HANDLE_GENERAL_INDEX_AFDSOCKETFLAGS,
+    PH_HANDLE_GENERAL_INDEX_AFDSOCKETCONNECTTIME,
+    PH_HANDLE_GENERAL_INDEX_AFDSOCKETADDRESS,
+    PH_HANDLE_GENERAL_INDEX_AFDSOCKETREMOTEADDRESS,
 
     PH_HANDLE_GENERAL_INDEX_MAXIMUM
 } PHP_HANDLE_GENERAL_INDEX;
@@ -470,6 +493,31 @@ VOID PhpUpdateHandleGeneralListViewGroups(
         {
             PhAddHandleListViewItem(Context->ListViewClass, PH_HANDLE_GENERAL_CATEGORY_FILE, PH_HANDLE_GENERAL_INDEX_FILEDRIVER, L"Driver");
             PhAddHandleListViewItem(Context->ListViewClass, PH_HANDLE_GENERAL_CATEGORY_FILE, PH_HANDLE_GENERAL_INDEX_FILEDRIVERIMAGE, L"Driver Image");
+        }
+
+        if (PhAfdIsSocketObjectName(Context->HandleItem->ObjectName))
+        {
+            PhAddIListViewGroup(Context->ListViewClass, PH_HANDLE_GENERAL_CATEGORY_AFDSOCKET, L"Socket information");
+            PhAddHandleListViewItem(Context->ListViewClass, PH_HANDLE_GENERAL_CATEGORY_AFDSOCKET, PH_HANDLE_GENERAL_INDEX_AFDSOCKETRAWNAME, L"Raw name");
+            PhAddHandleListViewItem(Context->ListViewClass, PH_HANDLE_GENERAL_CATEGORY_AFDSOCKET, PH_HANDLE_GENERAL_INDEX_AFDSOCKETTDIADDRESSDEVICE, L"TDI address device");
+            PhAddHandleListViewItem(Context->ListViewClass, PH_HANDLE_GENERAL_CATEGORY_AFDSOCKET, PH_HANDLE_GENERAL_INDEX_AFDSOCKETTDICONNECTIONDEVICE, L"TDI connection device");
+            PhAddHandleListViewItem(Context->ListViewClass, PH_HANDLE_GENERAL_CATEGORY_AFDSOCKET, PH_HANDLE_GENERAL_INDEX_AFDSOCKETSTATE, L"State");
+            PhAddHandleListViewItem(Context->ListViewClass, PH_HANDLE_GENERAL_CATEGORY_AFDSOCKET, PH_HANDLE_GENERAL_INDEX_AFDSOCKETTYPE, L"Type");
+            PhAddHandleListViewItem(Context->ListViewClass, PH_HANDLE_GENERAL_CATEGORY_AFDSOCKET, PH_HANDLE_GENERAL_INDEX_AFDSOCKETADDRESSFAMILY, L"Address family");
+            PhAddHandleListViewItem(Context->ListViewClass, PH_HANDLE_GENERAL_CATEGORY_AFDSOCKET, PH_HANDLE_GENERAL_INDEX_AFDSOCKETPROTOCOL, L"Protocol");
+            PhAddHandleListViewItem(Context->ListViewClass, PH_HANDLE_GENERAL_CATEGORY_AFDSOCKET, PH_HANDLE_GENERAL_INDEX_AFDSOCKETCATALOGENTRYID, L"Catalog entry ID");
+            PhAddHandleListViewItem(Context->ListViewClass, PH_HANDLE_GENERAL_CATEGORY_AFDSOCKET, PH_HANDLE_GENERAL_INDEX_AFDSOCKETPROVIDERID, L"Provider ID");
+            PhAddHandleListViewItem(Context->ListViewClass, PH_HANDLE_GENERAL_CATEGORY_AFDSOCKET, PH_HANDLE_GENERAL_INDEX_AFDSOCKETPROVIDERFLAGS, L"Provider flags");
+            PhAddHandleListViewItem(Context->ListViewClass, PH_HANDLE_GENERAL_CATEGORY_AFDSOCKET, PH_HANDLE_GENERAL_INDEX_AFDSOCKETSERVICEFLAGS, L"Service flags");
+            PhAddHandleListViewItem(Context->ListViewClass, PH_HANDLE_GENERAL_CATEGORY_AFDSOCKET, PH_HANDLE_GENERAL_INDEX_AFDSOCKETSENDTIMEOUT, L"Send timeout");
+            PhAddHandleListViewItem(Context->ListViewClass, PH_HANDLE_GENERAL_CATEGORY_AFDSOCKET, PH_HANDLE_GENERAL_INDEX_AFDSOCKETRECEIVETIMEOUT, L"Receive timeout");
+            PhAddHandleListViewItem(Context->ListViewClass, PH_HANDLE_GENERAL_CATEGORY_AFDSOCKET, PH_HANDLE_GENERAL_INDEX_AFDSOCKETSENDBUFFERSIZE, L"Send buffer size");
+            PhAddHandleListViewItem(Context->ListViewClass, PH_HANDLE_GENERAL_CATEGORY_AFDSOCKET, PH_HANDLE_GENERAL_INDEX_AFDSOCKETRECEIVEBUFFERSIZE, L"Receive buffer size");
+            PhAddHandleListViewItem(Context->ListViewClass, PH_HANDLE_GENERAL_CATEGORY_AFDSOCKET, PH_HANDLE_GENERAL_INDEX_AFDSOCKETCREATIONFLAGS, L"Creation flags");
+            PhAddHandleListViewItem(Context->ListViewClass, PH_HANDLE_GENERAL_CATEGORY_AFDSOCKET, PH_HANDLE_GENERAL_INDEX_AFDSOCKETFLAGS, L"Flags");
+            PhAddHandleListViewItem(Context->ListViewClass, PH_HANDLE_GENERAL_CATEGORY_AFDSOCKET, PH_HANDLE_GENERAL_INDEX_AFDSOCKETCONNECTTIME, L"Connect time");
+            PhAddHandleListViewItem(Context->ListViewClass, PH_HANDLE_GENERAL_CATEGORY_AFDSOCKET, PH_HANDLE_GENERAL_INDEX_AFDSOCKETADDRESS, L"Address");
+            PhAddHandleListViewItem(Context->ListViewClass, PH_HANDLE_GENERAL_CATEGORY_AFDSOCKET, PH_HANDLE_GENERAL_INDEX_AFDSOCKETREMOTEADDRESS, L"Remote address");
         }
     }
     else if (PhEqualStringRef2(&Context->HandleItem->TypeName->sr, L"Section", TRUE))
@@ -1452,6 +1500,165 @@ VOID PhpUpdateHandleGeneral(
                     case IoPriorityCritical:
                         PhSetHandleListViewItem(Context, PH_HANDLE_GENERAL_INDEX_FILEPRIORITY, 1, L"Critical");
                         break;
+                    }
+                }
+
+                // AFD socket information
+                if (PhAfdIsSocketObjectName(Context->HandleItem->ObjectName))
+                {
+                    PPH_STRING itemString;
+                    SOCK_SHARED_INFO socketInfo;
+                    AFD_INFORMATION simpleInfo;
+
+                    // Raw name
+                    if (Context->HandleItem->ObjectName)
+                    {
+                        PhSetHandleListViewItem(Context, PH_HANDLE_GENERAL_INDEX_AFDSOCKETRAWNAME, 1, Context->HandleItem->ObjectName->Buffer);
+                    }
+
+                    // TDI address device
+                    if (NT_SUCCESS(PhAfdQueryFormatTdiDeviceName(fileHandle, AFD_QUERY_ADDRESS_HANDLE, &itemString)))
+                    {
+                        PhSetHandleListViewItem(Context, PH_HANDLE_GENERAL_INDEX_AFDSOCKETTDIADDRESSDEVICE, 1, itemString->Buffer);
+                        PhDereferenceObject(itemString);
+                    }
+
+                    // TDI connection device
+                    if (NT_SUCCESS(PhAfdQueryFormatTdiDeviceName(fileHandle, AFD_QUERY_CONNECTION_HANDLE, &itemString)))
+                    {
+                        PhSetHandleListViewItem(Context, PH_HANDLE_GENERAL_INDEX_AFDSOCKETTDICONNECTIONDEVICE, 1, itemString->Buffer);
+                        PhDereferenceObject(itemString);
+                    }
+
+                    if (NT_SUCCESS(PhAfdQuerySharedInfo(fileHandle, &socketInfo)))
+                    {
+                        // State
+                        itemString = PhAfdFormatSocketState(socketInfo.State);
+                        PhSetHandleListViewItem(Context, PH_HANDLE_GENERAL_INDEX_AFDSOCKETSTATE, 1, itemString->Buffer);
+                        PhDereferenceObject(itemString);
+
+                        // Type
+                        itemString = PhAfdFormatSocketType(socketInfo.SocketType);
+                        PhSetHandleListViewItem(Context, PH_HANDLE_GENERAL_INDEX_AFDSOCKETTYPE, 1, itemString->Buffer);
+                        PhDereferenceObject(itemString);
+
+                        // Address family
+                        itemString = PhAfdFormatAddressFamily(socketInfo.AddressFamily);
+                        PhSetHandleListViewItem(Context, PH_HANDLE_GENERAL_INDEX_AFDSOCKETADDRESSFAMILY, 1, itemString->Buffer);
+                        PhDereferenceObject(itemString);
+
+                        // Protocol
+                        itemString = PhAfdFormatProtocol(socketInfo.AddressFamily, socketInfo.Protocol);
+                        PhSetHandleListViewItem(Context, PH_HANDLE_GENERAL_INDEX_AFDSOCKETPROTOCOL, 1, itemString->Buffer);
+                        PhDereferenceObject(itemString);
+
+                        // Catalog entry ID
+                        itemString = PhFormatString(L"%d", socketInfo.CatalogEntryId);
+                        PhSetHandleListViewItem(Context, PH_HANDLE_GENERAL_INDEX_AFDSOCKETCATALOGENTRYID, 1, itemString->Buffer);
+                        PhDereferenceObject(itemString);
+
+                        // Provider ID
+                        itemString = PhFormatGuid(&socketInfo.ProviderId);
+                        PhSetHandleListViewItem(Context, PH_HANDLE_GENERAL_INDEX_AFDSOCKETPROVIDERID, 1, itemString->Buffer);
+                        PhDereferenceObject(itemString);
+
+                        // Provider flags
+                        itemString = PhAfdFormatProviderFlags(socketInfo.ProviderFlags);
+                        PhSetHandleListViewItem(Context, PH_HANDLE_GENERAL_INDEX_AFDSOCKETPROVIDERFLAGS, 1, itemString->Buffer);
+                        PhDereferenceObject(itemString);
+
+                        // Service flags
+                        itemString = PhAfdFormatServiceFlags(socketInfo.ServiceFlags1);
+                        PhSetHandleListViewItem(Context, PH_HANDLE_GENERAL_INDEX_AFDSOCKETSERVICEFLAGS, 1, itemString->Buffer);
+                        PhDereferenceObject(itemString);
+
+                        // Send timeout
+                        if (socketInfo.SendTimeout)
+                        {
+                            itemString = PhFormatTimeSpanRelative(PH_TICKS_PER_MS * socketInfo.SendTimeout);
+                            PhSetHandleListViewItem(Context, PH_HANDLE_GENERAL_INDEX_AFDSOCKETSENDTIMEOUT, 1, itemString->Buffer);
+                            PhDereferenceObject(itemString);
+                        }
+                        else
+                        {
+                            PhSetHandleListViewItem(Context, PH_HANDLE_GENERAL_INDEX_AFDSOCKETSENDTIMEOUT, 1, L"Unlimited");
+                        }
+
+                        // Receive timeout
+                        if (socketInfo.ReceiveTimeout)
+                        {
+                            itemString = PhFormatTimeSpanRelative(PH_TICKS_PER_MS * socketInfo.ReceiveTimeout);
+                            PhSetHandleListViewItem(Context, PH_HANDLE_GENERAL_INDEX_AFDSOCKETRECEIVETIMEOUT, 1, itemString->Buffer);
+                            PhDereferenceObject(itemString);
+                        }
+                        else
+                        {
+                            PhSetHandleListViewItem(Context, PH_HANDLE_GENERAL_INDEX_AFDSOCKETRECEIVETIMEOUT, 1, L"Unlimited");
+                        }
+
+                        // Send buffer size
+                        itemString = PhFormatSize(socketInfo.SendBufferSize, -1);
+                        PhSetHandleListViewItem(Context, PH_HANDLE_GENERAL_INDEX_AFDSOCKETSENDBUFFERSIZE, 1, itemString->Buffer);
+                        PhDereferenceObject(itemString);
+
+                        // Receive buffer size
+                        itemString = PhFormatSize(socketInfo.ReceiveBufferSize, -1);
+                        PhSetHandleListViewItem(Context, PH_HANDLE_GENERAL_INDEX_AFDSOCKETRECEIVEBUFFERSIZE, 1, itemString->Buffer);
+                        PhDereferenceObject(itemString);
+
+                        // Creation flags
+                        itemString = PhAfdFormatCreationFlags(socketInfo.CreationFlags);
+                        PhSetHandleListViewItem(Context, PH_HANDLE_GENERAL_INDEX_AFDSOCKETCREATIONFLAGS, 1, itemString->Buffer);
+                        PhDereferenceObject(itemString);
+
+                        // Flags
+                        itemString = PhAfdFormatSharedInfoFlags(&socketInfo);
+                        PhSetHandleListViewItem(Context, PH_HANDLE_GENERAL_INDEX_AFDSOCKETFLAGS, 1, itemString->Buffer);
+                        PhDereferenceObject(itemString);
+                    }
+
+                    // Connect time
+                    if (NT_SUCCESS(PhAfdQuerySimpleInfo(fileHandle, AFD_CONNECT_TIME, &simpleInfo)))
+                    {
+                        if (simpleInfo.Information.Ulong != ULONG_MAX)
+                        {
+                            LARGE_INTEGER time;
+                            SYSTEMTIME timeFields;
+                            PPH_STRING timeRelativeString;
+                            PPH_STRING timeString;
+
+                            // Derive connection time from relative number of seconds
+                            PhQuerySystemTime(&time);
+                            time.QuadPart -= PH_TICKS_PER_SEC * simpleInfo.Information.Ulong;
+                            PhLargeIntegerToLocalSystemTime(&timeFields, &time);
+
+                            timeRelativeString = PhFormatTimeSpanRelative(PH_TICKS_PER_SEC * simpleInfo.Information.Ulong);
+                            timeString = PhFormatDateTime(&timeFields);
+                            itemString = PhFormatString(L"%s ago (%s)", timeRelativeString->Buffer, timeString->Buffer);
+                            PhDereferenceObject(timeRelativeString);
+                            PhDereferenceObject(timeString);
+
+                            PhSetHandleListViewItem(Context, PH_HANDLE_GENERAL_INDEX_AFDSOCKETCONNECTTIME, 1, itemString->Buffer);
+                            PhDereferenceObject(itemString);
+                        }
+                        else
+                        {
+                            PhSetHandleListViewItem(Context, PH_HANDLE_GENERAL_INDEX_AFDSOCKETCONNECTTIME, 1, L"N/A");
+                        }
+                    }
+
+                    // Address
+                    if (NT_SUCCESS(PhAfdQueryFormatAddress(fileHandle, FALSE, &itemString, FALSE)))
+                    {
+                        PhSetHandleListViewItem(Context, PH_HANDLE_GENERAL_INDEX_AFDSOCKETADDRESS, 1, itemString->Buffer);
+                        PhDereferenceObject(itemString);
+                    }
+
+                    // Remote address
+                    if (NT_SUCCESS(PhAfdQueryFormatAddress(fileHandle, TRUE, &itemString, FALSE)))
+                    {
+                        PhSetHandleListViewItem(Context, PH_HANDLE_GENERAL_INDEX_AFDSOCKETREMOTEADDRESS, 1, itemString->Buffer);
+                        PhDereferenceObject(itemString);
                     }
                 }
 

--- a/phlib/include/phafd.h
+++ b/phlib/include/phafd.h
@@ -1,0 +1,165 @@
+/*
+ * Copyright (c) 2022 Winsider Seminars & Solutions, Inc.  All rights reserved.
+ *
+ * This file is part of System Informer.
+ *
+ * Authors:
+ *
+ *     diversenok   2025
+ *
+ */
+
+#ifndef _PH_PHAFD_H
+#define _PH_PHAFD_H
+
+#include <ph.h>
+#include <ntafd.h>
+
+EXTERN_C_START
+
+PHLIBAPI
+BOOLEAN
+NTAPI
+PhAfdIsSocketObjectName(
+    _In_opt_ PPH_STRING ObjectName
+    );
+
+PHLIBAPI
+NTSTATUS
+NTAPI
+PhAfdIsSocketHandle(
+    _In_ HANDLE Handle
+    );
+
+NTSTATUS
+NTAPI
+PhAfdDeviceIoControl(
+    _In_ HANDLE SocketHandle,
+    _In_ ULONG IoControlCode,
+    _In_reads_bytes_(InBufferSize) PVOID InBuffer,
+    _In_ ULONG InBufferSize,
+    _Out_writes_bytes_to_opt_(OutputBufferSize, *BytesReturned) PVOID OutputBuffer,
+    _In_ ULONG OutputBufferSize,
+    _Out_opt_ PULONG BytesReturned,
+    _Inout_opt_ LPOVERLAPPED Overlapped
+    );
+
+PHLIBAPI
+NTSTATUS
+NTAPI
+PhAfdQuerySharedInfo(
+    _In_ HANDLE SocketHandle,
+    _Out_ PSOCK_SHARED_INFO SharedInfo
+    );
+
+PHLIBAPI
+NTSTATUS
+NTAPI
+PhAfdQuerySimpleInfo(
+    _In_ HANDLE SocketHandle,
+    _In_ ULONG InformationType,
+    _Out_ PAFD_INFORMATION Information
+    );
+
+NTSTATUS
+NTAPI
+PhAfdQueryOption(
+    _In_ HANDLE SocketHandle,
+    _In_ ULONG Level,
+    _In_ ULONG OptionName,
+    _Out_ PULONG OptionValue
+    );
+
+NTSTATUS
+NTAPI
+PhAfdQueryTdiHandle(
+    _In_ HANDLE SocketHandle,
+    _In_ ULONG QueryMode,
+    _Out_ PHANDLE TdiHandle
+    );
+
+NTSTATUS
+NTAPI
+PhAfdQueryFormatTdiDeviceName(
+    _In_ HANDLE SocketHandle,
+    _In_ ULONG QueryMode,
+    _Outptr_ PPH_STRING* TdiDeviceName
+    );
+
+PHLIBAPI
+NTSTATUS
+NTAPI
+PhAfdQueryAddress(
+    _In_ HANDLE SocketHandle,
+    _In_ BOOLEAN Remote,
+    _Out_ PSOCKADDR_STORAGE Address
+    );
+
+NTSTATUS
+NTAPI
+PhAfdQueryFormatAddress(
+    _In_ HANDLE SocketHandle,
+    _In_ BOOLEAN Remote,
+    _Out_ PPH_STRING *AddressString,
+    _In_ BOOLEAN Simplify
+    );
+
+PPH_STRING
+NTAPI
+PhAfdFormatSocketState(
+    _In_ SOCKET_STATE SocketState
+    );
+
+PPH_STRING
+NTAPI
+PhAfdFormatSocketType(
+    _In_ LONG SocketType
+    );
+
+PPH_STRING
+NTAPI
+PhAfdFormatAddressFamily(
+    _In_ LONG AddressFamily
+    );
+
+PPH_STRING
+NTAPI
+PhAfdFormatProtocol(
+    _In_ LONG AddressFamily,
+    _In_ LONG Protocol
+    );
+
+PPH_STRING
+NTAPI
+PhAfdFormatProviderFlags(
+    _In_ ULONG ProviderFlags
+    );
+
+PPH_STRING
+NTAPI
+PhAfdFormatServiceFlags(
+    _In_ ULONG ServiceFlags
+    );
+
+PPH_STRING
+NTAPI
+PhAfdFormatCreationFlags(
+    _In_ ULONG CreationFlags
+    );
+
+PPH_STRING
+NTAPI
+PhAfdFormatSharedInfoFlags(
+    _In_ PSOCK_SHARED_INFO SharedInfo
+    );
+
+_Maybenull_
+PPH_STRING
+NTAPI
+PhAfdFormatSocketBestName(
+    _In_ HANDLE SocketHandle
+    );
+
+EXTERN_C_END
+
+#endif _PH_PHAFD_H

--- a/phlib/nativesocket.c
+++ b/phlib/nativesocket.c
@@ -1,0 +1,1237 @@
+/*
+ * Copyright (c) 2022 Winsider Seminars & Solutions, Inc.  All rights reserved.
+ *
+ * This file is part of System Informer.
+ *
+ * Authors:
+ *
+ *     diversenok   2025
+ *
+ */
+
+#include <phafd.h>
+#include <hndlinfo.h>
+#include <ws2ipdef.h>
+#include <ws2bth.h>
+#include <hvsocket.h>
+
+ /**
+   * \brief Determines if an object name represents an AFD socket handle.
+   *
+   * \param[in] ObjectName A native object name.
+   *
+   * \return Whether the name matches an AFD socket name format.
+   */
+BOOLEAN
+NTAPI
+PhAfdIsSocketObjectName(
+    _In_opt_ PPH_STRING ObjectName
+    )
+{
+    return ObjectName && PhStartsWithString2(ObjectName, AFD_DEVICE_NAME, TRUE) &&
+        (ObjectName->Length == sizeof(AFD_DEVICE_NAME) - sizeof(UNICODE_NULL) ||
+         ObjectName->Buffer[ObjectName->Length / sizeof(WCHAR)] == OBJ_NAME_PATH_SEPARATOR);
+}
+
+/**
+  * \brief Determines if a file handle is an AFD socket handle.
+  *
+  * \param[in] Handle A file handle.
+  *
+  * \return A successful status if the handle is an AFD socket or an errant status otherwise.
+  */
+NTSTATUS
+NTAPI
+PhAfdIsSocketHandle(
+    _In_ HANDLE Handle
+    )
+{
+    NTSTATUS status;
+    IO_STATUS_BLOCK ioStatusBlock;
+
+    union {
+        FILE_VOLUME_NAME_INFORMATION VolumeName;
+        UCHAR Raw[sizeof(FILE_VOLUME_NAME_INFORMATION) + sizeof(AFD_DEVICE_NAME) - sizeof(UNICODE_NULL)];
+    } Buffer;
+
+    // Query the backing device name
+    status = NtQueryInformationFile(
+        Handle,
+        &ioStatusBlock,
+        &Buffer,
+        sizeof(Buffer),
+        FileVolumeNameInformation
+        );
+
+    // If the name does not fit into the buffer, it's not AFD
+    if (status == STATUS_BUFFER_OVERFLOW)
+        return STATUS_NOT_SAME_DEVICE;
+
+    if (!NT_SUCCESS(status))
+        return status;
+
+    static UNICODE_STRING afdDeviceName = RTL_CONSTANT_STRING(AFD_DEVICE_NAME);
+    UNICODE_STRING volumeName;
+
+    volumeName.Buffer = Buffer.VolumeName.DeviceName;
+    volumeName.Length = (USHORT)Buffer.VolumeName.DeviceNameLength;
+    volumeName.MaximumLength = (USHORT)Buffer.VolumeName.DeviceNameLength;
+
+    // Compare the file's device name to AFD
+    return RtlEqualUnicodeString(&volumeName, &afdDeviceName, TRUE) ? STATUS_SUCCESS : STATUS_NOT_SAME_DEVICE;
+}
+
+ /**
+  * \brief Issues an IOCTL on an AFD handle and waits for its completion.
+  *
+  * \param[in] SocketHandle An AFD socket handle.
+  * \param[in] IoControlCode I/O control code
+  * \param[in] InBuffer Input buffer.
+  * \param[in] InBufferSize Input buffer size.
+  * \param[out] OutputBuffer Output Buffer.
+  * \param[in] OutputBufferSize Output buffer size.
+  * \param[out] BytesReturned Optionally set to the number of bytes returned.
+  * \param[in,out] Overlapped Optional overlapped structure.
+  *
+  * \return Successful or errant status.
+  */
+NTSTATUS
+NTAPI
+PhAfdDeviceIoControl(
+    _In_ HANDLE SocketHandle,
+    _In_ ULONG IoControlCode,
+    _In_reads_bytes_(InBufferSize) PVOID InBuffer,
+    _In_ ULONG InBufferSize,
+    _Out_writes_bytes_to_opt_(OutputBufferSize, *BytesReturned) PVOID OutputBuffer,
+    _In_ ULONG OutputBufferSize,
+    _Out_opt_ PULONG BytesReturned,
+    _Inout_opt_ LPOVERLAPPED Overlapped
+    )
+{
+    NTSTATUS status;
+    HANDLE hEvent;
+    IO_STATUS_BLOCK ioStatusBlock;
+
+    if (BytesReturned)
+    {
+        *BytesReturned = 0;
+    }
+
+    if (Overlapped)
+    {
+        hEvent = Overlapped->hEvent;
+        Overlapped->Internal = STATUS_PENDING;
+    }
+    else
+    {
+        // We cannot wait on the file handle because it might not grant SYNCHRONIZE access.
+        // Always use an event instead.
+
+        status = NtCreateEvent(
+            &hEvent,
+            EVENT_ALL_ACCESS,
+            NULL,
+            SynchronizationEvent,
+            FALSE
+            );
+
+        if (!NT_SUCCESS(status))
+            return status;
+    }
+
+    status = NtDeviceIoControlFile(
+        SocketHandle,
+        hEvent,
+        NULL,
+        Overlapped,
+        Overlapped ? (PIO_STATUS_BLOCK)Overlapped : &ioStatusBlock,
+        IoControlCode,
+        InBuffer,
+        InBufferSize,
+        OutputBuffer,
+        OutputBufferSize
+        );
+
+    if (Overlapped)
+    {
+        if (NT_INFORMATION(status) && BytesReturned)
+        {
+            *BytesReturned = (ULONG)Overlapped->InternalHigh;
+        }
+    }
+    else
+    {
+        if (status == STATUS_PENDING)
+        {
+            NtWaitForSingleObject(hEvent, FALSE, NULL);
+            status = ioStatusBlock.Status;
+        }
+
+        NtClose(hEvent);
+
+        if (BytesReturned)
+        {
+            *BytesReturned = (ULONG)ioStatusBlock.Information;
+        }
+    }
+
+    return status;
+}
+
+/**
+  * \brief Retrieves shared information for an AFD socket.
+  *
+  * \param[in] SocketHandle An AFD socket handle.
+  * \param[out] SharedInfo A buffer with the shared socket information.
+  *
+  * \return Successful or errant status.
+  */
+NTSTATUS
+NTAPI
+PhAfdQuerySharedInfo(
+    _In_ HANDLE SocketHandle,
+    _Out_ PSOCK_SHARED_INFO SharedInfo
+    )
+{
+    NTSTATUS status;
+    ULONG returnedSize;
+
+    status = PhAfdDeviceIoControl(
+        SocketHandle,
+        IOCTL_AFD_GET_CONTEXT,
+        NULL,
+        0,
+        SharedInfo,
+        sizeof(SOCK_SHARED_INFO),
+        &returnedSize,
+        NULL
+        );
+
+    if (status == STATUS_BUFFER_OVERFLOW)
+        return STATUS_SUCCESS;
+
+    if (!NT_SUCCESS(status))
+        return status;
+
+    // Shared information is provided by the Win32 level; do a sanity check on the returned size
+    return returnedSize < sizeof(SOCK_SHARED_INFO) ? STATUS_NOT_FOUND : status;
+}
+
+/**
+  * \brief Retrieves simple information for an AFD socket.
+  *
+  * \param[in] SocketHandle An AFD socket handle.
+  * \param[in] InformationType The type of information to query, such as AFD_CONNECT_TIME or AFD_GROUP_ID_AND_TYPE.
+  * \param[out] Information Output buffer.
+  *
+  * \return Successful or errant status.
+  */
+NTSTATUS
+NTAPI
+PhAfdQuerySimpleInfo(
+    _In_ HANDLE SocketHandle,
+    _In_ ULONG InformationType,
+    _Out_ PAFD_INFORMATION Information
+    )
+{
+    Information->InformationType = InformationType;
+
+    return PhAfdDeviceIoControl(
+        SocketHandle,
+        IOCTL_AFD_GET_INFORMATION,
+        Information,
+        sizeof(AFD_INFORMATION),
+        Information,
+        sizeof(AFD_INFORMATION),
+        NULL,
+        NULL
+        );
+}
+
+/**
+  * \brief Retrieves socket option for an AFD socket.
+  *
+  * \param[in] Level A level for the option, such as SOL_SOCKET or IPPROTO_IP.
+  * \param[in] OptionName An option identifier within the level, such as SO_REUSEADDR or IP_TTL.
+  * \param[out] OptionValue A buffer that receives the option value.
+  *
+  * \return Successful or errant status.
+  */
+NTSTATUS
+NTAPI
+PhAfdQueryOption(
+    _In_ HANDLE SocketHandle,
+    _In_ ULONG Level,
+    _In_ ULONG OptionName,
+    _Out_ PULONG OptionValue
+    )
+{
+    AFD_TL_IO_CONTROL_INFO controlInfo = { 0 };
+    controlInfo.Type = TlGetSockOptIoControlType;
+    controlInfo.EndpointIoctl = TRUE;
+    controlInfo.Level = Level;
+    controlInfo.IoControlCode = OptionName;
+    *OptionValue = 0;
+
+    return PhAfdDeviceIoControl(
+        SocketHandle,
+        IOCTL_AFD_TRANSPORT_IOCTL,
+        &controlInfo,
+        sizeof(AFD_TL_IO_CONTROL_INFO),
+        OptionValue,
+        sizeof(ULONG),
+        NULL,
+        NULL
+        );
+}
+
+/**
+  * \brief Opens an address or a connection handle to the underlying device for a TDI socket.
+  *
+  * \param[in] SocketHandle An AFD socket handle.
+  * \param[in] QueryMode A type of the query, either AFD_QUERY_ADDRESS_HANDLE or AFD_QUERY_CONNECTION_HANDLE.
+  * \param[out] TdiHandle A pointer to a variable that receives a TDI device handle, NULL (when no handle is available), or INVALID_HANDLE_VALUE (for non-TDI sockets).
+  *
+  * \return Successful or errant status.
+  */
+NTSTATUS
+NTAPI
+PhAfdQueryTdiHandle(
+    _In_ HANDLE SocketHandle,
+    _In_ ULONG QueryMode,
+    _Out_ PHANDLE TdiHandle
+    )
+{
+    NTSTATUS status;
+    AFD_HANDLE_INFO handles;
+
+    if (QueryMode != AFD_QUERY_ADDRESS_HANDLE && QueryMode != AFD_QUERY_CONNECTION_HANDLE)
+        return STATUS_INVALID_INFO_CLASS;
+
+    status = PhAfdDeviceIoControl(
+        SocketHandle,
+        IOCTL_AFD_QUERY_HANDLES,
+        &QueryMode,
+        sizeof(QueryMode),
+        &handles,
+        sizeof(handles),
+        NULL,
+        NULL
+        );
+
+    if (NT_SUCCESS(status))
+    {
+        if (QueryMode == AFD_QUERY_ADDRESS_HANDLE)
+            *TdiHandle = handles.TdiAddressHandle;
+        else
+            *TdiHandle = handles.TdiConnectionHandle;
+    }
+
+    return status;
+}
+
+/**
+  * \brief Formats a TDI device name for a socket.
+  *
+  * \param[in] SocketHandle An AFD socket handle.
+  * \param[in] QueryMode A type of the query, either AFD_QUERY_ADDRESS_HANDLE or AFD_QUERY_CONNECTION_HANDLE.
+  * \param[out] TdiDeviceName A pointer to a variable that receives a device name string.
+  *
+  * \return Successful or errant status.
+  */
+NTSTATUS
+NTAPI
+PhAfdQueryFormatTdiDeviceName(
+    _In_ HANDLE SocketHandle,
+    _In_ ULONG QueryMode,
+    _Outptr_ PPH_STRING *TdiDeviceName
+    )
+{
+    NTSTATUS status;
+    HANDLE hTdiDevice;
+
+    status = PhAfdQueryTdiHandle(
+        SocketHandle,
+        QueryMode,
+        &hTdiDevice
+        );
+
+    if (!NT_SUCCESS(status))
+        return status;
+
+    if (hTdiDevice == INVALID_HANDLE_VALUE)
+    {
+        *TdiDeviceName = PhCreateString(L"N/A");
+    }
+    else if (hTdiDevice == NULL)
+    {
+        *TdiDeviceName = PhCreateString(L"None");
+    }
+    else
+    {
+        status = PhGetObjectName(NtCurrentProcess(), hTdiDevice, TRUE, TdiDeviceName);
+        NtClose(hTdiDevice);
+    }
+
+    return status;
+}
+
+/**
+  * \brief Determines if we know how to handle a specific address family.
+  *
+  * \param[in] AddressFamily A socket address family value.
+  *
+  * \return Whether the address family is supported.
+  */
+BOOLEAN
+NTAPI
+PhpAfdIsSupportedAddressFamily(
+    _In_ LONG AddressFamily
+    )
+{
+    switch (AddressFamily)
+    {
+    case AF_INET:
+    case AF_INET6:
+    case AF_BTH:
+    case AF_HYPERV:
+        return TRUE;
+    default:
+        return FALSE;
+    }
+}
+
+/**
+  * \brief Retrieves an address associated with an AFD socket.
+  *
+  * \param[in] SocketHandle An AFD socket handle.
+  * \param[in] Remote Whether the function should return a remote or a local address.
+  * \param[out] Address Output buffer.
+  *
+  * \return Successful or errant status.
+  */
+NTSTATUS
+NTAPI
+PhAfdQueryAddress(
+    _In_ HANDLE SocketHandle,
+    _In_ BOOLEAN Remote,
+    _Out_ PSOCKADDR_STORAGE Address
+    )
+{
+    NTSTATUS status;
+    AFD_ADDRESS buffer = { 0 };
+
+    if (Remote)
+    {
+        // HACK: If the socket has a suitable state but no remote address, the IOCTL can succeed without
+        // writing anything to the buffer, yet setting IO_STATUS_BLOCK's Information to a non-zero value.
+        // We issue a zero-size query to recognize this scenario. (diversenok)
+
+        if (NT_SUCCESS(PhAfdDeviceIoControl(SocketHandle, IOCTL_AFD_GET_REMOTE_ADDRESS, NULL, 0, NULL, 0, NULL, NULL)))
+            return STATUS_NOT_FOUND;
+    }
+
+    // Retrieve the address
+    status = PhAfdDeviceIoControl(
+        SocketHandle,
+        Remote ? IOCTL_AFD_GET_REMOTE_ADDRESS : IOCTL_AFD_GET_ADDRESS,
+        NULL,
+        0,
+        &buffer,
+        sizeof(buffer),
+        NULL,
+        NULL
+        );
+
+    if (!NT_SUCCESS(status))
+        return status;
+
+    // Most sockets are TLI; their addresses don't need conversion.
+    if (PhpAfdIsSupportedAddressFamily(buffer.TliAddress.ss_family))
+    {
+        *Address = buffer.TliAddress;
+        return status;
+    }
+
+    // Some sockets (like Bluetooth) use TDI. Verify the header and extarct the socket address.
+    if (buffer.TdiAddress.ActivityCount > 0 &&
+        buffer.TdiAddress.Address.TAAddressCount >= 1 &&
+        buffer.TdiAddress.Address.Address[0].AddressLength <= sizeof(buffer) - RTL_SIZEOF_THROUGH_FIELD(TDI_ADDRESS_INFO, Address.Address[0].AddressType) &&
+        PhpAfdIsSupportedAddressFamily(buffer.TdiAddress.Address.Address[0].AddressType))
+    {
+        RtlZeroMemory(Address, sizeof(SOCKADDR_STORAGE));
+
+        // AddressLength covers the length after the AddressType field, while the socket address starts at the AddressType field.
+        // See comments in AFD_ADDRESS for details about the layout.
+        RtlCopyMemory(
+            Address,
+            &buffer.TdiAddressUnpacked.EmbeddedAddress,
+            buffer.TdiAddress.Address.Address[0].AddressLength + RTL_FIELD_SIZE(TDI_ADDRESS_INFO, Address.Address[0].AddressType)
+            );
+
+        return status;
+    }
+
+    return STATUS_UNKNOWN_REVISION;
+}
+
+/**
+  * \brief Formats a socket address as a strings.
+  *
+  * \param[in] Address The address buffer.
+  * \param[out] AddressString The string representation of the address.
+  * \param[in] Simplify A boolean indicating whether the function should prefer a human-readable or a complete version of the address.
+  *
+  * \return Successful or errant status.
+  */
+NTSTATUS
+NTAPI
+PhAfdFormatAddress(
+    _In_ PSOCKADDR_STORAGE Address,
+    _Out_ PPH_STRING *AddressString,
+    _In_ BOOLEAN Simplify
+    )
+{
+    NTSTATUS status = STATUS_NOT_SUPPORTED;
+    WCHAR buffer[70];
+    ULONG characters = RTL_NUMBER_OF(buffer);
+
+    if (Address->ss_family == AF_INET)
+    {
+        PSOCKADDR_IN address = (PSOCKADDR_IN)Address;
+
+        // Format an IPv4 address
+        status = RtlIpv4AddressToStringExW(
+            &address->sin_addr,
+            address->sin_port,
+            buffer,
+            &characters
+            );
+
+        if (!NT_SUCCESS(status))
+            return status;
+
+        *AddressString = PhCreateStringEx(buffer, characters * sizeof(WCHAR) - sizeof(UNICODE_NULL));
+    }
+    else if (Address->ss_family == AF_INET6)
+    {
+        PSOCKADDR_IN6 address = (PSOCKADDR_IN6)Address;
+
+        // Format an IPv6 address
+        status = RtlIpv6AddressToStringExW(
+            &address->sin6_addr,
+            address->sin6_scope_id,
+            address->sin6_port,
+            buffer,
+            &characters
+            );
+
+        if (!NT_SUCCESS(status))
+            return status;
+
+        *AddressString = PhCreateStringEx(buffer, characters * sizeof(WCHAR) - sizeof(UNICODE_NULL));
+    }
+    else if (Address->ss_family == AF_BTH)
+    {
+        PSOCKADDR_BTH address = (PSOCKADDR_BTH)Address;
+
+        // Format a Bluetooth address
+        *AddressString = PhFormatString(
+            L"(%02X:%02X:%02X:%02X:%02X:%02X):%d",
+            (UCHAR)(address->btAddr >> 40),
+            (UCHAR)(address->btAddr >> 32),
+            (UCHAR)(address->btAddr >> 24),
+            (UCHAR)(address->btAddr >> 16),
+            (UCHAR)(address->btAddr >> 8),
+            (UCHAR)(address->btAddr),
+            address->port
+            );
+
+        status = STATUS_SUCCESS;
+    }
+    else if (Address->ss_family == AF_HYPERV)
+    {
+        PSOCKADDR_HV address = (PSOCKADDR_HV)Address;
+        PCWSTR knownVmId = NULL;
+        PPH_STRING vmIdPart = NULL;
+        PPH_STRING serviceIdPart;
+
+        if (Simplify)
+        {
+            // Recognize placeholder VmId values
+            if (IsEqualGUID(&address->VmId, &HV_GUID_WILDCARD))
+                knownVmId = L"{Wildcard}";
+            else if (IsEqualGUID(&address->VmId, &HV_GUID_BROADCAST))
+                knownVmId = L"{Broadcast}";
+            else if (IsEqualGUID(&address->VmId, &HV_GUID_CHILDREN))
+                knownVmId = L"{Children}";
+            else if (IsEqualGUID(&address->VmId, &HV_GUID_LOOPBACK))
+                knownVmId = L"{Loopback}";
+            else if (IsEqualGUID(&address->VmId, &HV_GUID_PARENT))
+                knownVmId = L"{Parent}";
+            else if (IsEqualGUID(&address->VmId, &HV_GUID_SILOHOST))
+                knownVmId = L"{Silo host}";
+        }
+
+        if (!knownVmId)
+        {
+            // Fall back to using a GUID name
+            vmIdPart = PhFormatGuid(&address->VmId);
+        }
+
+        serviceIdPart = PhFormatGuid(&address->ServiceId);
+
+        // Format a Hyper-V address as {VmId}:{ServiceId}
+        *AddressString = PhFormatString(
+            L"%s:%s",
+            vmIdPart ? vmIdPart->Buffer : knownVmId,
+            serviceIdPart->Buffer
+            );
+
+        if (vmIdPart)
+            PhDereferenceObject(vmIdPart);
+
+        PhDereferenceObject(serviceIdPart);
+
+        status = STATUS_SUCCESS;
+    }
+
+    return status;
+}
+
+/**
+  * \brief Queries an address associated with an AFD socket and prints it into a string.
+  *
+  * \param[in] SocketHandle An AFD socket handle.
+  * \param[in] Remote Whether the function should return a remote or a local address.
+  * \param[out] AddressString The string representation of the address.
+  * \param[in] Simplify A boolean indicating whether the function should prefer a human-readable or a complete version of the address.
+  *
+  * \return Successful or errant status.
+  */
+NTSTATUS
+NTAPI
+PhAfdQueryFormatAddress(
+    _In_ HANDLE SocketHandle,
+    _In_ BOOLEAN Remote,
+    _Out_ PPH_STRING *AddressString,
+    _In_ BOOLEAN Simplify
+    )
+{
+    NTSTATUS status;
+    SOCKADDR_STORAGE address;
+
+    status = PhAfdQueryAddress(SocketHandle, Remote, &address);
+
+    if (!NT_SUCCESS(status))
+        return status;
+
+    return PhAfdFormatAddress(&address, AddressString, Simplify);
+}
+
+/**
+  * \brief Looks up a human-readable name of a known socket state.
+  *
+  * \param[in] SocketState The socket state value.
+  *
+  * \return A string with the state name or NULL when the state value is not recognized.
+  */
+_Maybenull_
+PCWSTR
+NTAPI
+PhpAfdGetSocketStateString(
+    _In_ SOCKET_STATE SocketState
+    )
+{
+    switch (SocketState)
+    {
+    case SocketStateInitializing:
+        return L"Initializing";
+    case SocketStateOpen:
+        return L"Open";
+    case SocketStateBound:
+        return L"Bound";
+    case SocketStateBoundSpecific:
+        return L"Bound (specific)";
+    case SocketStateConnected:
+        return L"Connected";
+    case SocketStateClosing:
+        return L"Closing";
+    default:
+        return NULL;
+    }
+}
+
+/**
+  * \brief Formats a socket state as a string.
+  *
+  * \param[in] SocketState The socket state value.
+  *
+  * \return A human-readable name of the socket state.
+  */
+PPH_STRING
+NTAPI
+PhAfdFormatSocketState(
+    _In_ SOCKET_STATE SocketState
+    )
+{
+    PCWSTR knownName = PhpAfdGetSocketStateString(SocketState);
+
+    if (knownName)
+        return PhCreateString(knownName);
+    else
+        return PhFormatString(L"Invalid state (%d)", SocketState);
+}
+
+/**
+  * \brief Looks up a human-readable name of a known socket type.
+  *
+  * \param[in] SocketType The socket type value.
+  *
+  * \return A string with the socket type name or NULL when the value is not recognized.
+  */
+_Maybenull_
+PCWSTR
+NTAPI
+PhpAfdGetSocketTypeString(
+    _In_ LONG SocketType
+    )
+{
+    switch (SocketType)
+    {
+    case SOCK_STREAM:
+        return L"Stream";
+    case SOCK_DGRAM:
+        return L"Datagram";
+    case SOCK_RAW:
+        return L"Raw";
+    case SOCK_RDM:
+        return L"Reliably-delivered message";
+    case SOCK_SEQPACKET:
+        return L"Pseudo-stream";
+    default:
+        return NULL;
+    }
+}
+
+/**
+  * \brief Formats a socket type as a string.
+  *
+  * \param[in] SocketType The socket type value.
+  *
+  * \return A human-readable name for the socket type.
+  */
+PPH_STRING
+NTAPI
+PhAfdFormatSocketType(
+    _In_ LONG SocketType
+    )
+{
+    PCWSTR knownName = PhpAfdGetSocketTypeString(SocketType);
+
+    if (knownName)
+        return PhCreateString(knownName);
+    else
+        return PhFormatString(L"Unknown (%d)", SocketType);
+}
+
+/**
+  * \brief Formats a human-readable name for a set of protocol provider flags.
+  *
+  * \param[in] ProviderFlags The provider flags value.
+  *
+  * \return A string with the flag names.
+  */
+PPH_STRING
+NTAPI
+PhAfdFormatProviderFlags(
+    _In_ ULONG ProviderFlags
+    )
+{
+    PH_STRING_BUILDER stringBuilder;
+
+    PhInitializeStringBuilder(&stringBuilder, 60);
+    PhAppendFormatStringBuilder(&stringBuilder, L"0x%04X (", ProviderFlags);
+
+    if (ProviderFlags & PFL_MULTIPLE_PROTO_ENTRIES)
+        PhAppendStringBuilder2(&stringBuilder, L"Multiple entries, ");
+    if (ProviderFlags & PFL_RECOMMENDED_PROTO_ENTRY)
+        PhAppendStringBuilder2(&stringBuilder, L"Recommended entry, ");
+    if (ProviderFlags & PFL_HIDDEN)
+        PhAppendStringBuilder2(&stringBuilder, L"Hidden, ");
+    if (ProviderFlags & PFL_MATCHES_PROTOCOL_ZERO)
+        PhAppendStringBuilder2(&stringBuilder, L"Matches protocol zero, ");
+    if (ProviderFlags & PFL_NETWORKDIRECT_PROVIDER)
+        PhAppendStringBuilder2(&stringBuilder, L"Network direct, ");
+
+    if (!ProviderFlags)
+    {
+        PhAppendStringBuilder2(&stringBuilder, L"none");
+    }
+    else
+    {
+        // Remove the trailing comma
+        PhRemoveEndStringBuilder(&stringBuilder, 2);
+    }
+
+    PhAppendCharStringBuilder(&stringBuilder, L')');
+    return PhFinalStringBuilderString(&stringBuilder);
+}
+
+/**
+  * \brief Formats a human-readable name for a set of service flags.
+  *
+  * \param[in] ServiceFlags The service flags value.
+  *
+  * \return A string with the flag names.
+  */
+PPH_STRING
+NTAPI
+PhAfdFormatServiceFlags(
+    _In_ ULONG ServiceFlags
+    )
+{
+    PH_STRING_BUILDER stringBuilder;
+
+    PhInitializeStringBuilder(&stringBuilder, 0x100);
+    PhAppendFormatStringBuilder(&stringBuilder, L"0x%04X (", ServiceFlags);
+
+    if (ServiceFlags & XP1_CONNECTIONLESS)
+        PhAppendStringBuilder2(&stringBuilder, L"Connectionless, ");
+    if (ServiceFlags & XP1_GUARANTEED_DELIVERY)
+        PhAppendStringBuilder2(&stringBuilder, L"Guaranteed delivery, ");
+    if (ServiceFlags & XP1_GUARANTEED_ORDER)
+        PhAppendStringBuilder2(&stringBuilder, L"Guaranteed order, ");
+    if (ServiceFlags & XP1_MESSAGE_ORIENTED)
+        PhAppendStringBuilder2(&stringBuilder, L"Message-oriented, ");
+    if (ServiceFlags & XP1_PSEUDO_STREAM)
+        PhAppendStringBuilder2(&stringBuilder, L"Pseudo-stream, ");
+    if (ServiceFlags & XP1_GRACEFUL_CLOSE)
+        PhAppendStringBuilder2(&stringBuilder, L"Graceful close, ");
+    if (ServiceFlags & XP1_EXPEDITED_DATA)
+        PhAppendStringBuilder2(&stringBuilder, L"Expedited data, ");
+    if (ServiceFlags & XP1_CONNECT_DATA)
+        PhAppendStringBuilder2(&stringBuilder, L"Connect data, ");
+    if (ServiceFlags & XP1_DISCONNECT_DATA)
+        PhAppendStringBuilder2(&stringBuilder, L"Disconnect data, ");
+    if (ServiceFlags & XP1_SUPPORT_BROADCAST)
+        PhAppendStringBuilder2(&stringBuilder, L"Broadcast, ");
+    if (ServiceFlags & XP1_SUPPORT_MULTIPOINT)
+        PhAppendStringBuilder2(&stringBuilder, L"Support multipoint, ");
+    if (ServiceFlags & XP1_MULTIPOINT_CONTROL_PLANE)
+        PhAppendStringBuilder2(&stringBuilder, L"Multipoint control plane, ");
+    if (ServiceFlags & XP1_MULTIPOINT_DATA_PLANE)
+        PhAppendStringBuilder2(&stringBuilder, L"Multipoint data plane, ");
+    if (ServiceFlags & XP1_QOS_SUPPORTED)
+        PhAppendStringBuilder2(&stringBuilder, L"QoS supported, ");
+    if (ServiceFlags & XP1_INTERRUPT)
+        PhAppendStringBuilder2(&stringBuilder, L"Interrupt, ");
+    if (ServiceFlags & XP1_UNI_SEND)
+        PhAppendStringBuilder2(&stringBuilder, L"Unidirectional send, ");
+    if (ServiceFlags & XP1_UNI_RECV)
+        PhAppendStringBuilder2(&stringBuilder, L"Unidirectional receive, ");
+    if (ServiceFlags & XP1_IFS_HANDLES)
+        PhAppendStringBuilder2(&stringBuilder, L"IFS handles, ");
+    if (ServiceFlags & XP1_PARTIAL_MESSAGE)
+        PhAppendStringBuilder2(&stringBuilder, L"Partial message, ");
+    if (ServiceFlags & XP1_SAN_SUPPORT_SDP)
+        PhAppendStringBuilder2(&stringBuilder, L"SAN, ");
+
+    if (!ServiceFlags)
+    {
+        PhAppendStringBuilder2(&stringBuilder, L"none");
+    }
+    else
+    {
+        // Remove the trailing comma
+        PhRemoveEndStringBuilder(&stringBuilder, 2);
+    }
+
+    PhAppendCharStringBuilder(&stringBuilder, L')');
+    return PhFinalStringBuilderString(&stringBuilder);
+}
+
+/**
+  * \brief Formats a human-readable name for a set of socket creation flags.
+  *
+  * \param[in] CreationFlags The creation flags value.
+  *
+  * \return A string with the flag names.
+  */
+PPH_STRING
+NTAPI
+PhAfdFormatCreationFlags(
+    _In_ ULONG CreationFlags
+    )
+{
+    PH_STRING_BUILDER stringBuilder;
+
+    PhInitializeStringBuilder(&stringBuilder, 60);
+    PhAppendFormatStringBuilder(&stringBuilder, L"0x%04X (", CreationFlags);
+
+    if (CreationFlags & WSA_FLAG_OVERLAPPED)
+        PhAppendStringBuilder2(&stringBuilder, L"Overlapped, ");
+    if (CreationFlags & WSA_FLAG_MULTIPOINT_C_ROOT)
+        PhAppendStringBuilder2(&stringBuilder, L"Multipoint control root, ");
+    if (CreationFlags & WSA_FLAG_MULTIPOINT_C_LEAF)
+        PhAppendStringBuilder2(&stringBuilder, L"Multipoint control leaf, ");
+    if (CreationFlags & WSA_FLAG_MULTIPOINT_D_ROOT)
+        PhAppendStringBuilder2(&stringBuilder, L"Multipoint data root, ");
+    if (CreationFlags & WSA_FLAG_MULTIPOINT_D_LEAF)
+        PhAppendStringBuilder2(&stringBuilder, L"Multipoint data leaf, ");
+    if (CreationFlags & WSA_FLAG_ACCESS_SYSTEM_SECURITY)
+        PhAppendStringBuilder2(&stringBuilder, L"Access SACL, ");
+    if (CreationFlags & WSA_FLAG_NO_HANDLE_INHERIT)
+        PhAppendStringBuilder2(&stringBuilder, L"No handle inherit, ");
+    if (CreationFlags & WSA_FLAG_REGISTERED_IO)
+        PhAppendStringBuilder2(&stringBuilder, L"Registered I/O, ");
+
+    if (!CreationFlags)
+    {
+        PhAppendStringBuilder2(&stringBuilder, L"none");
+    }
+    else
+    {
+        // Remove the trailing comma
+        PhRemoveEndStringBuilder(&stringBuilder, 2);
+    }
+
+    PhAppendCharStringBuilder(&stringBuilder, L')');
+    return PhFinalStringBuilderString(&stringBuilder);
+}
+
+/**
+  * \brief Formats a human-readable name for a set of AFD socket flags.
+  *
+  * \param[in] SharedInfo The shared socket information buffer.
+  *
+  * \return A string with the flag names.
+  */
+PPH_STRING
+NTAPI
+PhAfdFormatSharedInfoFlags(
+    _In_ PSOCK_SHARED_INFO SharedInfo
+    )
+{
+    PH_STRING_BUILDER stringBuilder;
+
+    PhInitializeStringBuilder(&stringBuilder, 80);
+    PhAppendFormatStringBuilder(&stringBuilder, L"0x%04X (", SharedInfo->Flags);
+
+    if (SharedInfo->Listening)
+        PhAppendStringBuilder2(&stringBuilder, L"Listening, ");
+    if (SharedInfo->Broadcast)
+        PhAppendStringBuilder2(&stringBuilder, L"Broadcast, ");
+    if (SharedInfo->Debug)
+        PhAppendStringBuilder2(&stringBuilder, L"Debug, ");
+    if (SharedInfo->OobInline)
+        PhAppendStringBuilder2(&stringBuilder, L"OOB in line, ");
+    if (SharedInfo->ReuseAddresses)
+        PhAppendStringBuilder2(&stringBuilder, L"Reuse addresses, ");
+    if (SharedInfo->ExclusiveAddressUse)
+        PhAppendStringBuilder2(&stringBuilder, L"Exclusive address use, ");
+    if (SharedInfo->NonBlocking)
+        PhAppendStringBuilder2(&stringBuilder, L"Non-blocking, ");
+    if (SharedInfo->DontUseWildcard)
+        PhAppendStringBuilder2(&stringBuilder, L"Don't use wildcard, ");
+    if (SharedInfo->ReceiveShutdown)
+        PhAppendStringBuilder2(&stringBuilder, L"Receive shutdown, ");
+    if (SharedInfo->SendShutdown)
+        PhAppendStringBuilder2(&stringBuilder, L"Send shutdown, ");
+    if (SharedInfo->ConditionalAccept)
+        PhAppendStringBuilder2(&stringBuilder, L"Conditional accept, ");
+    if (SharedInfo->IsSANSocket)
+        PhAppendStringBuilder2(&stringBuilder, L"SAN, ");
+    if (SharedInfo->fIsTLI)
+        PhAppendStringBuilder2(&stringBuilder, L"TLI, ");
+    if (SharedInfo->Rio)
+        PhAppendStringBuilder2(&stringBuilder, L"RIO, ");
+    if (SharedInfo->ReceiveBufferSizeSet)
+        PhAppendStringBuilder2(&stringBuilder, L"Receive buffer size set, ");
+    if (SharedInfo->SendBufferSizeSet)
+        PhAppendStringBuilder2(&stringBuilder, L"Send buffer size set, ");
+
+    if (!SharedInfo->Flags)
+    {
+        PhAppendStringBuilder2(&stringBuilder, L"none");
+    }
+    else
+    {
+        // Remove the trailing comma
+        PhRemoveEndStringBuilder(&stringBuilder, 2);
+    }
+
+    PhAppendCharStringBuilder(&stringBuilder, L')');
+    return PhFinalStringBuilderString(&stringBuilder);
+}
+
+/**
+  * \brief Looks up a name of a known address family.
+  *
+  * \param[in] AddressFamily The address family value.
+  *
+  * \return A string with the address family name or NULL when it is not recognized.
+  */
+_Maybenull_
+PCWSTR
+NTAPI
+PhpAfdGetAddressFamilyString(
+    _In_ LONG AddressFamily
+    )
+{
+    switch (AddressFamily)
+    {
+    case AF_UNSPEC:
+        return L"Unspecified";
+    case AF_INET:
+        return L"Internet";
+    case AF_INET6:
+        return L"Internet v6";
+    case AF_BTH:
+        return L"Bluetooth";
+    case AF_HYPERV:
+        return L"Hyper-V";
+    default:
+        return NULL;
+    }
+}
+
+/**
+  * \brief Formats an address family as a string.
+  *
+  * \param[in] AddressFamily The address family value.
+  *
+  * \return A string with the address family name.
+  */
+PPH_STRING
+NTAPI
+PhAfdFormatAddressFamily(
+    _In_ LONG AddressFamily
+    )
+{
+    PCWSTR knownName = PhpAfdGetAddressFamilyString(AddressFamily);
+
+    if (knownName)
+        return PhCreateString(knownName);
+    else
+        return PhFormatString(L"Unrecognized address family %d", AddressFamily);
+}
+
+/**
+  * \brief Looks up a name for a known protocol.
+  *
+  * \param[in] AddressFamily The address family of the protocol.
+  * \param[in] Protocol The protocol value.
+  *
+  * \return A string with the protocol name or NULL when it is not recognized.
+  */
+_Maybenull_
+PCWSTR
+NTAPI
+PhpAfdGetProtocolString(
+    _In_ LONG AddressFamily,
+    _In_ LONG Protocol
+    )
+{
+    switch (AddressFamily)
+    {
+    case AF_INET:
+    case AF_INET6:
+        switch (Protocol)
+        {
+        case IPPROTO_ICMP:
+            return L"ICMP";
+        case IPPROTO_IGMP:
+            return L"IGMP";
+        case IPPROTO_TCP:
+            return L"TCP";
+        case IPPROTO_UDP:
+            return L"UDP";
+        case IPPROTO_RDP:
+            return L"RDP";
+        case IPPROTO_ICMPV6:
+            return L"ICMPv6";
+        case IPPROTO_PGM:
+            return L"PGM";
+        case IPPROTO_L2TP:
+            return L"L2TP";
+        case IPPROTO_SCTP:
+            return L"SCTP";
+        case IPPROTO_RAW:
+            return L"RAW";
+        case IPPROTO_RESERVED_IPSEC:
+            return L"IPSec";
+        }
+    case AF_BTH:
+        switch (Protocol)
+        {
+        case BTHPROTO_RFCOMM:
+            return L"RFCOMM";
+        case BTHPROTO_L2CAP:
+            return L"L2CAP";
+        }
+    case AF_HYPERV:
+        switch (Protocol)
+        {
+        case HV_PROTOCOL_RAW:
+            return L"RAW";
+        }
+    }
+
+    return NULL;
+}
+
+/**
+  * \brief Formats a protocol name as a string.
+  *
+  * \param[in] AddressFamily The address family of the protocol.
+  * \param[in] Protocol The protocol value.
+  *
+  * \return A string with a human-readable protocol name.
+  */
+PPH_STRING
+NTAPI
+PhAfdFormatProtocol(
+    _In_ LONG AddressFamily,
+    _In_ LONG Protocol
+    )
+{
+    PCWSTR knownName = PhpAfdGetProtocolString(AddressFamily, Protocol);
+
+    if (knownName)
+        return PhCreateString(knownName);
+    else
+        return PhFormatString(L"Unrecognized protocol %d", Protocol);
+}
+
+/**
+  * \brief Looks up a short human-readable identifier for a known protocol.
+  *
+  * \param[in] AddressFamily The address family of the protocol.
+  * \param[in] Protocol The protocol value.
+  *
+  * \return A string with the protocol name or NULL when it is not recognized.
+  */
+_Maybenull_
+PCWSTR
+NTAPI
+PhpAfdGetProtocolSummary(
+    _In_ LONG AddressFamily,
+    _In_ LONG Protocol
+    )
+{
+    switch (AddressFamily)
+    {
+    case AF_INET:
+        switch (Protocol)
+        {
+        case IPPROTO_ICMP:
+            return L"ICMP";
+        case IPPROTO_TCP:
+            return L"TCP";
+        case IPPROTO_UDP:
+            return L"UDP";
+        case IPPROTO_RAW:
+            return L"RAW/IPv4";
+        }
+    case AF_INET6:
+        switch (Protocol)
+        {
+        case IPPROTO_ICMPV6:
+            return L"ICMP6";
+        case IPPROTO_TCP:
+            return L"TCP6";
+        case IPPROTO_UDP:
+            return L"UDP6";
+        case IPPROTO_RAW:
+            return L"RAW/IPv6";
+        }
+    case AF_BTH:
+        switch (Protocol)
+        {
+        case BTHPROTO_RFCOMM:
+            return L"RFCOMM [Bluetooth]";
+        case BTHPROTO_L2CAP:
+            return L"L2CAP [Bluetooth]";
+        }
+    case AF_HYPERV:
+        switch (Protocol)
+        {
+        case HV_PROTOCOL_RAW:
+            return L"Hyper-V RAW";
+        }
+    }
+
+    return NULL;
+}
+
+/**
+  * \brief Formats a human-readable name for an AFD socket.
+  *
+  * \param[in] SocketHandle An AFD socket handle.
+  *
+  * \return The best handle name representation available on success, or NULL on error.
+  */
+_Maybenull_
+PPH_STRING
+NTAPI
+PhAfdFormatSocketBestName(
+    _In_ HANDLE SocketHandle
+    )
+{
+    PH_STRING_BUILDER stringBuilder;
+    SOCK_SHARED_INFO sharedInfo;
+    PPH_STRING addressString;
+    BOOLEAN sharedInfoAvailable;
+    BOOLEAN addressAvailable;
+
+    // Query socket information
+    sharedInfoAvailable = NT_SUCCESS(PhAfdQuerySharedInfo(SocketHandle, &sharedInfo));
+    addressAvailable = NT_SUCCESS(PhAfdQueryFormatAddress(SocketHandle, FALSE, &addressString, TRUE));
+
+    if (!sharedInfoAvailable && !addressAvailable)
+        return NULL;
+
+    PhInitializeStringBuilder(&stringBuilder, 0x100);
+    PhAppendStringBuilder2(&stringBuilder, L"AFD socket: ");
+
+    if (sharedInfoAvailable)
+    {
+        PCWSTR detail;
+
+        // State
+        if (detail = PhpAfdGetSocketStateString(sharedInfo.State))
+        {
+            PhAppendStringBuilder2(&stringBuilder, detail);
+            PhAppendStringBuilder2(&stringBuilder, L" ");
+        }
+
+        // Protocol
+        if (detail = PhpAfdGetProtocolSummary(sharedInfo.AddressFamily, sharedInfo.Protocol))
+        {
+            PhAppendStringBuilder2(&stringBuilder, detail);
+            PhAppendStringBuilder2(&stringBuilder, L" ");
+        }
+    }
+
+    if (addressAvailable)
+    {
+        PPH_STRING remoteAddressString;
+
+        // Local address
+        PhAppendStringBuilder2(&stringBuilder, L"on ");
+        PhAppendStringBuilder(&stringBuilder, &addressString->sr);
+
+        // Remote address
+        if (NT_SUCCESS(PhAfdQueryFormatAddress(SocketHandle, TRUE, &remoteAddressString, TRUE)))
+        {
+            PhAppendStringBuilder2(&stringBuilder, L" --> ");
+            PhAppendStringBuilder(&stringBuilder, &remoteAddressString->sr);
+            PhDereferenceObject(remoteAddressString);
+        }
+
+        PhDereferenceObject(addressString);
+    }
+
+    return PhFinalStringBuilderString(&stringBuilder);
+}

--- a/phlib/phlib.vcxproj
+++ b/phlib/phlib.vcxproj
@@ -226,6 +226,7 @@
     <ClCompile Include="mapimg.c" />
     <ClCompile Include="maplib.c" />
     <ClCompile Include="native.c" />
+    <ClCompile Include="nativesocket.c" />
     <ClCompile Include="nativeflt.c" />
     <ClCompile Include="nativepipe.c" />
     <ClCompile Include="nativemodule.c" />
@@ -257,6 +258,7 @@
     <ClInclude Include="include\appresolver.h" />
     <ClInclude Include="include\appresolverp.h" />
     <ClInclude Include="include\bcd.h" />
+    <ClInclude Include="include\phafd.h" />
     <ClInclude Include="include\phconsole.h" />
     <ClInclude Include="include\phfirmware.h" />
     <ClInclude Include="include\searchbox.h" />

--- a/phlib/phlib.vcxproj.filters
+++ b/phlib/phlib.vcxproj.filters
@@ -209,6 +209,9 @@
     <ClCompile Include="nativetoken.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="nativesocket.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="include\circbuf.h">
@@ -425,6 +428,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="include\phfirmware.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="include\phafd.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/phnt/include/ntafd.h
+++ b/phnt/include/ntafd.h
@@ -1,0 +1,1124 @@
+/*
+ * Ancillary Function Driver definitions
+ *
+ * This file is part of System Informer.
+ */
+
+#ifndef _NTAFD_H
+#define _NTAFD_H
+
+#include <WinSock2.h>
+#include <MSWSock.h>
+#include <tdi.h>
+
+// private
+#define AFD_DEVICE_NAME L"\\Device\\Afd"
+
+// private // Extended Attributes
+#define AfdOpenPacket      "AfdOpenPacketXX"    // AFD_OPEN_PACKET
+#define AfdSwOpenPacket    "AfdSwOpenPacket"    // AFD_SWITCH_OPEN_PACKET // rev
+#define AfdRioRDOpenPacket "AfdRioRDOpenPacket" // void // rev
+
+// private
+typedef struct _AFD_ENDPOINT_FLAGS
+{
+    union
+    {
+        struct
+        {
+            UCHAR ConnectionLess : 1;
+            UCHAR : 3;
+            UCHAR MessageMode : 1;
+            UCHAR Raw : 1;
+            UCHAR : 3;
+            UCHAR Multipoint : 1;
+            UCHAR C_Root : 1;
+            UCHAR : 3;
+            UCHAR D_Root : 1;
+            UCHAR IgnoreTDI : 1;
+            UCHAR : 3;
+            UCHAR RioSocket : 1;
+        };
+        ULONG EndpointFlags;
+    };
+} AFD_ENDPOINT_FLAGS, *PAFD_ENDPOINT_FLAGS;
+
+// private // Transport device names
+#define DD_TCP_DEVICE_NAME      L"\\Device\\Tcp"
+#define DD_TCPV6_DEVICE_NAME    L"\\Device\\Tcp6"
+#define DD_UDP_DEVICE_NAME      L"\\Device\\Udp"
+#define DD_UDPV6_DEVICE_NAME    L"\\Device\\Udp6"
+#define DD_RAW_IP_DEVICE_NAME   L"\\Device\\RawIp"
+#define DD_RAW_IPV6_DEVICE_NAME L"\\Device\\RawIp6"
+
+// private
+typedef struct _AFD_OPEN_PACKET
+{
+    _In_ AFD_ENDPOINT_FLAGS __f;
+    _In_opt_ GROUP GroupID;
+    _In_ LONG AddressFamily; // AF_*
+    _In_ LONG SocketType; // SOCK_*
+    _In_ LONG Protocol; // IPPROTO_*, BTHPROTO_*, HV_PROTOCOL_*, etc.
+    _In_opt_ ULONG TransportDeviceNameLength; // Note: specifying a device changes the transport mode
+    _Field_size_bytes_opt_(TransportDeviceNameLength) WCHAR TransportDeviceName[ANYSIZE_ARRAY];
+} AFD_OPEN_PACKET, *PAFD_OPEN_PACKET;
+
+// rev (FILE_FULL_EA_INFORMATION + AfdOpenPacket + AFD_OPEN_PACKET)
+typedef struct _AFD_OPEN_PACKET_FULL_EA
+{
+    ULONG NextEntryOffset;
+    UCHAR Flags;
+    UCHAR EaNameLength; // sizeof(AfdOpenPacket) - sizeof(ANSI_NULL);
+    USHORT EaValueLength; // sizeof(AFD_OPEN_PACKET)
+    CHAR EaName[sizeof(AfdOpenPacket)];
+    AFD_OPEN_PACKET OpenPacket;
+} AFD_OPEN_PACKET_FULL_EA, *PAFD_OPEN_PACKET_FULL_EA;
+
+// private
+typedef struct _AFD_SWITCH_OPEN_PACKET
+{
+    HANDLE CompletionPort;
+    HANDLE CompletionEvent;
+} AFD_SWITCH_OPEN_PACKET, *PAFD_SWITCH_OPEN_PACKET;
+
+//
+// Since Vista, sockets can use different modes of transport: TLI, TDI, and hybrid. The mode is selected
+// based on whether the caller specifies the transport device at socket creation and whether this device
+// is suitable for hybrid operation. No device means TLI, which is the most common choice.
+//
+// The transport mode affects which structures AFD uses for IOCTLs on the socket:
+//  - TLI sockets use *_TL structures (where applicable) and SOCKADDR for addresses.
+//  - TDI and hybrid sockets use non-TL structures and TDI_ADDRESS_INFO for addresses.
+//
+
+// private // IOCTL function numbers
+#define AFD_BIND                        0 // in: AFD_BIND_INFO_TL; out: SOCKADDR /or/ in: AFD_BIND_INFO; out: TDI_ADDRESS_INFO (depending on transport mode)
+#define AFD_CONNECT                     1 // in: AFD_CONNECT_JOIN_INFO_TL or AFD_CONNECT_JOIN_INFO (depending on transport mode); out (opt): IO_STATUS_BLOCK
+#define AFD_START_LISTEN                2 // in: AFD_LISTEN_INFO
+#define AFD_WAIT_FOR_LISTEN             3 // out: AFD_LISTEN_RESPONSE_INFO_TL or AFD_LISTEN_RESPONSE_INFO (depending on transport mode)
+#define AFD_ACCEPT                      4 // in: AFD_ACCEPT_INFO
+#define AFD_RECEIVE                     5 // in: AFD_RECV_INFO
+#define AFD_RECEIVE_DATAGRAM            6 // in: AFD_DATAGRAM_INFO
+#define AFD_SEND                        7 // in: AFD_SEND_INFO
+#define AFD_SEND_DATAGRAM               8 // in: AFD_SEND_DATAGRAM_INFO
+#define AFD_POLL                        9 // in, out: AFD_POLL_INFO
+#define AFD_PARTIAL_DISCONNECT          10 // in: AFD_PARTIAL_DISCONNECT_INFO
+#define AFD_GET_ADDRESS                 11 // out: AFD_ADDRESS (SOCKADDR or TDI_ADDRESS_INFO, depending on transport mode)
+#define AFD_QUERY_RECEIVE_INFO          12 // out: AFD_RECEIVE_INFORMATION
+#define AFD_QUERY_HANDLES               13 // in: ULONG (AFD_QUERY_*); out: AFD_HANDLE_INFO
+#define AFD_SET_INFORMATION             14 // in: AFD_INFORMATION
+#define AFD_GET_REMOTE_ADDRESS          15 // out: AFD_ADDRESS (SOCKADDR or TDI_ADDRESS_INFO, depending on transport mode)
+#define AFD_GET_CONTEXT                 16 // out: SOCK_SHARED_INFO (on Win32 level) or custom data
+#define AFD_SET_CONTEXT                 17 // in: SOCK_SHARED_INFO (on Win32 level) or custom data; out: AFD_ADDRESS (SOCKADDR or TDI_ADDRESS_INFO, depending on transport mode; output buffer must be inside the input buffer)
+#define AFD_SET_CONNECT_DATA            18 // in: AFD_UNACCEPTED_CONNECT_DATA_INFO; out: payload
+#define AFD_SET_CONNECT_OPTIONS         19 // in: AFD_UNACCEPTED_CONNECT_DATA_INFO; out: payload
+#define AFD_SET_DISCONNECT_DATA         20 // in: AFD_UNACCEPTED_CONNECT_DATA_INFO; out: payload
+#define AFD_SET_DISCONNECT_OPTIONS      21 // in: AFD_UNACCEPTED_CONNECT_DATA_INFO; out: payload
+#define AFD_GET_CONNECT_DATA            22 // in: AFD_UNACCEPTED_CONNECT_DATA_INFO; out: payload
+#define AFD_GET_CONNECT_OPTIONS         23 // in: AFD_UNACCEPTED_CONNECT_DATA_INFO; out: payload
+#define AFD_GET_DISCONNECT_DATA         24 // in: AFD_UNACCEPTED_CONNECT_DATA_INFO; out: payload
+#define AFD_GET_DISCONNECT_OPTIONS      25 // in: AFD_UNACCEPTED_CONNECT_DATA_INFO; out: payload
+#define AFD_SIZE_CONNECT_DATA           26 // in: AFD_UNACCEPTED_CONNECT_DATA_INFO; out: payload
+#define AFD_SIZE_CONNECT_OPTIONS        27 // in: AFD_UNACCEPTED_CONNECT_DATA_INFO; out: payload
+#define AFD_SIZE_DISCONNECT_DATA        28 // in: AFD_UNACCEPTED_CONNECT_DATA_INFO; out: payload
+#define AFD_SIZE_DISCONNECT_OPTIONS     29 // in: AFD_UNACCEPTED_CONNECT_DATA_INFO; out: payload
+#define AFD_GET_INFORMATION             30 // in, out: AFD_INFORMATION
+#define AFD_TRANSMIT_FILE               31 // in: AFD_TRANSMIT_FILE_INFO; out (opt): BOOLEAN
+#define AFD_SUPER_ACCEPT                32 // in: AFD_SUPER_ACCEPT_INFO; out: received data + local address + remote address (at offsets according to the input)
+#define AFD_EVENT_SELECT                33 // in: AFD_EVENT_SELECT_INFO
+#define AFD_ENUM_NETWORK_EVENTS         34 // in (opt): HANDLE; out: AFD_ENUM_NETWORK_EVENTS_INFO
+#define AFD_DEFER_ACCEPT                35 // in: AFD_DEFER_ACCEPT_INFO
+#define AFD_WAIT_FOR_LISTEN_LIFO        36 // out: AFD_LISTEN_RESPONSE_INFO_TL or AFD_LISTEN_RESPONSE_INFO (depending on transport mode)
+#define AFD_SET_QOS                     37 // in: AFD_QOS_INFO
+#define AFD_GET_QOS                     38 // out: AFD_QOS_INFO
+#define AFD_NO_OPERATION                39 // in (opt): IO_STATUS_BLOCK
+#define AFD_VALIDATE_GROUP              40 // in: AFD_VALIDATE_GROUP_INFO
+#define AFD_GET_UNACCEPTED_CONNECT_DATA 41 // in: AFD_UNACCEPTED_CONNECT_DATA_INFO; out: AFD_UNACCEPTED_CONNECT_DATA_INFO (when LengthOnly is set) or received data
+#define AFD_ROUTING_INTERFACE_QUERY     42 // in: TRANSPORT_ADDRESS; out: SOCKADDR
+#define AFD_ROUTING_INTERFACE_CHANGE    43 // in: AFD_TRANSPORT_IOCTL_INFO
+#define AFD_ADDRESS_LIST_QUERY          44 // in: USHORT (TDI_ADDRESS_TYPE_*/AF_*); out: TRANSPORT_ADDRESS
+#define AFD_ADDRESS_LIST_CHANGE         45 // in: AFD_TRANSPORT_IOCTL_INFO
+#define AFD_JOIN_LEAF                   46 // in: AFD_CONNECT_JOIN_INFO_TL or AFD_CONNECT_JOIN_INFO (depending on transport mode); out (opt): IO_STATUS_BLOCK
+#define AFD_TRANSPORT_IOCTL             47 // in: AFD_TL_IO_CONTROL_INFO; out: variable
+#define AFD_TRANSMIT_PACKETS            48 // in: AFD_TPACKETS_INFO; out (opt): BOOLEAN
+#define AFD_SUPER_CONNECT               49 // in: AFD_SUPER_CONNECT_INFO_TL or AFD_SUPER_CONNECT_INFO (depending on transport mode); out: payload
+#define AFD_SUPER_DISCONNECT            50 // in: AFD_SUPER_DISCONNECT_INFO
+#define AFD_RECEIVE_MESSAGE             51 // in: AFD_MESSAGE_INFO
+#define AFD_SEND_MESSAGE                52 // in: AFD_MESSAGE_INFO // rev // since VISTA // breaks layout; values below are different on XP
+#define AFD_SWITCH_CEMENT_SAN           53 // in: AFD_SWITCH_CONTEXT_INFO
+#define AFD_SWITCH_SET_EVENTS           54 // in: AFD_SWITCH_EVENT_INFO
+#define AFD_SWITCH_RESET_EVENTS         55 // in: AFD_SWITCH_EVENT_INFO
+#define AFD_SWITCH_CONNECT_IND          56 // in: AFD_SWITCH_CONNECT_INFO; out: AFD_SWITCH_ACCEPT_INFO
+#define AFD_SWITCH_CMPL_ACCEPT          57 // in: AFD_SWITCH_CONTEXT_INFO; out: payload
+#define AFD_SWITCH_CMPL_REQUEST         58 // in: AFD_SWITCH_REQUEST_INFO; out: payload
+#define AFD_SWITCH_CMPL_IO              59 // in: IO_STATUS_BLOCK
+#define AFD_SWITCH_REFRESH_ENDP         60 // in: AFD_SWITCH_CONTEXT_INFO
+#define AFD_SWITCH_GET_PHYSICAL_ADDR    61 // deprecated
+#define AFD_SWITCH_ACQUIRE_CTX          62 // in: AFD_SWITCH_ACQUIRE_CTX_INFO; out: payload
+#define AFD_SWITCH_TRANSFER_CTX         63 // in: AFD_SWITCH_TRANSFER_CTX_INFO
+#define AFD_SWITCH_GET_SERVICE_PID      64 // in/out: void; returns PID in IO_STATUS_BLOCK.Information
+#define AFD_SWITCH_SET_SERVICE_PROCESS  65 // in/out: void
+#define AFD_SWITCH_PROVIDER_CHANGE      66 // in/out: void
+#define AFD_SWITCH_ADDRLIST_CHANGE      67 // in: AFD_TRANSPORT_IOCTL_INFO
+#define AFD_UNBIND                      68 // in: AFD_UNBIND_INFO // rev // since VISTA
+#define AFD_SQM                         69 // in: AFD_SQM_INFO // rev // since WIN7
+#define AFD_RIO                         70 // in/out: AFD_RIO_COMMAND_HEADER // rev // since WIN8
+#define AFD_TRANSFER_BEGIN              71 // in/out: void // rev // since TH1
+#define AFD_TRANSFER_END                72 // in/out: void // rev // since TH1
+#define AFD_NOTIFY                      73 // rev // since 22H2
+
+// private // Note: different bit layout from CTL_CODE
+#define FSCTL_AFD_BASE  FILE_DEVICE_NETWORK
+#define _AFD_CONTROL_CODE(request, method) (FSCTL_AFD_BASE << 12 | request << 2 | method)
+
+// private // IOCTLs
+#define IOCTL_AFD_BIND                        _AFD_CONTROL_CODE(AFD_BIND, METHOD_NEITHER) // 0x12003
+#define IOCTL_AFD_CONNECT                     _AFD_CONTROL_CODE(AFD_CONNECT, METHOD_NEITHER) // 0x12007
+#define IOCTL_AFD_START_LISTEN                _AFD_CONTROL_CODE(AFD_START_LISTEN, METHOD_NEITHER) // 0x1200B
+#define IOCTL_AFD_WAIT_FOR_LISTEN             _AFD_CONTROL_CODE(AFD_WAIT_FOR_LISTEN, METHOD_BUFFERED) // 0x1200C
+#define IOCTL_AFD_ACCEPT                      _AFD_CONTROL_CODE(AFD_ACCEPT, METHOD_BUFFERED) // 0x12010
+#define IOCTL_AFD_RECEIVE                     _AFD_CONTROL_CODE(AFD_RECEIVE, METHOD_NEITHER) // 0x12017
+#define IOCTL_AFD_RECEIVE_DATAGRAM            _AFD_CONTROL_CODE(AFD_RECEIVE_DATAGRAM, METHOD_NEITHER) // 0x1201B
+#define IOCTL_AFD_SEND                        _AFD_CONTROL_CODE(AFD_SEND, METHOD_NEITHER) // 0x1201F
+#define IOCTL_AFD_SEND_DATAGRAM               _AFD_CONTROL_CODE(AFD_SEND_DATAGRAM, METHOD_NEITHER) // 0x12023
+#define IOCTL_AFD_POLL                        _AFD_CONTROL_CODE(AFD_POLL, METHOD_BUFFERED) // 0x12024
+#define IOCTL_AFD_PARTIAL_DISCONNECT          _AFD_CONTROL_CODE(AFD_PARTIAL_DISCONNECT, METHOD_NEITHER) // 0x1202B
+#define IOCTL_AFD_GET_ADDRESS                 _AFD_CONTROL_CODE(AFD_GET_ADDRESS, METHOD_NEITHER) // 0x1202F
+#define IOCTL_AFD_QUERY_RECEIVE_INFO          _AFD_CONTROL_CODE(AFD_QUERY_RECEIVE_INFO, METHOD_NEITHER) // 0x12033
+#define IOCTL_AFD_QUERY_HANDLES               _AFD_CONTROL_CODE(AFD_QUERY_HANDLES, METHOD_NEITHER) // 0x12037
+#define IOCTL_AFD_SET_INFORMATION             _AFD_CONTROL_CODE(AFD_SET_INFORMATION, METHOD_NEITHER) // 0x1203B
+#define IOCTL_AFD_GET_REMOTE_ADDRESS          _AFD_CONTROL_CODE(AFD_GET_REMOTE_ADDRESS, METHOD_NEITHER) // 0x1203F
+#define IOCTL_AFD_GET_CONTEXT                 _AFD_CONTROL_CODE(AFD_GET_CONTEXT, METHOD_NEITHER) // 0x12043
+#define IOCTL_AFD_SET_CONTEXT                 _AFD_CONTROL_CODE(AFD_SET_CONTEXT, METHOD_NEITHER) // 0x12047
+#define IOCTL_AFD_SET_CONNECT_DATA            _AFD_CONTROL_CODE(AFD_SET_CONNECT_DATA, METHOD_NEITHER) // 0x1204B
+#define IOCTL_AFD_SET_CONNECT_OPTIONS         _AFD_CONTROL_CODE(AFD_SET_CONNECT_OPTIONS, METHOD_NEITHER) // 0x1204F
+#define IOCTL_AFD_SET_DISCONNECT_DATA         _AFD_CONTROL_CODE(AFD_SET_DISCONNECT_DATA, METHOD_NEITHER) // 0x12053
+#define IOCTL_AFD_SET_DISCONNECT_OPTIONS      _AFD_CONTROL_CODE(AFD_SET_DISCONNECT_OPTIONS, METHOD_NEITHER) // 0x12057
+#define IOCTL_AFD_GET_CONNECT_DATA            _AFD_CONTROL_CODE(AFD_GET_CONNECT_DATA, METHOD_NEITHER) // 0x1205B
+#define IOCTL_AFD_GET_CONNECT_OPTIONS         _AFD_CONTROL_CODE(AFD_GET_CONNECT_OPTIONS, METHOD_NEITHER) // 0x1205F
+#define IOCTL_AFD_GET_DISCONNECT_DATA         _AFD_CONTROL_CODE(AFD_GET_DISCONNECT_DATA, METHOD_NEITHER) // 0x12063
+#define IOCTL_AFD_GET_DISCONNECT_OPTIONS      _AFD_CONTROL_CODE(AFD_GET_DISCONNECT_OPTIONS, METHOD_NEITHER) // 0x12067
+#define IOCTL_AFD_SIZE_CONNECT_DATA           _AFD_CONTROL_CODE(AFD_SIZE_CONNECT_DATA, METHOD_NEITHER) // 0x1206B
+#define IOCTL_AFD_SIZE_CONNECT_OPTIONS        _AFD_CONTROL_CODE(AFD_SIZE_CONNECT_OPTIONS, METHOD_NEITHER) // 0x1206F
+#define IOCTL_AFD_SIZE_DISCONNECT_DATA        _AFD_CONTROL_CODE(AFD_SIZE_DISCONNECT_DATA, METHOD_NEITHER) // 0x12073
+#define IOCTL_AFD_SIZE_DISCONNECT_OPTIONS     _AFD_CONTROL_CODE(AFD_SIZE_DISCONNECT_OPTIONS, METHOD_NEITHER) // 0x12077
+#define IOCTL_AFD_GET_INFORMATION             _AFD_CONTROL_CODE(AFD_GET_INFORMATION, METHOD_NEITHER) // 0x1207B
+#define IOCTL_AFD_TRANSMIT_FILE               _AFD_CONTROL_CODE(AFD_TRANSMIT_FILE, METHOD_NEITHER) // 0x1207F
+#define IOCTL_AFD_SUPER_ACCEPT                _AFD_CONTROL_CODE(AFD_SUPER_ACCEPT, METHOD_NEITHER) // 0x12083
+#define IOCTL_AFD_EVENT_SELECT                _AFD_CONTROL_CODE(AFD_EVENT_SELECT, METHOD_NEITHER) // 0x12087
+#define IOCTL_AFD_ENUM_NETWORK_EVENTS         _AFD_CONTROL_CODE(AFD_ENUM_NETWORK_EVENTS, METHOD_NEITHER) // 0x1208B
+#define IOCTL_AFD_DEFER_ACCEPT                _AFD_CONTROL_CODE(AFD_DEFER_ACCEPT, METHOD_BUFFERED) // 0x1208C
+#define IOCTL_AFD_WAIT_FOR_LISTEN_LIFO        _AFD_CONTROL_CODE(AFD_WAIT_FOR_LISTEN_LIFO, METHOD_BUFFERED) // 0x12090
+#define IOCTL_AFD_SET_QOS                     _AFD_CONTROL_CODE(AFD_SET_QOS, METHOD_BUFFERED) // 0x12094
+#define IOCTL_AFD_GET_QOS                     _AFD_CONTROL_CODE(AFD_GET_QOS, METHOD_BUFFERED) // 0x12098
+#define IOCTL_AFD_NO_OPERATION                _AFD_CONTROL_CODE(AFD_NO_OPERATION, METHOD_NEITHER) // 0x1209F
+#define IOCTL_AFD_VALIDATE_GROUP              _AFD_CONTROL_CODE(AFD_VALIDATE_GROUP, METHOD_BUFFERED) // 0x120A0
+#define IOCTL_AFD_GET_UNACCEPTED_CONNECT_DATA _AFD_CONTROL_CODE(AFD_GET_UNACCEPTED_CONNECT_DATA, METHOD_NEITHER) // 0x120A7
+#define IOCTL_AFD_ROUTING_INTERFACE_QUERY     _AFD_CONTROL_CODE(AFD_ROUTING_INTERFACE_QUERY, METHOD_NEITHER) // 0x120AB
+#define IOCTL_AFD_ROUTING_INTERFACE_CHANGE    _AFD_CONTROL_CODE(AFD_ROUTING_INTERFACE_CHANGE, METHOD_BUFFERED) // 0x120AC
+#define IOCTL_AFD_ADDRESS_LIST_QUERY          _AFD_CONTROL_CODE(AFD_ADDRESS_LIST_QUERY, METHOD_NEITHER) // 0x120B3
+#define IOCTL_AFD_ADDRESS_LIST_CHANGE         _AFD_CONTROL_CODE(AFD_ADDRESS_LIST_CHANGE, METHOD_BUFFERED) // 0x120B4
+#define IOCTL_AFD_JOIN_LEAF                   _AFD_CONTROL_CODE(AFD_JOIN_LEAF, METHOD_NEITHER) // 0x120BB
+#define IOCTL_AFD_TRANSPORT_IOCTL             _AFD_CONTROL_CODE(AFD_TRANSPORT_IOCTL, METHOD_NEITHER) // 0x120BF
+#define IOCTL_AFD_TRANSMIT_PACKETS            _AFD_CONTROL_CODE(AFD_TRANSMIT_PACKETS, METHOD_NEITHER) // 0x120C3
+#define IOCTL_AFD_SUPER_CONNECT               _AFD_CONTROL_CODE(AFD_SUPER_CONNECT, METHOD_NEITHER) // 0x120C7
+#define IOCTL_AFD_SUPER_DISCONNECT            _AFD_CONTROL_CODE(AFD_SUPER_DISCONNECT, METHOD_NEITHER) // 0x120CB
+#define IOCTL_AFD_RECEIVE_MESSAGE             _AFD_CONTROL_CODE(AFD_RECEIVE_MESSAGE, METHOD_NEITHER) // 0x120CF
+#define IOCTL_AFD_SEND_MESSAGE                _AFD_CONTROL_CODE(AFD_SEND_MESSAGE, METHOD_NEITHER) // 0x120D3 // rev // since VISTA
+#define IOCTL_AFD_SWITCH_CEMENT_SAN           _AFD_CONTROL_CODE(AFD_SWITCH_CEMENT_SAN, METHOD_NEITHER) // 0x120D7
+#define IOCTL_AFD_SWITCH_SET_EVENTS           _AFD_CONTROL_CODE(AFD_SWITCH_SET_EVENTS, METHOD_NEITHER) // 0x120DB
+#define IOCTL_AFD_SWITCH_RESET_EVENTS         _AFD_CONTROL_CODE(AFD_SWITCH_RESET_EVENTS, METHOD_NEITHER) // 0x120DF
+#define IOCTL_AFD_SWITCH_CONNECT_IND          _AFD_CONTROL_CODE(AFD_SWITCH_CONNECT_IND, METHOD_OUT_DIRECT) // 0x120E2
+#define IOCTL_AFD_SWITCH_CMPL_ACCEPT          _AFD_CONTROL_CODE(AFD_SWITCH_CMPL_ACCEPT, METHOD_NEITHER) // 0x120E7
+#define IOCTL_AFD_SWITCH_CMPL_REQUEST         _AFD_CONTROL_CODE(AFD_SWITCH_CMPL_REQUEST, METHOD_NEITHER) // 0x120EB
+#define IOCTL_AFD_SWITCH_CMPL_IO              _AFD_CONTROL_CODE(AFD_SWITCH_CMPL_IO, METHOD_NEITHER) // 0x120EF
+#define IOCTL_AFD_SWITCH_REFRESH_ENDP         _AFD_CONTROL_CODE(AFD_SWITCH_REFRESH_ENDP, METHOD_NEITHER) // 0x120F3
+#define IOCTL_AFD_SWITCH_GET_PHYSICAL_ADDR    _AFD_CONTROL_CODE(AFD_SWITCH_GET_PHYSICAL_ADDR, METHOD_NEITHER) // 0x120F7
+#define IOCTL_AFD_SWITCH_ACQUIRE_CTX          _AFD_CONTROL_CODE(AFD_SWITCH_ACQUIRE_CTX, METHOD_NEITHER) // 0x120FB
+#define IOCTL_AFD_SWITCH_TRANSFER_CTX         _AFD_CONTROL_CODE(AFD_SWITCH_TRANSFER_CTX, METHOD_NEITHER) // 0x120FF
+#define IOCTL_AFD_SWITCH_GET_SERVICE_PID      _AFD_CONTROL_CODE(AFD_SWITCH_GET_SERVICE_PID, METHOD_NEITHER) // 0x12103
+#define IOCTL_AFD_SWITCH_SET_SERVICE_PROCESS  _AFD_CONTROL_CODE(AFD_SWITCH_SET_SERVICE_PROCESS, METHOD_NEITHER) // 0x12107
+#define IOCTL_AFD_SWITCH_PROVIDER_CHANGE      _AFD_CONTROL_CODE(AFD_SWITCH_PROVIDER_CHANGE, METHOD_NEITHER) // 0x1210B
+#define IOCTL_AFD_SWITCH_ADDRLIST_CHANGE      _AFD_CONTROL_CODE(AFD_SWITCH_ADDRLIST_CHANGE, METHOD_BUFFERED) // 0x1210C
+#define IOCTL_AFD_UNBIND                      _AFD_CONTROL_CODE(AFD_UNBIND, METHOD_NEITHER) // 0x12113 // rev
+#define IOCTL_AFD_SQM                         _AFD_CONTROL_CODE(AFD_SQM, METHOD_NEITHER) // 0x12117 // rev // since WIN7
+#define IOCTL_AFD_RIO                         _AFD_CONTROL_CODE(AFD_RIO, METHOD_NEITHER) // 0x1211B // rev // since WIN8
+#define IOCTL_AFD_TRANSFER_BEGIN              _AFD_CONTROL_CODE(AFD_TRANSFER_BEGIN, METHOD_NEITHER) // 0x1211F // rev // since TH1
+#define IOCTL_AFD_TRANSFER_END                _AFD_CONTROL_CODE(AFD_TRANSFER_END, METHOD_NEITHER) // 0x12123 // rev
+#define IOCTL_AFD_NOTIFY                      _AFD_CONTROL_CODE(AFD_NOTIFY, METHOD_NEITHER) // 0x12127 // rev // since 22H2
+
+#include <pshpack1.h>
+
+// rev - a union for TLI/TDI socket addresses
+typedef union _AFD_ADDRESS
+{
+    SOCKADDR_STORAGE TliAddress;
+    TDI_ADDRESS_INFO TdiAddress;
+
+    struct
+    {
+        //
+        // TDI_ADDRESS_INFO includes an embedded socket address that starts at AddressType (which corresponds to sa_family).
+        //
+        // ---------------- | ------------------------- |
+        //                  | ULONG ActivityCount       |
+        //                  | ------------------------- | --------------------- |
+        //                  |                           | ULONG TAAddressCount  |
+        //                  |                           | --------------------- | ---------------------------- |
+        //                  |                           |                       | USHORT AddressLength         |
+        // TDI_ADDRESS_INFO | TRANSPORT_ADDRESS Address |                       | ---------------------------- | ---------- | ---------------- |
+        //                  |                           | TA_ADDRESS Address[1] | USHORT AddressType           |            | USHORT sa_family |
+        //                  |                           |                       | ---------------------------- |  SOCKADDR  | ---------------- |
+        //                  |                           |                       | UCHAR Address[AddressLength] | (embedded) |       ...        |
+        //                  |                           |                       |             ...              |            |                  |
+        // ---------------- | ------------------------- | --------------------- | ---------------------------- | ---------- | ---------------- |
+        //
+
+        UCHAR Padding[10]; // RTL_SIZEOF_THROUGH_FIELD(TDI_ADDRESS_INFO, Address.Address[0].AddressLength)
+        SOCKADDR_STORAGE EmbeddedAddress;
+    } TdiAddressUnpacked;
+} AFD_ADDRESS, *PAFD_ADDRESS;
+
+#include <poppack.h>
+
+// private // Bind share access
+#define AFD_NORMALADDRUSE    0
+#define AFD_REUSEADDRESS     1
+#define AFD_WILDCARDADDRESS  2
+#define AFD_EXCLUSIVEADDRUSE 3
+
+// private
+typedef struct _AFD_BIND_INFO
+{
+    ULONG ShareAccess;
+    TRANSPORT_ADDRESS Address;
+} AFD_BIND_INFO, *PAFD_BIND_INFO;
+
+// private
+typedef struct _AFD_BIND_INFO_TL
+{
+    ULONG ShareAccess;
+    SOCKADDR Address;
+} AFD_BIND_INFO_TL, *PAFD_BIND_INFO_TL;
+
+// private
+typedef struct _AFD_CONNECT_JOIN_INFO
+{
+    BOOLEAN SanActive;
+    HANDLE RootEndpoint;
+    HANDLE ConnectEndpoint;
+    TRANSPORT_ADDRESS RemoteAddress;
+} AFD_CONNECT_JOIN_INFO, *PAFD_CONNECT_JOIN_INFO;
+
+// private
+typedef struct _AFD_CONNECT_JOIN_INFO_TL
+{
+    BOOLEAN SanActive;
+    HANDLE RootEndpoint;
+    HANDLE ConnectEndpoint;
+    SOCKADDR RemoteAddress;
+} AFD_CONNECT_JOIN_INFO_TL, *PAFD_CONNECT_JOIN_INFO_TL;
+
+// private
+typedef struct _AFD_LISTEN_INFO
+{
+    BOOLEAN SanActive;
+    ULONG MaximumConnectionQueue;
+    BOOLEAN UseDelayedAcceptance;
+} AFD_LISTEN_INFO, *PAFD_LISTEN_INFO;
+
+// private
+typedef struct _AFD_LISTEN_RESPONSE_INFO
+{
+    LONG Sequence;
+    TRANSPORT_ADDRESS RemoteAddress;
+} AFD_LISTEN_RESPONSE_INFO, *PAFD_LISTEN_RESPONSE_INFO;
+
+// private
+typedef struct _AFD_LISTEN_RESPONSE_INFO_TL
+{
+    LONG Sequence;
+    SOCKADDR RemoteAddress;
+} AFD_LISTEN_RESPONSE_INFO_TL, *PAFD_LISTEN_RESPONSE_INFO_TL;
+
+// private
+typedef struct _AFD_ACCEPT_INFO
+{
+    BOOLEAN SanActive;
+    LONG Sequence;
+    HANDLE AcceptHandle;
+} AFD_ACCEPT_INFO, *PAFD_ACCEPT_INFO;
+
+// private // AfdFlags
+#define AFD_NO_FAST_IO 0x0001
+#define AFD_OVERLAPPED 0x0002
+
+// private
+typedef struct _AFD_RECV_INFO
+{
+    _Field_size_(BufferCount) LPWSABUF BufferArray;
+    ULONG BufferCount;
+    ULONG AfdFlags;
+    ULONG TdiFlags; // TDI_RECEIVE_*
+} AFD_RECV_INFO, *PAFD_RECV_INFO;
+
+// private
+typedef struct _AFD_DATAGRAM_INFO
+{
+    _Field_size_(BufferCount) LPWSABUF BufferArray;
+    ULONG BufferCount;
+    ULONG AfdFlags;
+    ULONG TdiFlags; // TDI_RECEIVE_*
+    PVOID Address;
+    PULONG AddressLength;
+} AFD_DATAGRAM_INFO, *PAFD_DATAGRAM_INFO;
+
+// private
+typedef struct _AFD_SEND_INFO
+{
+    _Field_size_(BufferCount) LPWSABUF BufferArray;
+    ULONG BufferCount;
+    ULONG AfdFlags;
+    ULONG TdiFlags; // TDI_RECEIVE_*
+} AFD_SEND_INFO, *PAFD_SEND_INFO;
+
+// private
+typedef struct _AFD_SEND_DATAGRAM_INFO
+{
+    _Field_size_(BufferCount) LPWSABUF BufferArray;
+    ULONG BufferCount;
+    ULONG AfdFlags;
+    ULONG TdiFlags; // TDI_RECEIVE_*
+    TDI_REQUEST_SEND_DATAGRAM TdiRequest;
+    TDI_CONNECTION_INFORMATION TdiConnInfo;
+} AFD_SEND_DATAGRAM_INFO, *PAFD_SEND_DATAGRAM_INFO;
+
+// private // Poll event bit numbers
+#define AFD_POLL_RECEIVE_BIT             0
+#define AFD_POLL_RECEIVE_EXPEDITED_BIT   1
+#define AFD_POLL_SEND_BIT                2
+#define AFD_POLL_DISCONNECT_BIT          3
+#define AFD_POLL_ABORT_BIT               4
+#define AFD_POLL_LOCAL_CLOSE_BIT         5
+#define AFD_POLL_CONNECT_BIT             6
+#define AFD_POLL_ACCEPT_BIT              7
+#define AFD_POLL_CONNECT_FAIL_BIT        8
+#define AFD_POLL_QOS_BIT                 9
+#define AFD_POLL_GROUP_QOS_BIT           10
+#define AFD_POLL_ROUTING_IF_CHANGE_BIT   11
+#define AFD_POLL_ADDRESS_LIST_CHANGE_BIT 12
+#define AFD_NUM_POLL_EVENTS              13
+
+// private // Poll event flags
+#define AFD_POLL_RECEIVE             (1 << AFD_POLL_RECEIVE_BIT) // 0x0001
+#define AFD_POLL_RECEIVE_EXPEDITED   (1 << AFD_POLL_RECEIVE_EXPEDITED_BIT) // 0x0002
+#define AFD_POLL_SEND                (1 << AFD_POLL_SEND_BIT) // 0x0004
+#define AFD_POLL_DISCONNECT          (1 << AFD_POLL_DISCONNECT_BIT) // 0x0008
+#define AFD_POLL_ABORT               (1 << AFD_POLL_ABORT_BIT) // 0x0010
+#define AFD_POLL_LOCAL_CLOSE         (1 << AFD_POLL_LOCAL_CLOSE_BIT) // 0x0020
+#define AFD_POLL_CONNECT             (1 << AFD_POLL_CONNECT_BIT) // 0x0040
+#define AFD_POLL_ACCEPT              (1 << AFD_POLL_ACCEPT_BIT) // 0x0080
+#define AFD_POLL_CONNECT_FAIL        (1 << AFD_POLL_CONNECT_FAIL_BIT) // 0x0100
+#define AFD_POLL_QOS                 (1 << AFD_POLL_QOS_BIT) // 0x0200
+#define AFD_POLL_GROUP_QOS           (1 << AFD_POLL_GROUP_QOS_BIT) // 0x0400
+#define AFD_POLL_ROUTING_IF_CHANGE   (1 << AFD_POLL_ROUTING_IF_CHANGE_BIT) // 0x0800
+#define AFD_POLL_ADDRESS_LIST_CHANGE (1 << AFD_POLL_ADDRESS_LIST_CHANGE_BIT) // 0x1000
+#define AFD_POLL_ALL                 ((1 << AFD_NUM_POLL_EVENTS) - 1) // 0x1FFF
+#define AFD_POLL_SANCOUNTS_UPDATED   0x80000000
+
+// private
+typedef struct _AFD_POLL_HANDLE_INFO
+{
+    HANDLE Handle;
+    ULONG PollEvents; // AFD_POLL_*
+    NTSTATUS Status;
+} AFD_POLL_HANDLE_INFO, *PAFD_POLL_HANDLE_INFO;
+
+// private
+typedef struct _AFD_POLL_INFO
+{
+    LARGE_INTEGER Timeout;
+    ULONG NumberOfHandles;
+    BOOLEAN Unique;
+    _Field_size_(NumberOfHandles) AFD_POLL_HANDLE_INFO Handles[ANYSIZE_ARRAY];
+} AFD_POLL_INFO, *PAFD_POLL_INFO;
+
+// private // Disconnect flags
+#define AFD_PARTIAL_DISCONNECT_SEND    0x01
+#define AFD_PARTIAL_DISCONNECT_RECEIVE 0x02
+#define AFD_ABORTIVE_DISCONNECT        0x04
+#define AFD_UNCONNECT_DATAGRAM         0x08
+
+// private
+typedef struct _AFD_PARTIAL_DISCONNECT_INFO
+{
+    ULONG DisconnectMode;
+    LARGE_INTEGER Timeout;
+} AFD_PARTIAL_DISCONNECT_INFO, *PAFD_PARTIAL_DISCONNECT_INFO;
+
+// private
+typedef struct _AFD_RECEIVE_INFORMATION
+{
+    ULONG BytesAvailable;
+    ULONG ExpeditedBytesAvailable;
+} AFD_RECEIVE_INFORMATION, *PAFD_RECEIVE_INFORMATION;
+
+// private // Handle query flags
+#define AFD_QUERY_ADDRESS_HANDLE    0x01
+#define AFD_QUERY_CONNECTION_HANDLE 0x02
+
+// private
+typedef struct _AFD_HANDLE_INFO
+{
+    HANDLE TdiAddressHandle;
+    HANDLE TdiConnectionHandle;
+} AFD_HANDLE_INFO, *PAFD_HANDLE_INFO;
+
+// private // InformationType
+#define AFD_INLINE_MODE                1 // s: BOOLEAN
+#define AFD_NONBLOCKING_MODE           2 // s: BOOLEAN
+#define AFD_MAX_SEND_SIZE              3 // q: ULONG
+#define AFD_SENDS_PENDING              4 // q: ULONG
+#define AFD_MAX_PATH_SEND_SIZE         5 // q: ULONG
+#define AFD_RECEIVE_WINDOW_SIZE        6 // q; s: ULONG
+#define AFD_SEND_WINDOW_SIZE           7 // q; s: ULONG
+#define AFD_CONNECT_TIME               8 // q: ULONG (in seconds)
+#define AFD_CIRCULAR_QUEUEING          9 // s: BOOLEAN
+#define AFD_GROUP_ID_AND_TYPE          10 // q: AFD_GROUP_INFO
+#define AFD_REPORT_PORT_UNREACHABLE    11 // s: BOOLEAN
+#define AFD_REPORT_NETWORK_UNREACHABLE 12 // s: BOOLEAN // rev
+#define AFD_DELIVERY_STATUS            14 // q: SIO_DELIVERY_STATUS // rev
+#define AFD_CANCEL_TL                  15 // s: void // rev
+
+// private
+typedef enum _AFD_GROUP_TYPE
+{
+    GroupTypeNeither = 0,
+    GroupTypeUnconstrained = SG_UNCONSTRAINED_GROUP,
+    GroupTypeConstrained = SG_CONSTRAINED_GROUP,
+} AFD_GROUP_TYPE, *PAFD_GROUP_TYPE;
+
+// private
+typedef struct _AFD_GROUP_INFO
+{
+    GROUP GroupID;
+    AFD_GROUP_TYPE GroupType;
+} AFD_GROUP_INFO, *PAFD_GROUP_INFO;
+
+// private
+typedef struct _SIO_DELIVERY_STATUS
+{
+    BOOLEAN DeliveryAvailable;
+    ULONG PendedReceiveRequests;
+} SIO_DELIVERY_STATUS, *PSIO_DELIVERY_STATUS;
+
+// private
+typedef struct _AFD_INFORMATION
+{
+    ULONG InformationType;
+    union
+    {
+        BOOLEAN Boolean;
+        ULONG Ulong;
+        LARGE_INTEGER LargeInteger;
+        AFD_GROUP_INFO GroupInfo; // rev
+        SIO_DELIVERY_STATUS DeliveryStatus; // rev
+    } Information;
+} AFD_INFORMATION, *PAFD_INFORMATION;
+
+// private
+typedef enum _SOCKET_STATE
+{
+  SocketStateInitializing = -1,
+  SocketStateOpen = 0,
+  SocketStateBound = 1,
+  SocketStateBoundSpecific = 2,
+  SocketStateConnected = 3,
+  SocketStateClosing = 4,
+} SOCKET_STATE, *PSOCKET_STATE;
+
+// private
+typedef struct _SOCK_SHARED_INFO
+{
+    SOCKET_STATE State;
+    LONG AddressFamily; // AF_*
+    LONG SocketType; // SOCK_*
+    LONG Protocol; // IPPROTO_*, BTHPROTO_*, HV_PROTOCOL_*, etc.
+    LONG LocalAddressLength;
+    LONG RemoteAddressLength;
+    LINGER LingerInfo;
+    ULONG SendTimeout; // in milliseconds
+    ULONG ReceiveTimeout; // in milliseconds
+    ULONG ReceiveBufferSize;
+    ULONG SendBufferSize;
+    union
+    {
+        struct
+        {
+            UCHAR Listening : 1;
+            UCHAR Broadcast : 1;
+            UCHAR Debug : 1;
+            UCHAR OobInline : 1;
+            UCHAR ReuseAddresses : 1;
+            UCHAR ExclusiveAddressUse : 1;
+            UCHAR NonBlocking : 1;
+            UCHAR DontUseWildcard : 1;
+            UCHAR ReceiveShutdown : 1;
+            UCHAR SendShutdown : 1;
+            UCHAR ConditionalAccept : 1;
+            UCHAR IsSANSocket : 1;
+            UCHAR fIsTLI : 1;
+            UCHAR Rio : 1;
+            UCHAR ReceiveBufferSizeSet : 1;
+            UCHAR SendBufferSizeSet : 1;
+        };
+        WORD Flags;
+    };
+    ULONG CreationFlags; // WSA_FLAG_*
+    ULONG CatalogEntryId;
+    ULONG ServiceFlags1; // XP1_*
+    ULONG ProviderFlags; // PFL_*
+    GROUP GroupID;
+    AFD_GROUP_TYPE GroupType;
+    LONG GroupPriority;
+    LONG LastError;
+    union
+    {
+        HWND AsyncSelecthWnd;
+        ULONGLONG AsyncSelectWnd64;
+    };
+    ULONG AsyncSelectSerialNumber;
+    ULONG AsyncSelectwMsg;
+    LONG AsyncSelectlEvent;
+    LONG DisabledAsyncSelectEvents;
+    GUID ProviderId;
+} SOCK_SHARED_INFO, *PSOCK_SHARED_INFO;
+
+// private
+typedef struct _AFD_UNACCEPTED_CONNECT_DATA_INFO
+{
+    LONG Sequence;
+    ULONG ConnectDataLength;
+    BOOLEAN LengthOnly;
+} AFD_UNACCEPTED_CONNECT_DATA_INFO, *PAFD_UNACCEPTED_CONNECT_DATA_INFO;
+
+// private // Transmit flags
+#define AFD_TF_DISCONNECT         0x01
+#define AFD_TF_REUSE_SOCKET       0x02
+#define AFD_TF_WRITE_BEHIND       0x04
+#define AFD_TF_USE_DEFAULT_WORKER 0x00
+#define AFD_TF_USE_SYSTEM_THREAD  0x10
+#define AFD_TF_USE_KERNEL_APC     0x20
+#define AFD_TF_WORKER_KIND_MASK   0x30
+
+// private
+typedef struct _AFD_TRANSMIT_FILE_INFO
+{
+    LARGE_INTEGER Offset;
+    LARGE_INTEGER WriteLength;
+    ULONG SendPacketLength;
+    HANDLE FileHandle;
+    PVOID Head;
+    ULONG HeadLength;
+    PVOID Tail;
+    ULONG TailLength;
+    ULONG Flags; // AFD_TF_*
+} AFD_TRANSMIT_FILE_INFO, *PAFD_TRANSMIT_FILE_INFO;
+
+// private
+typedef struct _AFD_SUPER_ACCEPT_INFO
+{
+    BOOLEAN SanActive;
+    BOOLEAN FixAddressAlignment;
+    HANDLE AcceptHandle;
+    ULONG ReceiveDataLength;
+    ULONG LocalAddressLength;
+    ULONG RemoteAddressLength;
+} AFD_SUPER_ACCEPT_INFO, *PAFD_SUPER_ACCEPT_INFO;
+
+// private
+typedef struct _AFD_EVENT_SELECT_INFO
+{
+    HANDLE Event;
+    ULONG PollEvents; // AFD_POLL_*
+} AFD_EVENT_SELECT_INFO, *PAFD_EVENT_SELECT_INFO;
+
+// private
+typedef struct _AFD_ENUM_NETWORK_EVENTS_INFO
+{
+    ULONG PollEvents; // AFD_POLL_*
+    NTSTATUS EventStatus[AFD_NUM_POLL_EVENTS];
+} AFD_ENUM_NETWORK_EVENTS_INFO, *PAFD_ENUM_NETWORK_EVENTS_INFO;
+
+// private
+typedef struct _AFD_DEFER_ACCEPT_INFO
+{
+    LONG Sequence;
+    BOOLEAN Reject;
+} AFD_DEFER_ACCEPT_INFO, *PAFD_DEFER_ACCEPT_INFO;
+
+// private
+typedef struct _AFD_QOS_INFO
+{
+    QOS Qos;
+    BOOLEAN GroupQos;
+} AFD_QOS_INFO, *PAFD_QOS_INFO;
+
+// private
+typedef struct _AFD_VALIDATE_GROUP_INFO
+{
+    GROUP GroupID;
+    TRANSPORT_ADDRESS RemoteAddress;
+} AFD_VALIDATE_GROUP_INFO, *PAFD_VALIDATE_GROUP_INFO;
+
+// private
+typedef struct _AFD_TRANSPORT_IOCTL_INFO
+{
+    HANDLE Handle;
+    _Field_size_bytes_(InputBufferLength) PVOID InputBuffer;
+    ULONG InputBufferLength;
+    ULONG IoControlCode;
+    ULONG AfdFlags;
+    ULONG PollEvent;
+} AFD_TRANSPORT_IOCTL_INFO, *PAFD_TRANSPORT_IOCTL_INFO;
+
+// private
+typedef enum TL_IO_CONTROL_TYPE
+{
+    TlEndpointIoControlType = 0,
+    TlSetSockOptIoControlType = 1,
+    TlGetSockOptIoControlType = 2,
+    TlSocketIoControlType = 3,
+} TL_IO_CONTROL_TYPE, *PTL_IO_CONTROL_TYPE;
+
+// private
+typedef struct _AFD_TL_IO_CONTROL_INFO
+{
+    TL_IO_CONTROL_TYPE Type;
+    ULONG Level; // SOL_* or IPPROTO_*
+    ULONG IoControlCode; // SIO_*, SO_*, IP_*, IPV6_*, TCP_*, UDP_*, etc. (depending on type and level)
+    BOOLEAN EndpointIoctl;
+    _Field_size_bytes_(InputBufferLength) PVOID InputBuffer;
+    SIZE_T InputBufferLength;
+} AFD_TL_IO_CONTROL_INFO, *PAFD_TL_IO_CONTROL_INFO;
+
+// private
+typedef struct _AFD_TPACKETS_INFO
+{
+    _Field_size_(ElementCount) PTRANSMIT_PACKETS_ELEMENT ElementArray;
+    ULONG ElementCount;
+    ULONG SendSize;
+    ULONG Flags;
+} AFD_TPACKETS_INFO, *PAFD_TPACKETS_INFO;
+
+// private
+typedef struct _AFD_SUPER_CONNECT_INFO
+{
+    BOOLEAN SanActive;
+    TRANSPORT_ADDRESS RemoteAddress;
+} AFD_SUPER_CONNECT_INFO, *PAFD_SUPER_CONNECT_INFO;
+
+// rev
+typedef struct _AFD_SUPER_CONNECT_INFO_TL
+{
+    BOOLEAN SanActive;
+    SOCKADDR RemoteAddress;
+} AFD_SUPER_CONNECT_INFO_TL, *PAFD_SUPER_CONNECT_INFO_TL;
+
+// private
+typedef struct _AFD_SUPER_DISCONNECT_INFO
+{
+    ULONG Flags; // same as partial disconnect
+} AFD_SUPER_DISCONNECT_INFO, *PAFD_SUPER_DISCONNECT_INFO;
+
+// private
+typedef struct _AFD_MESSAGE_INFO
+{
+    AFD_DATAGRAM_INFO dgi;
+    _Field_size_bytes_(ControlLength) PVOID ControlBuffer;
+    PULONG ControlLength;
+    PULONG MsgFlags;
+} AFD_MESSAGE_INFO, *PAFD_MESSAGE_INFO;
+
+// private
+typedef struct _AFD_SWITCH_CONTEXT
+{
+    LONG EventsActive;
+    LONG RcvCount;
+    LONG ExpCount;
+    LONG SndCount;
+    BOOLEAN SelectFlag;
+} AFD_SWITCH_CONTEXT, *PAFD_SWITCH_CONTEXT;
+
+// private
+typedef struct _AFD_SWITCH_CONTEXT_INFO
+{
+    HANDLE SocketHandle;
+    PAFD_SWITCH_CONTEXT SwitchContext;
+} AFD_SWITCH_CONTEXT_INFO, *PAFD_SWITCH_CONTEXT_INFO;
+
+// private
+typedef struct _AFD_SWITCH_EVENT_INFO
+{
+    HANDLE SocketHandle;
+    PAFD_SWITCH_CONTEXT SwitchContext;
+    ULONG EventBit; // AFD_POLL_*_BIT
+    NTSTATUS Status;
+} AFD_SWITCH_EVENT_INFO, *PAFD_SWITCH_EVENT_INFO;
+
+// private
+typedef struct _AFD_SWITCH_CONNECT_INFO
+{
+    HANDLE ListenHandle;
+    PAFD_SWITCH_CONTEXT SwitchContext;
+    TRANSPORT_ADDRESS RemoteAddress;
+} AFD_SWITCH_CONNECT_INFO, *PAFD_SWITCH_CONNECT_INFO;
+
+// private
+typedef struct _AFD_SWITCH_ACCEPT_INFO
+{
+    HANDLE AcceptHandle;
+    ULONG ReceiveLength;
+} AFD_SWITCH_ACCEPT_INFO, *PAFD_SWITCH_ACCEPT_INFO;
+
+// private
+typedef struct _AFD_SWITCH_REQUEST_INFO
+{
+    HANDLE SocketHandle;
+    PAFD_SWITCH_CONTEXT SwitchContext;
+    PVOID RequestContext;
+    NTSTATUS RequestStatus;
+    ULONG DataOffset;
+} AFD_SWITCH_REQUEST_INFO, *PAFD_SWITCH_REQUEST_INFO;
+
+// private
+typedef struct _AFD_SWITCH_ACQUIRE_CTX_INFO
+{
+    HANDLE SocketHandle;
+    PAFD_SWITCH_CONTEXT SwitchContext;
+    PVOID SocketCtxBuf;
+    ULONG SocketCtxBufSize;
+} AFD_SWITCH_ACQUIRE_CTX_INFO, *PAFD_SWITCH_ACQUIRE_CTX_INFO;
+
+// private
+typedef struct _AFD_SWITCH_TRANSFER_CTX_INFO
+{
+    HANDLE SocketHandle;
+    PAFD_SWITCH_CONTEXT SwitchContext;
+    PVOID RequestContext;
+    PVOID SocketCtxBuf;
+    ULONG SocketCtxBufSize;
+    _Field_size_(RcvBufferCount) LPWSABUF RcvBufferArray;
+    ULONG RcvBufferCount;
+    NTSTATUS Status;
+} AFD_SWITCH_TRANSFER_CTX_INFO, *PAFD_SWITCH_TRANSFER_CTX_INFO;
+
+// private
+typedef struct _AFD_UNBIND_INFO
+{
+    LONG AddressFamily; // AF_*
+    LONG Protocol; // IPPROTO_*, BTHPROTO_*, HV_PROTOCOL_*, etc.
+} AFD_UNBIND_INFO, *PAFD_UNBIND_INFO;
+
+// rev // SQM Control Codes
+#define AFD_SQM_CONTROL_CODE_STORE 1
+#define AFD_SQM_CONTROL_CODE_SWEEP -1
+
+// private
+typedef struct _AFD_SQM_CONTROL
+{
+    ULONG Code; // AFD_SQM_CONTROL_CODE_*
+} AFD_SQM_CONTROL, *PAFD_SQM_CONTROL;
+
+// private
+typedef struct _WINSOCK_SQM_SOCKTYPE_DESC
+{
+    ULONG StreamTCP : 1;
+    ULONG StreamOther : 1;
+    ULONG DatagramUDP : 1;
+    ULONG DatagramUDPMulticast : 1;
+    ULONG DatagramOther : 1;
+    ULONG RawTCP : 1;
+    ULONG RawUDP : 1;
+    ULONG RawOther : 1;
+    ULONG OtherSocketTypes : 1;
+    ULONG IPv6Socket : 1;
+    ULONG ProviderLoadedWSD : 1;
+    ULONG ProviderLoadedLSP : 1;
+    ULONG ProviderLoadedMultiLSP : 1;
+    ULONG NonMswsockBSP : 1;
+} WINSOCK_SQM_SOCKTYPE_DESC, *PWINSOCK_SQM_SOCKTYPE_DESC;
+
+// private
+typedef struct _WINSOCK_SQM_SOCKTYPE_COUNTS
+{
+    ULONG MaxStreamSocketsConn;
+    ULONG MaxStreamSocketsListen;
+    ULONG MaxDatagramSockets;
+    ULONG MaxRawSockets;
+    ULONG MaxOtherSockets;
+} WINSOCK_SQM_SOCKTYPE_COUNTS, *PWINSOCK_SQM_SOCKTYPE_COUNTS;
+
+// private
+typedef struct _WINSOCK_SQM_NONCORE_FUNC
+{
+    ULONG Select : 1;
+    ULONG WSAPoll : 1;
+    ULONG StreamWSAEventSelect : 1;
+    ULONG StreamWSAAsyncSelect : 1;
+    ULONG TransmitFile : 1;
+    ULONG StreamTransmitPackets : 1;
+    ULONG DisconnectEx : 1;
+    ULONG SocketReuse : 1;
+    ULONG StreamDuplicateSocket : 1;
+    ULONG ReadWriteFile : 1;
+    ULONG OOBSendRecv : 1;
+    ULONG StreamSoSndTimeO : 1;
+    ULONG StreamSoRcvTimeO : 1;
+    ULONG MsgWaitAll : 1;
+    ULONG StreamNonCoreSOLOptions : 1;
+    ULONG StreamNonCoreTCPOptions : 1;
+    ULONG StreamNonCoreIPOptions : 1;
+    ULONG StreamNonCoreOtherOptions : 1;
+    ULONG StreamNonCoreIOCTLs : 1;
+    ULONG StreamNonCoreWSASocket : 1;
+    ULONG NonCoreRecv : 1;
+    ULONG NonCoreSend : 1;
+    ULONG StreamNonCoreWSAIoctl : 1;
+    ULONG NonCoreWSAAccept : 1;
+    ULONG StreamNonCoreWSAConnect : 1;
+    ULONG StreamWSAJoinLeaf : 1;
+    ULONG StreamWSAGetQoSByName : 1;
+    ULONG WSASendDisconnect : 1;
+    ULONG WSARecvDisconnect : 1;
+} WINSOCK_SQM_NONCORE_FUNC, *PWINSOCK_SQM_NONCORE_FUNC;
+
+// private
+typedef struct _WINSOCK_SQM_DEPRECATION_LIST
+{
+    ULONG bEnumProtocols : 1;
+    ULONG bGetNameByType : 1;
+    ULONG bGetService : 1;
+    ULONG bGetTypeByName : 1;
+    ULONG bSetService : 1;
+    ULONG bWSACancelBlockingCall : 1;
+    ULONG bWSAIsBlocking : 1;
+    ULONG bWSASetBlockingHook : 1;
+    ULONG bWSAUnhookBlockingHook : 1;
+    ULONG bGetAddressByName : 1;
+    ULONG bGetHostByAddr : 1;
+    ULONG bGetHostByName : 1;
+    ULONG bGetHostName : 1;
+    ULONG bGetProtoByName : 1;
+    ULONG bGetProtoByNumber : 1;
+    ULONG bGetServByName : 1;
+    ULONG bGetServByPort : 1;
+    ULONG bInetAddr : 1;
+    ULONG bInetNtoa : 1;
+    ULONG bWSAAsyncGetHostByAddr : 1;
+    ULONG bWSAAsyncGetHostByName : 1;
+    ULONG bWSAAsyncGetProtoByName : 1;
+    ULONG bWSAAsyncGetProtoByNumber : 1;
+    ULONG bWSAAsyncGetServByName : 1;
+    ULONG bWSAAsyncGetServByPort : 1;
+    ULONG bWSACancelAsyncRequest : 1;
+    ULONG bWSARecvEx : 1;
+} WINSOCK_SQM_DEPRECATION_LIST, *PWINSOCK_SQM_DEPRECATION_LIST;
+
+// private
+typedef struct _WINSOCK_SQM_SOCK_OPTIONS
+{
+    ULONG SoSndBuf : 1;
+    ULONG SoRcvBuf : 1;
+    ULONG SoSndBuf0 : 1;
+    ULONG SoRcvBuf0 : 1;
+    ULONG SoKeepAliveOn : 1;
+    ULONG SoReuseAddrOn : 1;
+    ULONG SoExclusiveAddrUseOn : 1;
+    ULONG SoLingerOn : 1;
+    ULONG SoLingerOn0 : 1;
+    ULONG SoRandomizePortOn : 1;
+    ULONG SoPortScaleOn : 1;
+    ULONG SoCondAcceptOn : 1;
+    ULONG SoOobInlineOn : 1;
+    ULONG SoOther : 1;
+    ULONG TCPNoDelayOn : 1;
+    ULONG TCPOther : 1;
+    ULONG IPV6V6OnlyOff : 1;
+    ULONG IPV6ProtectLevel : 1;
+    ULONG IPOther : 1;
+    ULONG LevelOther : 1;
+    ULONG ISBQuery : 1;
+    ULONG ISBNotify : 1;
+    ULONG AddressQuery : 1;
+    ULONG AddressNotify : 1;
+    ULONG RouteQuery : 1;
+    ULONG RouteNotify : 1;
+    ULONG FionbioOn : 1;
+    ULONG Fionread : 1;
+    ULONG Siocatmark : 1;
+    ULONG Siokeepalivevals : 1;
+    ULONG Siosetcompatmode : 1;
+    ULONG Sioportreserve : 1;
+} WINSOCK_SQM_SOCK_OPTIONS, *PWINSOCK_SQM_SOCK_OPTIONS;
+
+// private
+typedef struct _WINSOCK_SQM_MISC_BEHAVIOR
+{
+    ULONG SendEverPended : 1;
+    ULONG RecvEverPended : 1;
+    ULONG ShutdownSend : 1;
+    ULONG ShutdownRecv : 1;
+    ULONG WSASocketProtocol : 1;
+} WINSOCK_SQM_MISC_BEHAVIOR, *PWINSOCK_SQM_MISC_BEHAVIOR;
+
+// private
+typedef struct _AFD_SQM_INFO
+{
+    AFD_SQM_CONTROL Control;
+    WCHAR AppName[16];
+    WCHAR LSPName[16];
+    ULONG AppVersion;
+    WINSOCK_SQM_SOCKTYPE_DESC SocketTypeDescriptor;
+    WINSOCK_SQM_SOCKTYPE_COUNTS SocketTypeCounts;
+    WINSOCK_SQM_NONCORE_FUNC NonCoreFunctions;
+    WINSOCK_SQM_DEPRECATION_LIST DeprecationList;
+    WINSOCK_SQM_SOCK_OPTIONS SocketOptions;
+    WINSOCK_SQM_MISC_BEHAVIOR MiscBehavior;
+} AFD_SQM_INFO, *PAFD_SQM_INFO;
+
+// private
+typedef enum _AFD_RIO_COMMAND
+{
+    AfdRioCommandIdCreateCq = 0,         // in: AFD_RIO_COMMAND_CREATE_CQ; out: AFD_RIO_COMMAND_CREATE_CQ_RESULT
+    AfdRioCommandIdDestroyCq = 1,        // in: AFD_RIO_COMMAND_DESTROY_CQ
+    AfdRioCommandIdNotifyCq = 2,         // in: AFD_RIO_COMMAND_NOTIFY_CQ
+    AfdRioCommandIdCreateRqPair = 3,     // in: AFD_RIO_COMMAND_CREATE_RQ_PAIR
+    AfdRioCommandIdRegisterBuffer = 4,   // in: AFD_RIO_COMMAND_REGISTER_BUFFER; out: AFD_RIO_COMMAND_REGISTER_BUFFER_RESULT
+    AfdRioCommandIdDeregisterBuffer = 5, // in: AFD_RIO_COMMAND_DEREGISTER_BUFFER
+    AfdRioCommandIdPokeSend = 6,         // in: AFD_RIO_COMMAND_POKE_SEND
+    AfdRioCommandIdPokeReceive = 7,      // in: AFD_RIO_COMMAND_POKE_RECEIVE
+    AfdRioCommandIdResizeCq = 8,         // in: AFD_RIO_COMMAND_RESIZE_CQ
+    AfdRioCommandIdResizeRqPair = 9,     // in: AFD_RIO_COMMAND_RESIZE_RQ_PAIR
+    AfdRioCommandIdMaximum = 10,
+} AFD_RIO_COMMAND, *PAFD_RIO_COMMAND;
+
+// private
+typedef struct _AFD_RIO_COMMAND_HEADER
+{
+    AFD_RIO_COMMAND Command;
+} AFD_RIO_COMMAND_HEADER, *PAFD_RIO_COMMAND_HEADER;
+
+// private
+typedef enum _AFD_RIO_NOTIFICATION_COMPLETION_TYPE
+{
+    AfdRioNoCompletion = 0,
+    AfdRioEventCompletion = 1,
+    AfdRioIocpCompletion = 2,
+} AFD_RIO_NOTIFICATION_COMPLETION_TYPE, *PAFD_RIO_NOTIFICATION_COMPLETION_TYPE;
+
+// private
+typedef struct _AFD_RIO_COMMAND_CREATE_CQ
+{
+    AFD_RIO_COMMAND_HEADER Header;
+    ULONG QSize;
+    AFD_RIO_NOTIFICATION_COMPLETION_TYPE NotificationType;
+    ULONGLONG NotificationHandle;
+    ULONGLONG NotificationContext;
+    ULONGLONG NotificationContext2;
+    ULONG BufferSize;
+    ULONGLONG Buffer;
+} AFD_RIO_COMMAND_CREATE_CQ, *PAFD_RIO_COMMAND_CREATE_CQ;
+
+// private
+typedef struct _AFD_RIO_COMMAND_CREATE_CQ_RESULT
+{
+    ULONG CqId;
+} AFD_RIO_COMMAND_CREATE_CQ_RESULT, *PAFD_RIO_COMMAND_CREATE_CQ_RESULT;
+
+// private
+typedef struct _AFD_RIO_COMMAND_DESTROY_CQ
+{
+    AFD_RIO_COMMAND_HEADER Header;
+    ULONG CqId;
+} AFD_RIO_COMMAND_DESTROY_CQ, *PAFD_RIO_COMMAND_DESTROY_CQ;
+
+// private
+typedef struct _AFD_RIO_COMMAND_NOTIFY_CQ
+{
+    AFD_RIO_COMMAND_HEADER Header;
+    ULONG Index;
+} AFD_RIO_COMMAND_NOTIFY_CQ, *PAFD_RIO_COMMAND_NOTIFY_CQ;
+
+// private
+typedef struct _AFD_RIO_COMMAND_CREATE_RQ_PAIR
+{
+    AFD_RIO_COMMAND_HEADER Header;
+    ULONG SendCompletionQueue;
+    ULONG ReceiveCompletionQueue;
+    ULONG SendQueueEntryCount;
+    ULONG SendQueueBufferSize;
+    ULONGLONG SendQueueBuffer;
+    ULONG ReceiveQueueEntryCount;
+    ULONG ReceiveQueueBufferSize;
+    ULONGLONG ReceiveQueueBuffer;
+    ULONGLONG EndpointHandle;
+    ULONGLONG SocketContext;
+} AFD_RIO_COMMAND_CREATE_RQ_PAIR, *PAFD_RIO_COMMAND_CREATE_RQ_PAIR;
+
+// private
+typedef struct _AFD_RIO_COMMAND_REGISTER_BUFFER
+{
+    AFD_RIO_COMMAND_HEADER Header;
+    ULONGLONG Buffer;
+    ULONG BufferLength;
+} AFD_RIO_COMMAND_REGISTER_BUFFER, *PAFD_RIO_COMMAND_REGISTER_BUFFER;
+
+// private
+typedef struct _AFD_RIO_COMMAND_REGISTER_BUFFER_RESULT
+{
+    ULONG BufferId;
+} AFD_RIO_COMMAND_REGISTER_BUFFER_RESULT, *PAFD_RIO_COMMAND_REGISTER_BUFFER_RESULT;
+
+// private
+typedef struct _AFD_RIO_COMMAND_DEREGISTER_BUFFER
+{
+    AFD_RIO_COMMAND_HEADER Header;
+    ULONG BufferId;
+} AFD_RIO_COMMAND_DEREGISTER_BUFFER, *PAFD_RIO_COMMAND_DEREGISTER_BUFFER;
+
+// private
+typedef struct _AFD_RIO_COMMAND_POKE_SEND
+{
+    AFD_RIO_COMMAND_HEADER Header;
+} AFD_RIO_COMMAND_POKE_SEND, *PAFD_RIO_COMMAND_POKE_SEND;
+
+// private
+typedef struct _AFD_RIO_COMMAND_POKE_RECEIVE
+{
+    AFD_RIO_COMMAND_HEADER Header;
+} AFD_RIO_COMMAND_POKE_RECEIVE, *PAFD_RIO_COMMAND_POKE_RECEIVE;
+
+// private
+typedef struct _AFD_RIO_COMMAND_RESIZE_CQ
+{
+    AFD_RIO_COMMAND_HEADER Header;
+    ULONG CqId;
+    ULONG QSize;
+    ULONG BufferSize;
+    ULONGLONG Buffer;
+} AFD_RIO_COMMAND_RESIZE_CQ, *PAFD_RIO_COMMAND_RESIZE_CQ;
+
+// private
+typedef struct _AFD_RIO_COMMAND_RESIZE_RQ_PAIR
+{
+    AFD_RIO_COMMAND_HEADER Header;
+    ULONG SendQueueEntryCount;
+    ULONG SendQueueBufferSize;
+    ULONGLONG SendQueueBuffer;
+    ULONG ReceiveQueueEntryCount;
+    ULONG ReceiveQueueBufferSize;
+    ULONGLONG ReceiveQueueBuffer;
+} AFD_RIO_COMMAND_RESIZE_RQ_PAIR, *PAFD_RIO_COMMAND_RESIZE_RQ_PAIR;
+
+#endif


### PR DESCRIPTION
This pull request adds definitions for interacting with `\Device\Afd` (Ancillary Function Driver) and implements support for viewing various information about socket handles.

![image](https://github.com/user-attachments/assets/df6ee19e-6739-4b8e-b0c0-4a900f613cc1)
