### PR TITLE
Format more known security attributes

### DIFF
--- a/phnt/include/ntrtl.h
+++ b/phnt/include/ntrtl.h
@@ -10758,6 +10758,16 @@ typedef struct _PS_PKG_CLAIM
     ULONG Origin; // PackageOrigin
 } PS_PKG_CLAIM, *PPS_PKG_CLAIM;
 
+// private // WIN://BGKD
+typedef enum _PSM_ACTIVATE_BACKGROUND_TYPE
+{
+  PsmActNotBackground = 0,
+  PsmActMixedHost = 1,
+  PsmActPureHost = 2,
+  PsmActSystemHost = 3,
+  PsmActInvalidType = 4,
+} PSM_ACTIVATE_BACKGROUND_TYPE;
+
 #if (PHNT_VERSION >= PHNT_WINDOWS_10)
 NTSYSAPI
 NTSTATUS


### PR DESCRIPTION
This pull request improves formatting for several known token security attributes, namely:
 - `WIN://BGKD` - appears on `backgroundTaskHost.exe` and shows the background activation type.
 - `APPID://SHA1HASH`, `APPID://SHA256HASH`, and ``APPID://SHA256FLATHASH`` - appear with enabled AppLocker when using hash-based rules - now shows the raw hash value.
 - `SMARTLOCKER://SMARTSCREENORIGINCLAIM` and `SMARTLOCKER://SMARTSCREENORIGINCLAIMNOTINHERITED` - appear when starting executables with MOTW and interacting with SmartScreen - now shows the prompt result flags and the file path.