### PR TITLE
peview: Fix crashes when sorting nullable columns

### DIFF
--- a/tools/peview/pdbprp.c
+++ b/tools/peview/pdbprp.c
@@ -297,7 +297,7 @@ END_SORT_FUNCTION
 
 BEGIN_SORT_FUNCTION(Value)
 {
-    sortResult = PhCompareString(node1->Value, node2->Value, TRUE);
+    sortResult = PhCompareStringWithNullSortOrder(node1->Value, node2->Value, ((PPDB_SYMBOL_CONTEXT)_context)->TreeNewSortOrder, TRUE);
 }
 END_SORT_FUNCTION
 

--- a/tools/peview/secprp.c
+++ b/tools/peview/secprp.c
@@ -412,7 +412,7 @@ END_SORT_FUNCTION
 
 BEGIN_SORT_FUNCTION(Issuer)
 {
-    sortResult = PhCompareString(node1->Issuer, node2->Issuer, TRUE);
+    sortResult = PhCompareStringWithNullSortOrder(node1->Issuer, node2->Issuer, ((PPV_PE_CERTIFICATE_CONTEXT)_context)->TreeNewSortOrder, TRUE);
 }
 END_SORT_FUNCTION
 
@@ -430,7 +430,7 @@ END_SORT_FUNCTION
 
 BEGIN_SORT_FUNCTION(Thumbprint)
 {
-    sortResult = PhCompareString(node1->Thumbprint, node2->Thumbprint, TRUE);
+    sortResult = PhCompareStringWithNullSortOrder(node1->Thumbprint, node2->Thumbprint, ((PPV_PE_CERTIFICATE_CONTEXT)_context)->TreeNewSortOrder, TRUE);
 }
 END_SORT_FUNCTION
 
@@ -442,7 +442,7 @@ END_SORT_FUNCTION
 
 BEGIN_SORT_FUNCTION(Alg)
 {
-    sortResult = PhCompareString(node1->Algorithm, node2->Algorithm, TRUE);
+    sortResult = PhCompareStringWithNullSortOrder(node1->Algorithm, node2->Algorithm, ((PPV_PE_CERTIFICATE_CONTEXT)_context)->TreeNewSortOrder, TRUE);
 }
 END_SORT_FUNCTION
 


### PR DESCRIPTION
## Description
This PR resolves an unchecked null pointer dereference that causes PE Viewer (`peview.exe`) to crash when sorting columns that contain `NULL` or empty string values.

---

### Root Cause
In `pdbprp.c` (PDB Symbols) and `secprp.c` (Security Certificates), list sorting by string columns was implemented using `PhCompareString`. Because `PhCompareString` expects valid `PPH_STRING` pointers, passing a null pointer (which happens for symbols without constant values, or missing certificate attributes) causes a null pointer dereference (`String1->sr`).

### Fix
Updated the sorting functions for the following columns to use `PhCompareStringWithNullSortOrder`, which safely handles null strings and respects the active tree view sort order:
- **PDB Symbols**: `Value` column
- **Security Certificates**: `Issuer`, `Thumbprint`, and `Algorithm` columns

### Steps to Verify
1. Run `peview.exe`.
2. Open any executable with symbols (e.g. `dbghelp.dll`).
3. Select the **PDB Symbols** tab.
4. Click on the **Value** column header to sort.
5. Select the **Security** tab, and click the **Issuer**, **Thumbprint**, or **Algorithm** column headers. (when the executable has a malformed self signed certificate)
6. Verify that sorting works correctly without crashing.
