### PR TITLE
phnt: Fix ThreadQuerySetWin32StartAddress comment

### DIFF
--- a/phnt/include/ntbcd.h
+++ b/phnt/include/ntbcd.h
@@ -1575,7 +1575,7 @@ typedef enum _BcdLibraryElementTypes
     /// <remarks>0x16000041</remarks>
     BcdLibraryBoolean_DisplayOptionsEdit = MAKE_BCDE_DATA_TYPE(BCD_ELEMENT_DATATYPE_CLASS_LIBRARY, BCD_ELEMENT_DATATYPE_FORMAT_BOOLEAN, 65),
     /// <summary>
-    /// Represents a refernce to the address of the FVE (Full Volume Encryption) Key Ring as an integer.
+    /// Represents a reference to the address of the FVE (Full Volume Encryption) Key Ring as an integer.
     /// </summary>
     /// <remarks>0x15000042</remarks>
     BcdLibraryInteger_FVEKeyRingAddress = MAKE_BCDE_DATA_TYPE(BCD_ELEMENT_DATATYPE_CLASS_LIBRARY, BCD_ELEMENT_DATATYPE_FORMAT_INTEGER, 66),

--- a/phnt/include/ntexapi.h
+++ b/phnt/include/ntexapi.h
@@ -2895,7 +2895,7 @@ typedef struct _RTL_PROCESS_BACKTRACES
     _Field_size_(NumberOfBackTraces) RTL_PROCESS_BACKTRACE_INFORMATION BackTraces[1];
 } RTL_PROCESS_BACKTRACES, *PRTL_PROCESS_BACKTRACES;
 
-// Note: This information class is deprecatd since values are limitd to 65535. Use SystemExtendedHandleInformation instead.
+// Note: This information class is deprecated since values are limited to 65535. Use SystemExtendedHandleInformation instead.
 typedef struct _SYSTEM_HANDLE_TABLE_ENTRY_INFO
 {
     USHORT UniqueProcessId;

--- a/phnt/include/ntintsafe.h
+++ b/phnt/include/ntintsafe.h
@@ -6915,7 +6915,7 @@ RtlUShortAdd(
 #define RtlUInt16Add   RtlUShortAdd
 
 //
-// WORD addtition
+// WORD addition
 //
 #define RtlWordAdd     RtlUShortAdd
 

--- a/phnt/include/ntmmapi.h
+++ b/phnt/include/ntmmapi.h
@@ -344,7 +344,7 @@ typedef struct _MEMORY_PHYSICAL_CONTIGUITY_UNIT_INFORMATION
 } MEMORY_PHYSICAL_CONTIGUITY_UNIT_INFORMATION, *PMEMORY_PHYSICAL_CONTIGUITY_UNIT_INFORMATION;
 
 /**
- * Thw MEMORY_PHYSICAL_CONTIGUITY_INFORMATION structure describes a virtual range and contiguity unit characteristics for physical contiguity queries.
+ * The MEMORY_PHYSICAL_CONTIGUITY_INFORMATION structure describes a virtual range and contiguity unit characteristics for physical contiguity queries.
  */
 typedef struct _MEMORY_PHYSICAL_CONTIGUITY_INFORMATION
 {
@@ -960,7 +960,7 @@ typedef enum _VIRTUAL_MEMORY_INFORMATION_CLASS
 #if (PHNT_MODE != PHNT_MODE_KERNEL)
 
 /**
- * Attempt to populate specified single or multiple adddress ranges
+ * Attempt to populate specified single or multiple address ranges
  * into the process working set (bring pages into physical memory).
  */
 #define VM_PREFETCH_TO_WORKING_SET 0x1 // since 24H4

--- a/phnt/include/ntpsapi.h
+++ b/phnt/include/ntpsapi.h
@@ -1237,7 +1237,7 @@ typedef struct _PS_PROTECTION
 } PS_PROTECTION, *PPS_PROTECTION;
 
 /**
- * The PROCESS_MEMORY_EXHAUSTION_TYPE enumeration defines the different memory exhaustion typess.
+ * The PROCESS_MEMORY_EXHAUSTION_TYPE enumeration defines the different memory exhaustion types.
  *
  * \sa https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/ne-processthreadsapi-process_memory_exhaustion_type
  */


### PR DESCRIPTION
According to @diversenok at https://github.com/m417z/ntdoc/pull/29#discussion_r2619425369:

> [T]he code for handling [`ThreadQuerySetWin32StartAddress`] in `NtSetInformationThread` looks like this:
> ```c
> case ThreadQuerySetWin32StartAddress:
>     return STATUS_INVALID_PARAMETER;
> ```
