### PR TITLE
Fix options page redraw artifacts

### DIFF
--- a/SystemInformer/options.c
+++ b/SystemInformer/options.c
@@ -723,8 +723,10 @@ VOID PhOptionsEnterSectionView(
 
     EndDeferWindowPos(containerDeferHandle);
 
+    RedrawWindow(ContainerControl, NULL, NULL, RDW_ERASE | RDW_ERASENOW | RDW_INVALIDATE | RDW_ALLCHILDREN | RDW_UPDATENOW);
+
     if (NewSection->DialogHandle)
-        RedrawWindow(NewSection->DialogHandle, NULL, NULL, RDW_ERASE | RDW_INVALIDATE | RDW_ALLCHILDREN | RDW_UPDATENOW);
+        RedrawWindow(NewSection->DialogHandle, NULL, NULL, RDW_ERASE | RDW_ERASENOW | RDW_INVALIDATE | RDW_ALLCHILDREN | RDW_UPDATENOW);
 }
 
 VOID PhOptionsEnterSectionViewInner(

--- a/plugins/ExtendedNotifications/main.c
+++ b/plugins/ExtendedNotifications/main.c
@@ -969,6 +969,7 @@ INT_PTR CALLBACK DevicesDlgProc(
             PhSetDialogItemText(WindowHandle, IDC_LOGFILENAME, PhaGetStringSetting(SETTING_NAME_LOG_FILENAME)->Buffer);
 
             PhInitializeLayoutManager(&LayoutManager, WindowHandle);
+            PhSetWindowStyle(WindowHandle, WS_CLIPCHILDREN, 0);
             PhAddLayoutItem(&LayoutManager, GetDlgItem(WindowHandle, IDC_INFO), NULL, PH_ANCHOR_TOP | PH_ANCHOR_LEFT | PH_ANCHOR_RIGHT);
             PhAddLayoutItem(&LayoutManager, GetDlgItem(WindowHandle, IDC_LOGFILENAME), NULL, PH_ANCHOR_TOP | PH_ANCHOR_LEFT | PH_ANCHOR_RIGHT);
             PhAddLayoutItem(&LayoutManager, GetDlgItem(WindowHandle, IDC_BROWSE), NULL, PH_ANCHOR_TOP | PH_ANCHOR_RIGHT);

--- a/plugins/NetworkTools/options.c
+++ b/plugins/NetworkTools/options.c
@@ -53,6 +53,7 @@ INT_PTR CALLBACK OptionsDlgProc(
             ComboBox_SetCurSel(comboHandle, PhGetIntegerSetting(SETTING_NAME_GEOLITE_DB_TYPE));
 
             PhInitializeLayoutManager(&LayoutManager, WindowHandle);
+            PhSetWindowStyle(WindowHandle, WS_CLIPCHILDREN, 0);
             PhAddLayoutItem(&LayoutManager, GetDlgItem(WindowHandle, IDC_DATABASE), NULL, PH_ANCHOR_TOP | PH_ANCHOR_LEFT | PH_ANCHOR_RIGHT);
             PhAddLayoutItem(&LayoutManager, GetDlgItem(WindowHandle, IDC_BROWSE), NULL, PH_ANCHOR_TOP | PH_ANCHOR_RIGHT);
         }

--- a/plugins/OnlineChecks/options.c
+++ b/plugins/OnlineChecks/options.c
@@ -91,6 +91,7 @@ INT_PTR CALLBACK OptionsDlgProc(
             ScanExclusionsPopulateListBox(GetDlgItem(WindowHandle, IDC_EXCLUDE_LIST));
 
             PhInitializeLayoutManager(&OptionsLayoutManager, WindowHandle);
+            PhSetWindowStyle(WindowHandle, WS_CLIPCHILDREN, 0);
             PhAddLayoutItem(&OptionsLayoutManager, GetDlgItem(WindowHandle, IDC_ENABLE_SCANNING), NULL, PH_ANCHOR_LEFT | PH_ANCHOR_TOP);
             PhAddLayoutItem(&OptionsLayoutManager, GetDlgItem(WindowHandle, IDC_SCAN_DELAY_LABEL), NULL, PH_ANCHOR_TOP | PH_ANCHOR_RIGHT);
             PhAddLayoutItem(&OptionsLayoutManager, GetDlgItem(WindowHandle, IDC_SCAN_DELAY), NULL, PH_ANCHOR_TOP | PH_ANCHOR_RIGHT);


### PR DESCRIPTION
## Summary
Fixes dirty/stale background artifacts when switching to some plugin Options pages.

The fix:
- Redraws the Options dialog container before redrawing the selected page.
- Clears `WS_CLIPCHILDREN` on plugin option pages whose group-box regions exposed stale backing pixels:
  - NetworkTools
  - OnlineChecks
  - ExtendedNotifications Logging

## Problem
Some Options pages showed stale pixels from previously selected pages inside group-box areas. The controls from the previous page were not active; this was a redraw artifact.

Confirmed affected pages:
- Network Tools
- Online Checks
- ExtendedNotifications - Logging

## Investigation signals
The issue was narrowed down through several visual checks:

- Switching to other Options pages and then back showed stale content only in specific group-box regions.
- The controls from the previous page were not interactive, confirming this was not a page merge or visibility issue.
- The bottom/non-group-box area of the page cleared correctly, which indicated the page/container was partially repainting.
- Updater did not reproduce because it has a sparse page without the same group-box/layout combination.
- ToolStatus has group boxes but did not show the same behavior because it does not use the same layout-manager path.
- ExtendedNotifications Logging reproduced the same issue, confirming this was not specific to NetworkTools or OnlineChecks.

Several probes helped isolate the cause:

- Adding `WS_EX_TRANSPARENT` to affected group boxes did not fix the artifact.
- Changing themed group-box paint/erase behavior did not fix the artifact.
- Clearing `WS_CLIPCHILDREN` alone did not fix the artifact.
- Redrawing the Options container cleared the stale pixels, but exposed the default grey dialog background in group-box regions.
- Combining the container redraw with clearing `WS_CLIPCHILDREN` on the affected page roots produced the correct visual result.

## Validation
- x64 local visual inspection:
  - Network Tools page
  - Online Checks page
  - ExtendedNotifications Logging page