### PR TITLE
SystemInformer: Fix focus loss on left-clicking items in tray mini popup list

### DIFF
--- a/SystemInformer/miniinfo.c
+++ b/SystemInformer/miniinfo.c
@@ -2196,7 +2196,12 @@ BOOLEAN PhMipListSectionTreeNewCallback(
         return TRUE;
     case TreeNewLeftClick:
         {
-            PhMipClearListSectionSelection(listSection);
+            PPH_TREENEW_MOUSE_EVENT mouseEvent = Parameter1;
+
+            if (mouseEvent && !mouseEvent->Node)
+            {
+                PhMipClearListSectionSelection(listSection);
+            }
         }
         break;
     case TreeNewLeftDoubleClick:


### PR DESCRIPTION
## Description
This PR fixes the focus and selection loss issue when left-clicking list entries in the tray mini popup window (Fixes #2975).

### Cause
In `SystemInformer/miniinfo.c`, the tree-new list notification handler receives the `TreeNewLeftClick` event. Previously, this handler unconditionally cleared the list selection by calling `PhMipClearListSectionSelection(listSection);` when any left-click occurred.
- If the user performed a drag-selection (by clicking, moving the mouse, then releasing), the click was handled as a drag by `PhTnpDetectDrag` and did not send `TreeNewLeftClick`, thereby preserving the selection.
- If the user simply clicked (press and release without drag), `TreeNewLeftClick` was sent, which immediately cleared the selection and caused the item to lose focus.

### Fix
Modified the `TreeNewLeftClick` handler inside `PhMipListSectionTreeNewCallback` to inspect the `mouseEvent->Node` parameter. The selection is now only cleared if the user clicks on the empty space of the control (i.e. `mouseEvent->Node` is `NULL`). Clicking directly on an item preserves its selection and focus correctly.