### PR TITLE
log, notification: Add process start command line and file version info

### DIFF
--- a/SystemInformer/include/phapp.h
+++ b/SystemInformer/include/phapp.h
@@ -264,6 +264,7 @@ typedef struct _PH_LOG_ENTRY
         {
             PPH_STRING Name;
             PPH_STRING DisplayName;
+            PPH_STRING FileName;
         } Service;
         struct
         {
@@ -299,7 +300,8 @@ VOID PhLogProcessEntry(
 VOID PhLogServiceEntry(
     _In_ UCHAR Type,
     _In_ PPH_STRING Name,
-    _In_ PPH_STRING DisplayName
+    _In_ PPH_STRING DisplayName,
+    _In_opt_ PPH_STRING FileName
     );
 
 VOID PhLogDeviceEntry(

--- a/SystemInformer/include/procprv.h
+++ b/SystemInformer/include/procprv.h
@@ -338,6 +338,7 @@ typedef struct _PH_PROCESS_RECORD
     PPH_STRING ProcessName;
     PPH_STRING FileName;
     PPH_STRING CommandLine;
+    PPH_STRING FileVersion;
     /*PPH_STRING UserName;*/
 } PH_PROCESS_RECORD, *PPH_PROCESS_RECORD;
 // end_phapppub

--- a/SystemInformer/log.c
+++ b/SystemInformer/log.c
@@ -67,6 +67,7 @@ VOID PhpFreeLogEntry(
     {
         PhDereferenceObject(Entry->Service.Name);
         PhDereferenceObject(Entry->Service.DisplayName);
+        if (Entry->Service.FileName) PhDereferenceObject(Entry->Service.FileName);
     }
     else if (Entry->Type == PH_LOG_ENTRY_MESSAGE)
     {
@@ -115,7 +116,8 @@ PPH_LOG_ENTRY PhpCreateProcessLogEntry(
 PPH_LOG_ENTRY PhpCreateServiceLogEntry(
     _In_ UCHAR Type,
     _In_ PPH_STRING Name,
-    _In_ PPH_STRING DisplayName
+    _In_ PPH_STRING DisplayName,
+    _In_opt_ PPH_STRING FileName
     )
 {
     PPH_LOG_ENTRY entry;
@@ -125,6 +127,12 @@ PPH_LOG_ENTRY PhpCreateServiceLogEntry(
     entry->Service.Name = Name;
     PhReferenceObject(DisplayName);
     entry->Service.DisplayName = DisplayName;
+
+    if (!PhIsNullOrEmptyString(FileName))
+    {
+        PhReferenceObject(FileName);
+        entry->Service.FileName = FileName;
+    }
 
     return entry;
 }
@@ -206,10 +214,11 @@ VOID PhLogProcessEntry(
 VOID PhLogServiceEntry(
     _In_ UCHAR Type,
     _In_ PPH_STRING Name,
-    _In_ PPH_STRING DisplayName
+    _In_ PPH_STRING DisplayName,
+    _In_opt_ PPH_STRING FileName
     )
 {
-    PhpLogEntry(PhpCreateServiceLogEntry(Type, Name, DisplayName));
+    PhpLogEntry(PhpCreateServiceLogEntry(Type, Name, DisplayName, FileName));
 }
 
 VOID PhLogDeviceEntry(
@@ -282,6 +291,41 @@ static PPH_STRING PhpFormatLogEntryExtra(
     return PhCreateStringEx((PVOID)Entry->Buffer, Entry->BufferLength);
 }
 
+static PPH_STRING PhpFormatServiceLogEntry(
+    _In_ PPH_LOG_ENTRY Entry
+    )
+{
+    PH_FORMAT format[16];
+    ULONG count = 0;
+    PPH_STRING version = NULL;
+    PH_IMAGE_VERSION_INFO versionInfo = { 0 };
+
+    if (PhCsEnableVersionSupport && !PhIsNullOrEmptyString(Entry->Service.FileName))
+    {
+        if (NT_SUCCESS(PhInitializeImageVersionInfoCached(&versionInfo, Entry->Service.FileName, FALSE, !!PhCsEnableVersionSupport)))
+        {
+            if (!PhIsNullOrEmptyString(versionInfo.FileVersion))
+                version = versionInfo.FileVersion;
+        }
+    }
+
+    PhInitFormatSR(&format[count++], Entry->Service.Name->sr);
+    PhInitFormatS(&format[count++], L" (");
+    PhInitFormatSR(&format[count++], Entry->Service.DisplayName->sr);
+    PhInitFormatC(&format[count++], L')');
+
+    if (!PhIsNullOrEmptyString(version))
+    {
+        PhInitFormatS(&format[count++], L" (v");
+        PhInitFormatSR(&format[count++], version->sr);
+        PhInitFormatC(&format[count++], L')');
+    }
+
+    PPH_STRING result = PhpFormatLogEntryToBuffer(format, count);
+    PhDeleteImageVersionInfo(&versionInfo);
+    return result;
+}
+
 PPH_STRING PhFormatLogEntry(
     _In_ PPH_LOG_ENTRY Entry
     )
@@ -290,176 +334,103 @@ PPH_STRING PhFormatLogEntry(
     {
     case PH_LOG_ENTRY_PROCESS_CREATE:
         {
-            PH_FORMAT format[8];
+            PH_FORMAT format[20];
+            ULONG count = 0;
+            PPH_STRING processString = Entry->Process.Name;
+            PPH_STRING version = NULL;
+            PH_IMAGE_VERSION_INFO versionInfo = { 0 };
 
-            // Process created: %s (%lu) started by %s (%lu)
-            //PhInitFormatS(&format[0], L"Process created: ");
-            PhInitFormatSR(&format[0], Entry->Process.Name->sr);
-            PhInitFormatS(&format[1], L" (");
-            PhInitFormatU(&format[2], HandleToUlong(Entry->Process.ProcessId));
-            PhInitFormatS(&format[3], L") started by ");
+            if (Entry->Process.Record)
+            {
+                if (!PhIsNullOrEmptyString(Entry->Process.Record->CommandLine))
+                    processString = Entry->Process.Record->CommandLine;
+
+                if (!PhIsNullOrEmptyString(Entry->Process.Record->FileVersion))
+                    version = Entry->Process.Record->FileVersion;
+                else if (PhCsEnableVersionSupport && !PhIsNullOrEmptyString(Entry->Process.Record->FileName))
+                {
+                    if (NT_SUCCESS(PhInitializeImageVersionInfoCached(&versionInfo, Entry->Process.Record->FileName, TRUE, !!PhCsEnableVersionSupport)))
+                    {
+                        if (!PhIsNullOrEmptyString(versionInfo.FileVersion))
+                            version = versionInfo.FileVersion;
+                    }
+                }
+            }
+
+            PhInitFormatSR(&format[count++], processString->sr);
+            PhInitFormatS(&format[count++], L" (");
+            PhInitFormatU(&format[count++], HandleToUlong(Entry->Process.ProcessId));
+            PhInitFormatC(&format[count++], L')');
+
+            if (!PhIsNullOrEmptyString(version))
+            {
+                PhInitFormatS(&format[count++], L" (v");
+                PhInitFormatSR(&format[count++], version->sr);
+                PhInitFormatC(&format[count++], L')');
+            }
+
+            PhInitFormatS(&format[count++], L" started by ");
             if (Entry->Process.ParentName)
-                PhInitFormatSR(&format[4], Entry->Process.ParentName->sr);
+                PhInitFormatSR(&format[count++], Entry->Process.ParentName->sr);
             else
-                PhInitFormatS(&format[4], L"Unknown process");
-            PhInitFormatS(&format[5], L" (");
-            PhInitFormatU(&format[6], HandleToUlong(Entry->Process.ParentProcessId));
-            PhInitFormatC(&format[7], L')');
+                PhInitFormatS(&format[count++], L"Unknown process");
+            PhInitFormatS(&format[count++], L" (");
+            PhInitFormatU(&format[count++], HandleToUlong(Entry->Process.ParentProcessId));
+            PhInitFormatC(&format[count++], L')');
 
-            //return PhFormatString(
-            //    L"Process created: %s (%lu) started by %s (%lu)",
-            //    Entry->Process.Name->Buffer,
-            //    HandleToUlong(Entry->Process.ProcessId),
-            //    PhGetStringOrDefault(Entry->Process.ParentName, L"Unknown process"),
-            //    HandleToUlong(Entry->Process.ParentProcessId)
-            //    );
-            return PhpFormatLogEntryToBuffer(format, RTL_NUMBER_OF(format));
+            PPH_STRING result = PhpFormatLogEntryToBuffer(format, count);
+            PhDeleteImageVersionInfo(&versionInfo);
+            return result;
         }
     case PH_LOG_ENTRY_PROCESS_DELETE:
         {
-            PH_FORMAT format[5];
+            PH_FORMAT format[16];
+            ULONG count = 0;
+            PPH_STRING version = NULL;
+            PH_IMAGE_VERSION_INFO versionInfo = { 0 };
 
-            // Process terminated: %s (%lu); exit status 0x%x
-            //PhInitFormatS(&format[0], L"Process terminated: ");
-            PhInitFormatSR(&format[0], Entry->Process.Name->sr);
-            PhInitFormatS(&format[1], L" (");
-            PhInitFormatU(&format[2], HandleToUlong(Entry->Process.ProcessId));
-            PhInitFormatS(&format[3], L"); exit status ");
-            PhInitFormatX(&format[4], Entry->Process.ExitStatus);
+            if (Entry->Process.Record)
+            {
+                if (!PhIsNullOrEmptyString(Entry->Process.Record->FileVersion))
+                    version = Entry->Process.Record->FileVersion;
+                else if (PhCsEnableVersionSupport && !PhIsNullOrEmptyString(Entry->Process.Record->FileName))
+                {
+                    if (NT_SUCCESS(PhInitializeImageVersionInfoCached(&versionInfo, Entry->Process.Record->FileName, TRUE, !!PhCsEnableVersionSupport)))
+                    {
+                        if (!PhIsNullOrEmptyString(versionInfo.FileVersion))
+                            version = versionInfo.FileVersion;
+                    }
+                }
+            }
 
-            //return PhFormatString(
-            //    L"Process terminated: %s (%lu); exit status 0x%x",
-            //    Entry->Process.Name->Buffer,
-            //    HandleToUlong(Entry->Process.ProcessId),
-            //    Entry->Process.ExitStatus
-            //    );
-            return PhpFormatLogEntryToBuffer(format, RTL_NUMBER_OF(format));
+            PhInitFormatSR(&format[count++], Entry->Process.Name->sr);
+            PhInitFormatS(&format[count++], L" (");
+            PhInitFormatU(&format[count++], HandleToUlong(Entry->Process.ProcessId));
+            PhInitFormatC(&format[count++], L')');
+
+            if (!PhIsNullOrEmptyString(version))
+            {
+                PhInitFormatS(&format[count++], L" (v");
+                PhInitFormatSR(&format[count++], version->sr);
+                PhInitFormatC(&format[count++], L')');
+            }
+
+            PhInitFormatS(&format[count++], L"; exit status ");
+            PhInitFormatX(&format[count++], Entry->Process.ExitStatus);
+
+            PPH_STRING result = PhpFormatLogEntryToBuffer(format, count);
+            PhDeleteImageVersionInfo(&versionInfo);
+            return result;
         }
     case PH_LOG_ENTRY_SERVICE_CREATE:
-        {
-            PH_FORMAT format[4];
-
-            // Service created: %s (%s)
-            //PhInitFormatS(&format[0], L"Service created: ");
-            PhInitFormatSR(&format[0], Entry->Service.Name->sr);
-            PhInitFormatS(&format[1], L" (");
-            PhInitFormatSR(&format[2], Entry->Service.DisplayName->sr);
-            PhInitFormatC(&format[3], L')');
-
-            //return PhFormatString(
-            //    L"Service created: %s (%s)",
-            //    Entry->Service.Name->Buffer,
-            //    Entry->Service.DisplayName->Buffer
-            //    );
-            return PhpFormatLogEntryToBuffer(format, RTL_NUMBER_OF(format));
-        }
     case PH_LOG_ENTRY_SERVICE_DELETE:
-        {
-            PH_FORMAT format[4];
-
-            // Service deleted: %s (%s)
-            //PhInitFormatS(&format[0], L"Service deleted: ");
-            PhInitFormatSR(&format[0], Entry->Service.Name->sr);
-            PhInitFormatS(&format[1], L" (");
-            PhInitFormatSR(&format[2], Entry->Service.DisplayName->sr);
-            PhInitFormatC(&format[3], L')');
-
-            //return PhFormatString(
-            //    L"Service deleted: %s (%s)",
-            //    Entry->Service.Name->Buffer,
-            //    Entry->Service.DisplayName->Buffer
-            //    );
-            return PhpFormatLogEntryToBuffer(format, RTL_NUMBER_OF(format));
-        }
     case PH_LOG_ENTRY_SERVICE_START:
-        {
-            PH_FORMAT format[4];
-
-            // Service started: %s (%s)
-            //PhInitFormatS(&format[0], L"Service started: ");
-            PhInitFormatSR(&format[0], Entry->Service.Name->sr);
-            PhInitFormatS(&format[1], L" (");
-            PhInitFormatSR(&format[2], Entry->Service.DisplayName->sr);
-            PhInitFormatC(&format[3], L')');
-
-            //return PhFormatString(
-            //    L"Service started: %s (%s)",
-            //    Entry->Service.Name->Buffer,
-            //    Entry->Service.DisplayName->Buffer
-            //    );
-            return PhpFormatLogEntryToBuffer(format, RTL_NUMBER_OF(format));
-        }
     case PH_LOG_ENTRY_SERVICE_STOP:
-        {
-            PH_FORMAT format[4];
-
-            // Service stopped: %s (%s)
-            //PhInitFormatS(&format[0], L"Service stopped: ");
-            PhInitFormatSR(&format[0], Entry->Service.Name->sr);
-            PhInitFormatS(&format[1], L" (");
-            PhInitFormatSR(&format[2], Entry->Service.DisplayName->sr);
-            PhInitFormatC(&format[3], L')');
-
-            //return PhFormatString(
-            //    L"Service stopped: %s (%s)",
-            //    Entry->Service.Name->Buffer,
-            //    Entry->Service.DisplayName->Buffer
-            //    );
-            return PhpFormatLogEntryToBuffer(format, RTL_NUMBER_OF(format));
-        }
     case PH_LOG_ENTRY_SERVICE_CONTINUE:
-        {
-            PH_FORMAT format[4];
-
-            // Service continued: %s (%s)
-            //PhInitFormatS(&format[0], L"Service continued: ");
-            PhInitFormatSR(&format[0], Entry->Service.Name->sr);
-            PhInitFormatS(&format[1], L" (");
-            PhInitFormatSR(&format[2], Entry->Service.DisplayName->sr);
-            PhInitFormatC(&format[3], L')');
-
-            //return PhFormatString(
-            //    L"Service continued: %s (%s)",
-            //    Entry->Service.Name->Buffer,
-            //    Entry->Service.DisplayName->Buffer
-            //    );
-            return PhpFormatLogEntryToBuffer(format, RTL_NUMBER_OF(format));
-        }
     case PH_LOG_ENTRY_SERVICE_PAUSE:
-        {
-            PH_FORMAT format[4];
-
-            // Service paused: %s (%s)
-            //PhInitFormatS(&format[0], L"Service paused: ");
-            PhInitFormatSR(&format[0], Entry->Service.Name->sr);
-            PhInitFormatS(&format[1], L" (");
-            PhInitFormatSR(&format[2], Entry->Service.DisplayName->sr);
-            PhInitFormatC(&format[3], L')');
-
-            //return PhFormatString(
-            //    L"Service paused: %s (%s)",
-            //    Entry->Service.Name->Buffer,
-            //    Entry->Service.DisplayName->Buffer
-            //    );
-            return PhpFormatLogEntryToBuffer(format, RTL_NUMBER_OF(format));
-        }
     case PH_LOG_ENTRY_SERVICE_MODIFIED:
         {
-            PH_FORMAT format[4];
-
-            // Service modified: %s (%s)
-            //PhInitFormatS(&format[0], L"Service modified: ");
-            PhInitFormatSR(&format[0], Entry->Service.Name->sr);
-            PhInitFormatS(&format[1], L" (");
-            PhInitFormatSR(&format[2], Entry->Service.DisplayName->sr);
-            PhInitFormatC(&format[3], L')');
-
-            //return PhFormatString(
-            //    L"Service modified: %s (%s)",
-            //    Entry->Service.Name->Buffer,
-            //    Entry->Service.DisplayName->Buffer
-            //    );
-            return PhpFormatLogEntryToBuffer(format, RTL_NUMBER_OF(format));
+            return PhpFormatServiceLogEntry(Entry);
         }
     case PH_LOG_ENTRY_DEVICE_REMOVED:
         {

--- a/SystemInformer/mwpgproc.c
+++ b/SystemInformer/mwpgproc.c
@@ -1129,32 +1129,43 @@ VOID PhMwpOnProcessAdded(
         {
             if (!PhPluginsEnabled || !PhMwpPluginNotifyEvent(PH_NOTIFY_PROCESS_CREATE, ProcessItem))
             {
-                PH_FORMAT format[9];
+                PH_FORMAT format[20];
+                ULONG count = 0;
                 WCHAR formatBuffer[260];
+                PPH_STRING processString = !PhIsNullOrEmptyString(ProcessItem->CommandLine) ? ProcessItem->CommandLine : ProcessItem->ProcessName;
 
                 PhMwpClearLastNotificationDetails();
                 PhMwpLastNotificationType = PH_NOTIFY_PROCESS_CREATE;
                 PhMwpLastNotificationDetails.ProcessId = ProcessItem->ProcessId;
 
-                // The process %s (%lu) was created by %s (%lu)
-                PhInitFormatS(&format[0], L"The process ");
-                PhInitFormatSR(&format[1], ProcessItem->ProcessName->sr);
-                PhInitFormatS(&format[2], L" (");
-                PhInitFormatU(&format[3], HandleToUlong(ProcessItem->ProcessId));
-                PhInitFormatS(&format[4], L") was created by ");
-                PhInitFormatS(&format[5], PhGetStringOrDefault(parentName, L"Unknown process")); // todo: SR type (dmex)
-                PhInitFormatS(&format[6], L" (");
-                PhInitFormatU(&format[7], HandleToUlong(ProcessItem->ParentProcessId));
-                PhInitFormatC(&format[8], L')');
+                // The process %s (%lu) (v%s) was created by %s (%lu)
+                PhInitFormatS(&format[count++], L"The process ");
+                PhInitFormatSR(&format[count++], processString->sr);
+                PhInitFormatS(&format[count++], L" (");
+                PhInitFormatU(&format[count++], HandleToUlong(ProcessItem->ProcessId));
+                PhInitFormatC(&format[count++], L')');
 
-                if (PhFormatToBuffer(format, RTL_NUMBER_OF(format), formatBuffer, sizeof(formatBuffer), NULL))
+                if (PhCsEnableVersionSupport && !PhIsNullOrEmptyString(ProcessItem->VersionInfo.FileVersion))
+                {
+                    PhInitFormatS(&format[count++], L" (v");
+                    PhInitFormatSR(&format[count++], ProcessItem->VersionInfo.FileVersion->sr);
+                    PhInitFormatC(&format[count++], L')');
+                }
+
+                PhInitFormatS(&format[count++], L" was created by ");
+                PhInitFormatS(&format[count++], PhGetStringOrDefault(parentName, L"Unknown process"));
+                PhInitFormatS(&format[count++], L" (");
+                PhInitFormatU(&format[count++], HandleToUlong(ProcessItem->ParentProcessId));
+                PhInitFormatC(&format[count++], L')');
+
+                if (PhFormatToBuffer(format, count, formatBuffer, sizeof(formatBuffer), NULL))
                 {
                     PhShowIconNotification(L"Process Created", formatBuffer);
                 }
                 else
                 {
                     PhShowIconNotification(L"Process Created",
-                        PH_AUTO_T(PH_STRING, PhFormat(format, RTL_NUMBER_OF(format), 0))->Buffer);
+                        PH_AUTO_T(PH_STRING, PhFormat(format, count, 0))->Buffer);
                 }
             }
         }

--- a/SystemInformer/mwpgsrv.c
+++ b/SystemInformer/mwpgsrv.c
@@ -455,6 +455,52 @@ VOID NTAPI PhMwpServicesUpdatedHandler(
     SystemInformer_Invoke(PhMwpOnServicesUpdated, PhGetRunIdProvider(&PhMwpServiceProviderRegistration));
 }
 
+static VOID PhpFormatServiceNotificationText(
+    _In_ PPH_SERVICE_ITEM ServiceItem,
+    _In_ PCWSTR ActionText,
+    _Out_writes_bytes_(BufferLength) PWSTR Buffer,
+    _In_ SIZE_T BufferLength
+    )
+{
+    PH_FORMAT format[16];
+    ULONG count = 0;
+    PPH_STRING version = NULL;
+    PH_IMAGE_VERSION_INFO versionInfo = { 0 };
+
+    if (PhCsEnableVersionSupport && !PhIsNullOrEmptyString(ServiceItem->FileName))
+    {
+        if (NT_SUCCESS(PhInitializeImageVersionInfoCached(&versionInfo, ServiceItem->FileName, FALSE, !!PhCsEnableVersionSupport)))
+        {
+            if (!PhIsNullOrEmptyString(versionInfo.FileVersion))
+                version = versionInfo.FileVersion;
+        }
+    }
+
+    PhInitFormatS(&format[count++], L"The service ");
+    PhInitFormatSR(&format[count++], ServiceItem->Name->sr);
+    PhInitFormatS(&format[count++], L" (");
+    PhInitFormatSR(&format[count++], ServiceItem->DisplayName->sr);
+    PhInitFormatC(&format[count++], L')');
+
+    if (!PhIsNullOrEmptyString(version))
+    {
+        PhInitFormatS(&format[count++], L" (v");
+        PhInitFormatSR(&format[count++], version->sr);
+        PhInitFormatC(&format[count++], L')');
+    }
+
+    PhInitFormatS(&format[count++], ActionText);
+
+    if (!PhFormatToBuffer(format, count, Buffer, BufferLength, NULL))
+    {
+        PPH_STRING str = PhFormat(format, count, 0);
+        wcsncpy_s(Buffer, BufferLength / sizeof(WCHAR), str->Buffer, _TRUNCATE);
+        PhDereferenceObject(str);
+    }
+
+    PhDeleteImageVersionInfo(&versionInfo);
+}
+
 VOID PhMwpOnServiceAdded(
     _In_ _Assume_refs_(1) PPH_SERVICE_ITEM ServiceItem,
     _In_ ULONG RunId
@@ -467,35 +513,20 @@ VOID PhMwpOnServiceAdded(
 
     if (RunId != 1)
     {
-        PhLogServiceEntry(PH_LOG_ENTRY_SERVICE_CREATE, ServiceItem->Name, ServiceItem->DisplayName);
+        PhLogServiceEntry(PH_LOG_ENTRY_SERVICE_CREATE, ServiceItem->Name, ServiceItem->DisplayName, ServiceItem->FileName);
 
         if (FlagOn(PhMwpNotifyIconNotifyMask, PH_NOTIFY_SERVICE_CREATE))
         {
             if (!PhPluginsEnabled || !PhMwpPluginNotifyEvent(PH_NOTIFY_SERVICE_CREATE, ServiceItem))
             {
-                PH_FORMAT format[5];
                 WCHAR formatBuffer[260];
 
                 PhMwpClearLastNotificationDetails();
                 PhMwpLastNotificationType = PH_NOTIFY_SERVICE_CREATE;
                 PhSwapReference(&PhMwpLastNotificationDetails.ServiceName, ServiceItem->Name);
 
-                // The service %s (%s) has been created.
-                PhInitFormatS(&format[0], L"The service ");
-                PhInitFormatSR(&format[1], ServiceItem->Name->sr);
-                PhInitFormatS(&format[2], L" (");
-                PhInitFormatSR(&format[3], ServiceItem->DisplayName->sr);
-                PhInitFormatS(&format[4], L") was created");
-
-                if (PhFormatToBuffer(format, RTL_NUMBER_OF(format), formatBuffer, sizeof(formatBuffer), NULL))
-                {
-                    PhShowIconNotification(L"Service Created", formatBuffer);
-                }
-                else
-                {
-                    PhShowIconNotification(L"Service Created",
-                        PH_AUTO_T(PH_STRING, PhFormat(format, RTL_NUMBER_OF(format), 0))->Buffer);
-                }
+                PhpFormatServiceNotificationText(ServiceItem, L" was created", formatBuffer, sizeof(formatBuffer));
+                PhShowIconNotification(L"Service Created", formatBuffer);
             }
         }
     }
@@ -538,7 +569,7 @@ VOID PhMwpOnServiceModified(
     }
 
     if (logEntryType != 0)
-        PhLogServiceEntry(logEntryType, ServiceModifiedData->ServiceItem->Name, ServiceModifiedData->ServiceItem->DisplayName);
+        PhLogServiceEntry(logEntryType, ServiceModifiedData->ServiceItem->Name, ServiceModifiedData->ServiceItem->DisplayName, ServiceModifiedData->ServiceItem->FileName);
 
     if (FlagOn(PhMwpNotifyIconNotifyMask, PH_NOTIFY_SERVICE_START | PH_NOTIFY_SERVICE_STOP | PH_NOTIFY_SERVICE_MODIFIED))
     {
@@ -550,87 +581,42 @@ VOID PhMwpOnServiceModified(
         {
             if (!PhPluginsEnabled || !PhMwpPluginNotifyEvent(PH_NOTIFY_SERVICE_START, serviceItem))
             {
-                PH_FORMAT format[5];
                 WCHAR formatBuffer[260];
 
                 PhMwpClearLastNotificationDetails();
                 PhMwpLastNotificationType = PH_NOTIFY_SERVICE_START;
                 PhSwapReference(&PhMwpLastNotificationDetails.ServiceName, serviceItem->Name);
 
-                // The service %s (%s) has been started.
-                PhInitFormatS(&format[0], L"The service ");
-                PhInitFormatSR(&format[1], serviceItem->Name->sr);
-                PhInitFormatS(&format[2], L" (");
-                PhInitFormatSR(&format[3], serviceItem->DisplayName->sr);
-                PhInitFormatS(&format[4], L") was started");
-
-                if (PhFormatToBuffer(format, RTL_NUMBER_OF(format), formatBuffer, sizeof(formatBuffer), NULL))
-                {
-                    PhShowIconNotification(L"Service Started", formatBuffer);
-                }
-                else
-                {
-                    PhShowIconNotification(L"Service Started",
-                        PH_AUTO_T(PH_STRING, PhFormat(format, RTL_NUMBER_OF(format), 0))->Buffer);
-                }
+                PhpFormatServiceNotificationText(serviceItem, L" was started", formatBuffer, sizeof(formatBuffer));
+                PhShowIconNotification(L"Service Started", formatBuffer);
             }
         }
         else if (serviceChange == ServiceStopped && FlagOn(PhMwpNotifyIconNotifyMask, PH_NOTIFY_SERVICE_STOP))
         {
             if (!PhPluginsEnabled || !PhMwpPluginNotifyEvent(PH_NOTIFY_SERVICE_STOP, serviceItem))
             {
-                PH_FORMAT format[5];
                 WCHAR formatBuffer[260];
 
                 PhMwpClearLastNotificationDetails();
                 PhMwpLastNotificationType = PH_NOTIFY_SERVICE_STOP;
                 PhSwapReference(&PhMwpLastNotificationDetails.ServiceName, serviceItem->Name);
 
-                // The service %s (%s) has been stopped.
-                PhInitFormatS(&format[0], L"The service ");
-                PhInitFormatSR(&format[1], serviceItem->Name->sr);
-                PhInitFormatS(&format[2], L" (");
-                PhInitFormatSR(&format[3], serviceItem->DisplayName->sr);
-                PhInitFormatS(&format[4], L") was stopped");
-
-                if (PhFormatToBuffer(format, RTL_NUMBER_OF(format), formatBuffer, sizeof(formatBuffer), NULL))
-                {
-                    PhShowIconNotification(L"Service Stopped", formatBuffer);
-                }
-                else
-                {
-                    PhShowIconNotification(L"Service Stopped",
-                        PH_AUTO_T(PH_STRING, PhFormat(format, RTL_NUMBER_OF(format), 0))->Buffer);
-                }
+                PhpFormatServiceNotificationText(serviceItem, L" was stopped", formatBuffer, sizeof(formatBuffer));
+                PhShowIconNotification(L"Service Stopped", formatBuffer);
             }
         }
         else if (serviceChange == ServiceModified && FlagOn(PhMwpNotifyIconNotifyMask, PH_NOTIFY_SERVICE_MODIFIED))
         {
             if (!PhPluginsEnabled || !PhMwpPluginNotifyEvent(PH_NOTIFY_SERVICE_MODIFIED, serviceItem))
             {
-                PH_FORMAT format[5];
                 WCHAR formatBuffer[260];
 
                 PhMwpClearLastNotificationDetails();
                 PhMwpLastNotificationType = PH_NOTIFY_SERVICE_MODIFIED;
                 PhSwapReference(&PhMwpLastNotificationDetails.ServiceName, serviceItem->Name);
 
-                // The service %s (%s) has been modified.
-                PhInitFormatS(&format[0], L"The service ");
-                PhInitFormatSR(&format[1], serviceItem->Name->sr);
-                PhInitFormatS(&format[2], L" (");
-                PhInitFormatSR(&format[3], serviceItem->DisplayName->sr);
-                PhInitFormatS(&format[4], L") was modified");
-
-                if (PhFormatToBuffer(format, RTL_NUMBER_OF(format), formatBuffer, sizeof(formatBuffer), NULL))
-                {
-                    PhShowIconNotification(L"Service Modified", formatBuffer);
-                }
-                else
-                {
-                    PhShowIconNotification(L"Service Modified",
-                        PH_AUTO_T(PH_STRING, PhFormat(format, RTL_NUMBER_OF(format), 0))->Buffer);
-                }
+                PhpFormatServiceNotificationText(serviceItem, L" was modified", formatBuffer, sizeof(formatBuffer));
+                PhShowIconNotification(L"Service Modified", formatBuffer);
             }
         }
     }
@@ -642,35 +628,20 @@ VOID PhMwpOnServiceRemoved(
     _In_ PPH_SERVICE_ITEM ServiceItem
     )
 {
-    PhLogServiceEntry(PH_LOG_ENTRY_SERVICE_DELETE, ServiceItem->Name, ServiceItem->DisplayName);
+    PhLogServiceEntry(PH_LOG_ENTRY_SERVICE_DELETE, ServiceItem->Name, ServiceItem->DisplayName, ServiceItem->FileName);
 
     if (FlagOn(PhMwpNotifyIconNotifyMask, PH_NOTIFY_SERVICE_DELETE))
     {
         if (!PhPluginsEnabled || !PhMwpPluginNotifyEvent(PH_NOTIFY_SERVICE_DELETE, ServiceItem))
         {
-            PH_FORMAT format[5];
             WCHAR formatBuffer[260];
 
             PhMwpClearLastNotificationDetails();
             PhMwpLastNotificationType = PH_NOTIFY_SERVICE_DELETE;
             PhSwapReference(&PhMwpLastNotificationDetails.ServiceName, ServiceItem->Name);
 
-            // The service %s (%s) has been deleted.
-            PhInitFormatS(&format[0], L"The service ");
-            PhInitFormatSR(&format[1], ServiceItem->Name->sr);
-            PhInitFormatS(&format[2], L" (");
-            PhInitFormatSR(&format[3], ServiceItem->DisplayName->sr);
-            PhInitFormatS(&format[4], L") was deleted");
-
-            if (PhFormatToBuffer(format, RTL_NUMBER_OF(format), formatBuffer, sizeof(formatBuffer), NULL))
-            {
-                PhShowIconNotification(L"Service Deleted", formatBuffer);
-            }
-            else
-            {
-                PhShowIconNotification(L"Service Deleted",
-                    PH_AUTO_T(PH_STRING, PhFormat(format, RTL_NUMBER_OF(format), 0))->Buffer);
-            }
+            PhpFormatServiceNotificationText(ServiceItem, L" was deleted", formatBuffer, sizeof(formatBuffer));
+            PhShowIconNotification(L"Service Deleted", formatBuffer);
         }
     }
 

--- a/SystemInformer/procprv.c
+++ b/SystemInformer/procprv.c
@@ -1274,6 +1274,8 @@ VOID PhpFillProcessItemStage1(
     processItem->IsPowerThrottling = Data->PowerThrottling;
 
     PhSwapReference(&processItem->Record->CommandLine, processItem->CommandLine);
+    if (!processItem->Record->FileVersion && processItem->VersionInfo.FileVersion)
+        PhSetReference(&processItem->Record->FileVersion, processItem->VersionInfo.FileVersion);
 
     // Note: We might have referenced the cached username so don't overwrite the previous data. (dmex)
     if (!processItem->UserName)
@@ -3696,6 +3698,7 @@ PPH_PROCESS_RECORD PhpCreateProcessRecord(
     PhSetReference(&processRecord->ProcessName, ProcessItem->ProcessName);
     PhSetReference(&processRecord->FileName, ProcessItem->FileName);
     PhSetReference(&processRecord->CommandLine, ProcessItem->CommandLine);
+    PhSetReference(&processRecord->FileVersion, ProcessItem->VersionInfo.FileVersion);
     //PhSetReference(&processRecord->UserName, ProcessItem->UserName);
 
     return processRecord;
@@ -3857,6 +3860,7 @@ VOID PhDereferenceProcessRecord(
         PhDereferenceObject(ProcessRecord->ProcessName);
         if (ProcessRecord->FileName) PhDereferenceObject(ProcessRecord->FileName);
         if (ProcessRecord->CommandLine) PhDereferenceObject(ProcessRecord->CommandLine);
+        if (ProcessRecord->FileVersion) PhDereferenceObject(ProcessRecord->FileVersion);
         /*if (ProcessRecord->UserName) PhDereferenceObject(ProcessRecord->UserName);*/
         PhFree(ProcessRecord);
     }


### PR DESCRIPTION
## Description

### Summary

This pull request resolves #2064 and resolves #2819 by adding process start command lines and file version information into logging and notification popups.

- **Process Command Line** (Resolves #2819):
  - Formats full process command-line arguments (`ProcessItem->CommandLine` / `Record->CommandLine`) in process creation notifications and log entries when available.

- **File Version Information** (Resolves #2064):
  - Extends `PH_PROCESS_RECORD` to reference `FileVersion`.
  - Extends `PH_LOG_ENTRY`'s Service structure to reference `FileName`.
  - Displays file version information `(vX.X.X.X)` in process creation & termination log entries as well as service log entries (create, delete, start, stop, continue, pause, modified).
  - Displays file version information `(vX.X.X.X)` in process creation and service notification popups when `EnableVersionSupport` is enabled.

### Fixes
- Resolves #2064
- Resolves #2819
