### PR TITLE
phnt: SAL and comment fixes

### DIFF
--- a/phnt/include/ntpsapi.h
+++ b/phnt/include/ntpsapi.h
@@ -327,7 +327,7 @@ typedef enum _THREADINFOCLASS
     ThreadDescriptorTableEntry,                     // q: DESCRIPTOR_TABLE_ENTRY (or WOW64_DESCRIPTOR_TABLE_ENTRY)
     ThreadEnableAlignmentFaultFixup,                // s: BOOLEAN
     ThreadEventPair,                                // q: Obsolete
-    ThreadQuerySetWin32StartAddress,                // qs: PVOID (requires THREAD_Set_LIMITED_INFORMATION)
+    ThreadQuerySetWin32StartAddress,                // qs: PVOID (requires THREAD_SET_LIMITED_INFORMATION)
     ThreadZeroTlsCell,                              // s: ULONG // TlsIndex // 10
     ThreadPerformanceCount,                         // q: LARGE_INTEGER
     ThreadAmILastThread,                            // q: ULONG

--- a/phnt/include/ntrtl.h
+++ b/phnt/include/ntrtl.h
@@ -11466,7 +11466,7 @@ NTSTATUS
 NTAPI
 RtlFlsSetValue(
     _In_ ULONG FlsIndex,
-    _In_ PVOID FlsData
+    _In_opt_ PVOID FlsData
     );
 
 #define RTL_FLS_DATA_CLEANUP_PER_SLOT 1
@@ -11503,7 +11503,7 @@ NTSTATUS
 NTAPI
 RtlTlsSetValue(
     _In_ ULONG TlsIndex,
-    _In_ PVOID TlsData
+    _In_opt_ PVOID TlsData
     );
 #endif // PHNT_VERSION >= PHNT_WINDOWS_11
 

--- a/phnt/include/winsta.h
+++ b/phnt/include/winsta.h
@@ -953,8 +953,8 @@ WinStationEnumerateW(
  * @param WinStationInformation Pointer to a caller-allocated buffer that receives the requested information about the token.
  * @param WinStationInformationLength Length, in bytes, of the caller-allocated TokenInformation buffer.
  * @param ReturnLength Pointer to a caller-allocated variable that receives the actual length, in bytes, of the information returned in the TokenInformation buffer.
- * @return NTSTATUS Successful or errant status.
- * @sa https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/ntifs/nf-ntifs-ntqueryinformationtoken
+ * @return BOOLEAN Nonzero if the function succeeds, or zero otherwise. To get extended error information, call GetLastError.
+ * @sa https://learn.microsoft.com/en-us/previous-versions/aa383827(v=vs.85)
  */
 NTSYSAPI
 BOOLEAN
@@ -1320,7 +1320,7 @@ WinStationGetLoggedOnCount(
  * \param[in] RenderHintType Specifies the type of hint represented by this call.
  * \param[in] HintDataLength The size in bytes, of the HintData buffer.
  * \param[in] HintData Additional data for the hint. The format of this data is dependent upon the value passed in the renderHintType parameter.
- * \return NTSTATUS Successful or errant status.
+ * \return BOOLEAN Nonzero if the function succeeds, or zero otherwise.
  * \sa https://learn.microsoft.com/en-us/windows/win32/api/wtshintapi/nf-wtshintapi-wtssetrenderhint
  */
 NTSYSAPI


### PR DESCRIPTION
- `THREAD_Set_LIMITED_INFORMATION` -> `THREAD_SET_LIMITED_INFORMATION`.
- Thread / Fiber local storage custom data can be anything, including `NULL`, `_In_ ` -> `_In_opt_`. See also [TlsSetValue](https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-tlssetvalue) and [FlsSetValue](https://learn.microsoft.com/en-us/windows/win32/api/fibersapi/nf-fibersapi-flssetvalue).
- Fix comment for `WinStationEnumerateW` and `WinStationGetLoggedOnCount`. They return `BOOLEAN`, and the former one sets Win32 error code in last error.