### PR TITLE
phnt: fix ALPC structure layouts

### DIFF
--- a/phnt/include/ntlpcapi.h
+++ b/phnt/include/ntlpcapi.h
@@ -700,41 +700,52 @@ typedef struct _ALPC_CONTEXT_ATTR
 // begin_rev
 #define ALPC_HANDLEFLG_DUPLICATE_SAME_ACCESS 0x10000
 #define ALPC_HANDLEFLG_DUPLICATE_SAME_ATTRIBUTES 0x20000
+#define ALPC_HANDLEFLG_INDIRECT 0x40000
 #define ALPC_HANDLEFLG_DUPLICATE_INHERIT 0x80000
 // end_rev
+
+#define ALPC_INDIRECT_HANDLE_MAX 512
 
 // private
 typedef struct _ALPC_HANDLE_ATTR32
 {
     ULONG Flags;
-    ULONG Reserved0;
-    ULONG SameAccess;
-    ULONG SameAttributes;
-    ULONG Indirect;
-    ULONG Inherit;
-    ULONG Reserved1;
     ULONG Handle;
     ULONG ObjectType; // ObjectTypeCode, not ObjectTypeIndex
     ACCESS_MASK DesiredAccess;
-    ACCESS_MASK GrantedAccess;
 } ALPC_HANDLE_ATTR32, *PALPC_HANDLE_ATTR32;
 
 // private
 typedef struct _ALPC_HANDLE_ATTR
 {
-    ULONG Flags;
-    ULONG Reserved0;
-    ULONG SameAccess;
-    ULONG SameAttributes;
-    ULONG Indirect;
-    ULONG Inherit;
-    ULONG Reserved1;
-    HANDLE Handle;
-    PALPC_HANDLE_ATTR32 HandleAttrArray;
-    ULONG ObjectType; // ObjectTypeCode, not ObjectTypeIndex
-    ULONG HandleCount;
-    ACCESS_MASK DesiredAccess;
-    ACCESS_MASK GrantedAccess;
+    union
+    {
+        ULONG Flags;
+        struct
+        {
+            ULONG Reserved0 : 16;
+            ULONG SameAccess : 1;
+            ULONG SameAttributes : 1;
+            ULONG Indirect : 1;
+            ULONG Inherit : 1;
+            ULONG Reserved1 : 12;
+        };
+    };
+
+    union
+    {
+        struct
+        {
+            HANDLE Handle;
+            ULONG ObjectType; // ObjectTypeCode, not ObjectTypeIndex
+            ACCESS_MASK DesiredAccess;
+        };
+        struct
+        {
+            PALPC_HANDLE_ATTR32 HandleAttrArray;
+            ULONG HandleCount;
+        };
+    };
 } ALPC_HANDLE_ATTR, *PALPC_HANDLE_ATTR;
 
 /*


### PR DESCRIPTION
## Summary

Fix the private ALPC handle attribute layouts in phnt:

- add `ALPC_HANDLEFLG_INDIRECT`
- add `ALPC_INDIRECT_HANDLE_MAX`
- reduce `ALPC_HANDLE_ATTR32` to the 0x10 message-attribute payload layout
- update `ALPC_HANDLE_ATTR` to model the direct/indirect union layout
- remove `GrantedAccess` from the ALPC message handle attribute payloads

## Rationale

These definitions are for the ALPC message handle attribute payload consumed by the kernel capture path, not for `ALPC_MESSAGE_HANDLE_INFORMATION`. The latter still has `GrantedAccess`, but the message attribute payload does not.

The corrected layouts match the observed native and 32-bit payload sizes used by `AlpcInitializeMessageAttribute`:

- `ALPC_HANDLE_ATTR32`: 0x10 bytes
- `ALPC_HANDLE_ATTR`: 0x18 bytes on 64-bit, 0x10 bytes on 32-bit

The indirect handle count limit is 512. User-mode probing through `NtAlpcConnectPort` reaches the kernel validation path and confirms:

- `HandleCount == 1` returns `STATUS_INVALID_PARAMETER`
- `HandleCount == 512` with a null array proceeds to array probing and returns `STATUS_ACCESS_VIOLATION`
- `HandleCount == 513` returns `STATUS_LPC_HANDLE_COUNT_EXCEEDED`

## Validation

The same ALPC definition changes were applied in KNSoft.NDK commit `211ef238a6b88561bfc83e9677872b81ecaf73a7`, with unit tests covering:

- structure sizes and field offsets
- `GrantedAccess` absence from the message attribute payload
- top-level handle attribute flag validation
- indirect element flag validation
- the 512 indirect handle count limit through a real user-mode ALPC call into the kernel

The NDK GitHub Actions run for that commit completed successfully:

- https://github.com/KNSoft/KNSoft.NDK/actions/runs/28962809926

Locally, the NDK ALPC tests passed on both x64 and x86.

For this phnt change, I also compiled a temporary x64/x86 layout assertion translation unit against `phnt.h` successfully. A full local System Informer solution build was blocked by missing VS Spectre-mitigated libraries on my machine, before reaching this header change.

## Note

Some of the reverse-engineering cross-checks and validation planning for this change were assisted by Codex.
