### PR TITLE
Branch certificate info fix

### DIFF
--- a/tools/peview/secprp.c
+++ b/tools/peview/secprp.c
@@ -1035,7 +1035,10 @@ BOOLEAN PvpPeFillNodeCertificateInfo(
             PPH_STRING data = PhCreateStringEx(NULL, dataLength);
 
             if (CertGetCertificateContextProperty(CertificateContext, CERT_SIGN_HASH_CNG_ALG_PROP_ID, data->Buffer, &dataLength))
+            {
                 CertificateNode->Algorithm = data;
+                PhTrimToNullTerminatorString(data);
+            }
             else
                 PhDereferenceObject(data);
         }


### PR DESCRIPTION
Refix bug#2709（In "certificate node-> algorithm = data;", the string length in the "data" variable in this line is also calculated by the length of a UNICODE_NULL terminator.）