### PR TITLE
phnt: Use relative include paths

### DIFF
--- a/phnt/include/ntexapi.h
+++ b/phnt/include/ntexapi.h
@@ -7,7 +7,7 @@
 #ifndef _NTEXAPI_H
 #define _NTEXAPI_H
 
-#include <ntkeapi.h>
+#include "ntkeapi.h"
 
 typedef struct _TEB* PTEB;
 typedef struct _COUNTED_REASON_CONTEXT* PCOUNTED_REASON_CONTEXT;

--- a/phnt/include/ntpebteb.h
+++ b/phnt/include/ntpebteb.h
@@ -7,7 +7,7 @@
 #ifndef _NTPEBTEB_H
 #define _NTPEBTEB_H
 
-#include <ntsxs.h>
+#include "ntsxs.h"
 
 typedef struct _RTL_USER_PROCESS_PARAMETERS *PRTL_USER_PROCESS_PARAMETERS;
 typedef struct _RTL_CRITICAL_SECTION *PRTL_CRITICAL_SECTION;

--- a/phnt/include/ntpsapi.h
+++ b/phnt/include/ntpsapi.h
@@ -7,7 +7,7 @@
 #ifndef _NTPSAPI_H
 #define _NTPSAPI_H
 
-#include <ntpebteb.h>
+#include "ntpebteb.h"
 
 //
 // Process Object Specific Access Rights

--- a/phnt/include/ntwow64.h
+++ b/phnt/include/ntwow64.h
@@ -9,8 +9,8 @@
 
 #if (PHNT_MODE != PHNT_MODE_KERNEL)
 #ifdef __has_include
-#if __has_include (<ntxcapi.h>)
-#include <ntxcapi.h>
+#if __has_include ("ntxcapi.h")
+#include "ntxcapi.h"
 #endif // __has_include
 #endif // __has_include
 #endif // (PHNT_MODE != PHNT_MODE_KERNEL)

--- a/phnt/include/phnt.h
+++ b/phnt/include/phnt.h
@@ -81,40 +81,40 @@
 EXTERN_C_START
 
 #if (PHNT_MODE != PHNT_MODE_KERNEL)
-#include <phnt_ntdef.h>
-#include <ntnls.h>
+#include "phnt_ntdef.h"
+#include "ntnls.h"
 #endif // (PHNT_MODE != PHNT_MODE_KERNEL)
 
-#include <ntkeapi.h>
-#include <ntldr.h>
-#include <ntexapi.h>
+#include "ntkeapi.h"
+#include "ntldr.h"
+#include "ntexapi.h"
 
-#include <ntbcd.h>
-#include <ntmmapi.h>
-#include <ntobapi.h>
-#include <ntpsapi.h>
+#include "ntbcd.h"
+#include "ntmmapi.h"
+#include "ntobapi.h"
+#include "ntpsapi.h"
 
 #if (PHNT_MODE != PHNT_MODE_KERNEL)
-#include <ntdbg.h>
-#include <ntimage.h>
-#include <ntioapi.h>
+#include "ntdbg.h"
+#include "ntimage.h"
+#include "ntioapi.h"
 #include <ntlsa.h>
-#include <ntlpcapi.h>
-#include <ntmisc.h>
-#include <ntpfapi.h>
-#include <ntpnpapi.h>
-#include <ntpoapi.h>
-#include <ntregapi.h>
-#include <ntrtl.h>
-#include <ntsam.h>
-#include <ntseapi.h>
-#include <nttmapi.h>
-#include <nttp.h>
-#include <ntuser.h>
-#include <ntwmi.h>
-#include <ntwow64.h>
-#include <ntxcapi.h>
-#include <ntzwapi.h>
+#include "ntlpcapi.h"
+#include "ntmisc.h"
+#include "ntpfapi.h"
+#include "ntpnpapi.h"
+#include "ntpoapi.h"
+#include "ntregapi.h"
+#include "ntrtl.h"
+#include "ntsam.h"
+#include "ntseapi.h"
+#include "nttmapi.h"
+#include "nttp.h"
+#include "ntuser.h"
+#include "ntwmi.h"
+#include "ntwow64.h"
+#include "ntxcapi.h"
+#include "ntzwapi.h"
 #endif // (PHNT_MODE != PHNT_MODE_KERNEL)
 
 EXTERN_C_END


### PR DESCRIPTION
Currently, phnt must be added to the include path and used as following:
```c
#include <phnt_windows.h>
#include <phnt.h>
```

This change allows to just drop the headers to any folder and use:
```c
#include "my_libraries/phnt/phnt_windows.h"
#include "my_libraries/phnt/phnt.h"
```

Without having to change compilation flags or project configurations