### PR TITLE
Update NuGet Cache

### DIFF
--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -23,8 +23,10 @@ jobs:
     - name: NuGet Cache
       uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # 5.0.5
       with:
-        path: packages
-        key: nuget-${{ runner.os }}-${{ hashFiles('**/packages.config') }}
+        path: |
+          packages
+          ~\.nuget\packages
+        key: nuget-${{ runner.os }}-${{ hashFiles('**/packages.config', '**/*.csproj', '**/Directory.Packages.props', '**/packages.lock.json', '**/NuGet.Config', '**/global.json') }}
         restore-keys: nuget-${{ runner.os }}-
 
     - name: Nuget Restore
@@ -73,8 +75,10 @@ jobs:
     - name: NuGet Cache
       uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # 5.0.5
       with:
-        path: packages
-        key: nuget-${{ runner.os }}-${{ hashFiles('**/packages.config') }}
+        path: |
+          packages
+          ~\.nuget\packages
+        key: nuget-${{ runner.os }}-${{ hashFiles('**/packages.config', '**/*.csproj', '**/Directory.Packages.props', '**/packages.lock.json', '**/NuGet.Config', '**/global.json') }}
         restore-keys: nuget-${{ runner.os }}-
 
     - name: Nuget Restore
@@ -123,8 +127,10 @@ jobs:
     - name: NuGet Cache
       uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # 5.0.5
       with:
-        path: packages
-        key: nuget-${{ runner.os }}-${{ hashFiles('**/packages.config') }}
+        path: |
+          packages
+          ~\.nuget\packages
+        key: nuget-${{ runner.os }}-${{ hashFiles('**/packages.config', '**/*.csproj', '**/Directory.Packages.props', '**/packages.lock.json', '**/NuGet.Config', '**/global.json') }}
         restore-keys: nuget-${{ runner.os }}-
 
     - name: Nuget Restore
@@ -165,8 +171,10 @@ jobs:
     - name: NuGet Cache
       uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # 5.0.5
       with:
-        path: packages
-        key: nuget-${{ runner.os }}-${{ hashFiles('**/packages.config') }}
+        path: |
+          packages
+          ~\.nuget\packages
+        key: nuget-${{ runner.os }}-${{ hashFiles('**/packages.config', '**/*.csproj', '**/Directory.Packages.props', '**/packages.lock.json', '**/NuGet.Config', '**/global.json') }}
         restore-keys: nuget-${{ runner.os }}-
 
     - name: Nuget Restore


### PR DESCRIPTION
This pull request improves the NuGet caching in the `.github/workflows/msbuild.yml` GitHub Actions workflow.

* The cache `path` now includes both the `packages` directory and the global NuGet cache at `~\.nuget\packages` to ensure all dependencies are cached, reducing redundant downloads. [[1]](diffhunk://#diff-de2a9656c10aacac69a56ff6ccf9b769be45400ac419e321b2090af70d8657cdL26-R29) [[2]](diffhunk://#diff-de2a9656c10aacac69a56ff6ccf9b769be45400ac419e321b2090af70d8657cdL76-R81) [[3]](diffhunk://#diff-de2a9656c10aacac69a56ff6ccf9b769be45400ac419e321b2090af70d8657cdL126-R133) [[4]](diffhunk://#diff-de2a9656c10aacac69a56ff6ccf9b769be45400ac419e321b2090af70d8657cdL168-R177)
* The cache `key` has been updated to include additional files (`*.csproj`, `Directory.Packages.props`, `packages.lock.json`, `NuGet.Config`, `global.json`) along with `packages.config`, making the cache more accurate and invalidating it when any relevant dependency file changes. [[1]](diffhunk://#diff-de2a9656c10aacac69a56ff6ccf9b769be45400ac419e321b2090af70d8657cdL26-R29) [[2]](diffhunk://#diff-de2a9656c10aacac69a56ff6ccf9b769be45400ac419e321b2090af70d8657cdL76-R81) [[3]](diffhunk://#diff-de2a9656c10aacac69a56ff6ccf9b769be45400ac419e321b2090af70d8657cdL126-R133) [[4]](diffhunk://#diff-de2a9656c10aacac69a56ff6ccf9b769be45400ac419e321b2090af70d8657cdL168-R177)