### PR TITLE
Fix PhEnumDirectoryFileEx

### DIFF
--- a/phlib/nativefile.c
+++ b/phlib/nativefile.c
@@ -859,8 +859,11 @@ NTSTATUS PhEnumDirectoryFileEx(
     ULONG i;
     BOOLEAN cont;
 
-    if (!PhStringRefToUnicodeString(SearchPattern, &searchPattern))
-        return STATUS_NAME_TOO_LONG;
+    if (SearchPattern)
+    {
+        if (!PhStringRefToUnicodeString(SearchPattern, &searchPattern))
+            return STATUS_NAME_TOO_LONG;
+    }
 
     buffer = PhAllocate(bufferSize);
 
@@ -879,7 +882,7 @@ NTSTATUS PhEnumDirectoryFileEx(
                 bufferSize,
                 FileInformationClass,
                 ReturnSingleEntry,
-                &searchPattern,
+                SearchPattern ? &searchPattern : NULL,
                 firstTime
                 );
 


### PR DESCRIPTION
SearchPattern parameter is optional, so we should use it only if valid one was provided.

This should fix crashing in update check (among others?) mentioned in https://github.com/winsiderss/systeminformer/issues/2508#issuecomment-2857683017.