### PR TITLE
phnt: Fix `RtlFlsAlloc[Ex]` SAL annotation

### DIFF
--- a/phnt/include/ntrtl.h
+++ b/phnt/include/ntrtl.h
@@ -10501,7 +10501,7 @@ NTSYSAPI
 NTSTATUS
 NTAPI
 RtlFlsAlloc(
-    _In_ PFLS_CALLBACK_FUNCTION Callback,
+    _In_opt_ PFLS_CALLBACK_FUNCTION Callback,
     _Out_ PULONG FlsIndex
     );
 
@@ -10510,7 +10510,7 @@ NTSYSAPI
 NTSTATUS
 NTAPI
 RtlFlsAllocEx(
-    _In_ PFLS_CALLBACK_FUNCTION Callback,
+    _In_opt_ PFLS_CALLBACK_FUNCTION Callback,
     _Out_ PULONG,
     _Out_ PULONG FlsIndex
     );


### PR DESCRIPTION
See also [Microsoft Learning: FlsAlloc function](https://learn.microsoft.com/en-us/windows/win32/api/fibersapi/nf-fibersapi-flsalloc):
> [in] lpCallback
> A pointer to the application-defined callback function of type PFLS_CALLBACK_FUNCTION. This parameter is optional. For more information, see [FlsCallback](https://learn.microsoft.com/en-us/windows/desktop/api/winnt/nc-winnt-pfls_callback_function).