### PR TITLE
Fix Compiler Issue

### DIFF
--- a/phlib/apistubs.cpp
+++ b/phlib/apistubs.cpp
@@ -174,7 +174,7 @@ static BOOL WINAPI ReadFile_Stub(
 {
     NTSTATUS status;
 
-    if (lpOverlapped)
+    if (Overlapped)
     {
         PhSetLastError(ERROR_NOT_SUPPORTED);
         return FALSE;
@@ -196,13 +196,13 @@ static BOOL WINAPI WriteFile_Stub(
     _In_ HANDLE hFile,
     _In_reads_bytes_opt_(NumberOfBytesToWrite) PCVOID Buffer,
     _In_ ULONG NumberOfBytesToWrite,
-    _Out_opt_ LPULONG NumberOfBytesWritten,
+    _Out_opt_ PULONG NumberOfBytesWritten,
     _Inout_opt_ LPOVERLAPPED Overlapped
     )
 {
     NTSTATUS status;
 
-    if (lpOverlapped)
+    if (Overlapped)
     {
         PhSetLastError(ERROR_NOT_SUPPORTED);
         return FALSE;


### PR DESCRIPTION
While building the project, I faced this issue where undeclared variables we used, to be honest I was skeptic and I am not sure how was that compiling on the devs end ? do you use different settings ? I was building using the build scripts provided with the project under `build\build_debug.cmd`