### PR TITLE
phlib: Fix reference count leak in PhfResetEvent

### DIFF
--- a/phlib/sync.c
+++ b/phlib/sync.c
@@ -219,7 +219,7 @@ VOID FASTCALL PhfResetEvent(
         if (!(oldValue & PH_EVENT_SET))
             return;
 
-        newValue = oldValue & ~(ULONG_PTR)PH_EVENT_SET;
+        newValue = (oldValue & ~(ULONG_PTR)PH_EVENT_SET) + PH_EVENT_REFCOUNT_INC;
     } while ((ULONG_PTR)_InterlockedCompareExchangePointer(
         (PVOID *)&Event->Value,
         (PVOID)newValue,


### PR DESCRIPTION
### Summary
This PR fixes a reference count leak in `PhfResetEvent` that caused the System Information window (and potentially other windows utilizing `PH_EVENT` synchronization) to fail to open on the first click after being opened and closed three times.

### Root Cause Analysis
A `PH_EVENT` initializes with a reference count of `1` (`PH_EVENT_REFCOUNT_INC`). When `PhfSetEvent` transitions the event to the signaled state (`PH_EVENT_SET`), it decrements the reference count by `1` (`PhpDereferenceEvent`) to automatically release the underlying kernel event handle (minimizing system handle overhead). 

When resetting the event back to non-signaled via `PhfResetEvent`, the event transitions from signaled back to non-signaled. To balance the decrement from `PhfSetEvent`, `PhfResetEvent` must increment the reference count by `1`. 

However, in the `#else` block of `PhfResetEvent`, only the `PH_EVENT_SET` bit was cleared:
```c
newValue = oldValue & ~(ULONG_PTR)PH_EVENT_SET;
```
Without restoring the reference count, the refcount leaked (decreased by 1) on every set/reset cycle:
* **Cycle 1:** Refcount starts at `1`, becomes `2` on wait, `1` on set, `0` on wake (handle closed), and remains `0` on reset.
* **Cycle 2:** Refcount starts at `0`, becomes `1` on wait, `0` on set (closing the handle prematurely before waiter wakes up!), and `-1` on wake.
* **Cycle 3:** Refcount starts at `-1`, becomes `0` on wait, `-1` on set, `-2` on wake. Because the refcount did not transition from `1` to `0` on this cycle, the event handle was left open/valid, but still in a signaled state.
* **Cycle 4:** `PhfWaitForEvent` sees the event handle is not `NULL` (due to the leak in Cycle 3) and uses it. Since it was never reset, `NtWaitForSingleObject` returns immediately. The main thread sends the activation message to `PhSipWindow` before the worker thread has initialized it, resulting in the window failing to open on the first click.

### Solution
Modified `PhfResetEvent` in `phlib/sync.c` to atomically clear `PH_EVENT_SET` and add `PH_EVENT_REFCOUNT_INC` (effectively incrementing the refcount field by 1):
```c
newValue = (oldValue & ~(ULONG_PTR)PH_EVENT_SET) + PH_EVENT_REFCOUNT_INC;
```
This restores the reference count balance and guarantees correct synchronization behavior across infinite set/reset cycles.

### Notes
This fixes issue #2995 