### PR TITLE
phnt: Fix `RtlCompactHeap` return type

### DIFF
--- a/phnt/include/ntrtl.h
+++ b/phnt/include/ntrtl.h
@@ -5721,7 +5721,7 @@ RtlExtendHeap(
     );
 
 NTSYSAPI
-SIZE_T
+ULONG
 NTAPI
 RtlCompactHeap(
     _In_ PVOID HeapHandle,


### PR DESCRIPTION
My RE result, ReactOS, NTinterlnals.net, Wine, ... all of them show the result is an `ULONG`.