### PR TITLE
Use the UNDNAME_NO_MS_KEYWORDS parameter in the UnDecorateSymbolNameW…

### DIFF
--- a/phlib/symprv.c
+++ b/phlib/symprv.c
@@ -2649,11 +2649,21 @@ PPH_STRING PhUndecorateSymbolName(
 
     PH_LOCK_SYMBOLS();
 
+    /** For the same function, using the difference between the parameters of UNDNAME_COMPLETE and UNDNAME_NO_MS_KEYWORDS, obviously, using UNDNAME_NO_MS_KEYWORDS is more practical.
+    The function is:
+    ?childMouseEventFilter@QQuickItem@@MEAA_NPEAV1@PEAVQEvent@@@Z
+
+    The result of using the UNDNAME_COMPLETE parameter:
+    protected: virtual bool __cdecl QQuickItem::childMouseEventFilter(class QQuickItem* __ptr64, class QEvent* __ptr64) __ptr64
+
+    The result of using the UNDNAME_NO_MS_KEYWORDS parameter:
+    protected: virtual bool QQuickItem::childMouseEventFilter(class QQuickItem*, class QEvent*);
+    */
     result = UnDecorateSymbolNameW_I(
         DecoratedName,
         undecoratedBuffer,
         PAGE_SIZE,
-        UNDNAME_COMPLETE
+        UNDNAME_NO_MS_KEYWORDS
         );
 
     PH_UNLOCK_SYMBOLS();

--- a/tools/peview/pdb.c
+++ b/tools/peview/pdb.c
@@ -908,7 +908,7 @@ VOID PePdbPrintDiaSymbol(
     IDiaSymbol_get_length(IDiaSymbol, &symbolLength);
     IDiaSymbol_get_name(IDiaSymbol, &bstrName);
 
-    if (IDiaSymbol_get_undecoratedNameEx(IDiaSymbol, UNDNAME_COMPLETE, &bstrUndname) != S_OK)
+    if (IDiaSymbol_get_undecoratedNameEx(IDiaSymbol, UNDNAME_NO_MS_KEYWORDS, &bstrUndname) != S_OK)
     {
         IDiaSymbol_get_undecoratedName(IDiaSymbol, &bstrUndname);
     }


### PR DESCRIPTION
Use the UNDNAME_NO_MS_KEYWORDS parameter in the UnDecorateSymbolNameW_I and IDiaSymbol_get_undecoratedNameEx functions.