### PR TITLE
Fix the bitness of the dynamic relocations for 32-bit

### DIFF
--- a/phlib/mapimg.c
+++ b/phlib/mapimg.c
@@ -4820,8 +4820,8 @@ PVOID PhpFillDynamicRelocationsArray32(
     PIMAGE_BASE_RELOCATION base;
     PVOID end;
 
-    base = PTR_ADD_OFFSET(Relocs, RTL_SIZEOF_THROUGH_FIELD(IMAGE_DYNAMIC_RELOCATION64, BaseRelocSize));
-    end = PTR_ADD_OFFSET(Relocs, RTL_SIZEOF_THROUGH_FIELD(IMAGE_DYNAMIC_RELOCATION64, BaseRelocSize));
+    base = PTR_ADD_OFFSET(Relocs, RTL_SIZEOF_THROUGH_FIELD(IMAGE_DYNAMIC_RELOCATION32, BaseRelocSize));
+    end = PTR_ADD_OFFSET(Relocs, RTL_SIZEOF_THROUGH_FIELD(IMAGE_DYNAMIC_RELOCATION32, BaseRelocSize));
     end = PTR_ADD_OFFSET(end, Relocs->BaseRelocSize);
 
     PhpFillDynamicRelocations(MappedImage, Relocs->Symbol, base, end, Array);


### PR DESCRIPTION
This PR swaps the struct used for calculating the base and end of the relocations. Originally, for calculations in 32-bit images, the 64-bit structure was being used. This swaps it to the correct 32-bit version 