### PR TITLE
phnt: Fix `RtlInitializeCriticalSectionAndSpinCount` SAL annotation

### DIFF
--- a/phnt/include/ntrtl.h
+++ b/phnt/include/ntrtl.h
@@ -1046,7 +1046,7 @@ NTSYSAPI
 NTSTATUS
 NTAPI
 RtlInitializeCriticalSectionAndSpinCount(
-    _Inout_ PRTL_CRITICAL_SECTION CriticalSection,
+    _Out_ PRTL_CRITICAL_SECTION CriticalSection,
     _In_ ULONG SpinCount
     );
 


### PR DESCRIPTION
See also synchapi.h in Windows SDK:
```C
WINBASEAPI
_Must_inspect_result_
BOOL
WINAPI
InitializeCriticalSectionAndSpinCount(
    _Out_ LPCRITICAL_SECTION lpCriticalSection,
    _In_ DWORD dwSpinCount
    );
```