### PR TITLE
feat(i18n): Add localization infrastructure and language switching

### DIFF
--- a/SystemInformer/include/phsettings.h
+++ b/SystemInformer/include/phsettings.h
@@ -276,6 +276,7 @@ EXT ULONG PhCsProcessMonitorCacheLimit;
 #define SETTING_ENABLE_SHUTDOWN_BOOT_MENU                           L"EnableShutdownBootMenu"
 #define SETTING_ENABLE_SILENT_CRASH_NOTIFY                          L"EnableSilentCrashNotify"
 #define SETTING_ENABLE_THEME_SUPPORT                                L"EnableThemeSupport"
+#define SETTING_LANGUAGE                                            L"Language"
 #define SETTING_THEME_MODE                                          L"ThemeMode"
 #define SETTING_THEME_MODE_MIGRATED                                 L"ThemeModeMigrated"
 #define SETTING_SCROLLBAR_THEME                                     L"ScrollBarTheme"

--- a/SystemInformer/main.c
+++ b/SystemInformer/main.c
@@ -118,6 +118,7 @@ INT WINAPI wWinMain(
 
     PhInitializeAppSystem();
     PhEmInitialization();
+    PhInitializeI18n();
 
     if (PhStartupParameters.ShowOptions)
     {

--- a/SystemInformer/mainwnd.c
+++ b/SystemInformer/mainwnd.c
@@ -1355,6 +1355,18 @@ VOID PhMwpOnCommand(
     case ID_VIEW_SYSTEMINFORMATION:
         PhShowSystemInformationDialog(NULL);
         break;
+    case ID_LANGUAGE_EN_US:
+        PhSetCurrentLanguage(L"en-US");
+        PhSetStringSetting(L"Language", L"en-US");
+        PhMwpInitializeMainMenu(WindowHandle);
+        DrawMenuBar(WindowHandle);
+        break;
+    case ID_LANGUAGE_ZH_CN:
+        PhSetCurrentLanguage(L"zh-CN");
+        PhSetStringSetting(L"Language", L"zh-CN");
+        PhMwpInitializeMainMenu(WindowHandle);
+        DrawMenuBar(WindowHandle);
+        break;
     case ID_NOTIFICATIONS_ENABLEALL:
     case ID_NOTIFICATIONS_DISABLEALL:
     case ID_NOTIFICATIONS_NEWPROCESSES:
@@ -3723,6 +3735,19 @@ PPH_EMENU PhpCreateViewMenu(
 
     PhInsertEMenuItem(ViewMenu, PhCreateEMenuItem(0, ID_VIEW_UPDATEAUTOMATICALLY, L"Refresh a&utomatically\bF6", NULL, NULL), ULONG_MAX);
 
+    menuItem = PhCreateEMenuItem(0, 0, PH_I18N(L"&Language"), NULL, NULL);
+    {
+        PPH_EMENU_ITEM itemEn = PhCreateEMenuItem(0, ID_LANGUAGE_EN_US, L"English", NULL, NULL);
+        PPH_EMENU_ITEM itemZh = PhCreateEMenuItem(0, ID_LANGUAGE_ZH_CN, L"简体中文", NULL, NULL);
+        if (PhEqualStringZ(PhGetCurrentLanguage(), L"en-US", TRUE))
+            itemEn->Flags |= PH_EMENU_CHECKED;
+        else
+            itemZh->Flags |= PH_EMENU_CHECKED;
+        PhInsertEMenuItem(menuItem, itemEn, ULONG_MAX);
+        PhInsertEMenuItem(menuItem, itemZh, ULONG_MAX);
+    }
+    PhInsertEMenuItem(ViewMenu, menuItem, ULONG_MAX);
+
     return ViewMenu;
 }
 
@@ -3846,31 +3871,31 @@ PPH_EMENU PhpCreateMainMenu(
             PPH_EMENU_ITEM menuItem;
             menu->Flags |= PH_EMENU_MAINMENU;
 
-            menuItem = PhCreateEMenuItem(PH_EMENU_MAINMENU, PH_MENU_ITEM_LOCATION_SYSTEM, L"&System", NULL, NULL);
+            menuItem = PhCreateEMenuItem(PH_EMENU_MAINMENU, PH_MENU_ITEM_LOCATION_SYSTEM, PH_I18N(L"&System"), NULL, NULL);
             // Insert an empty menuitem so we're able to delay load the submenu. (dmex)
             PhInsertEMenuItem(menuItem, PhCreateEMenuItemEmpty(), ULONG_MAX);
             PhInsertEMenuItem(menu, menuItem, ULONG_MAX);
             //PhInsertEMenuItem(menu, PhpCreateSystemMenu(menuItem, TRUE), ULONG_MAX);
 
-            menuItem = PhCreateEMenuItem(PH_EMENU_MAINMENU, PH_MENU_ITEM_LOCATION_VIEW, L"&View", NULL, NULL);
+            menuItem = PhCreateEMenuItem(PH_EMENU_MAINMENU, PH_MENU_ITEM_LOCATION_VIEW, PH_I18N(L"&View"), NULL, NULL);
             // Insert an empty menuitem so we're able to delay load the submenu. (dmex)
             PhInsertEMenuItem(menuItem, PhCreateEMenuItemEmpty(), ULONG_MAX);
             PhInsertEMenuItem(menu, menuItem, ULONG_MAX);
             //PhInsertEMenuItem(menu, PhpCreateViewMenu(menuItem), ULONG_MAX);
 
-            menuItem = PhCreateEMenuItem(PH_EMENU_MAINMENU, PH_MENU_ITEM_LOCATION_TOOLS, L"&Tools", NULL, NULL);
+            menuItem = PhCreateEMenuItem(PH_EMENU_MAINMENU, PH_MENU_ITEM_LOCATION_TOOLS, PH_I18N(L"&Tools"), NULL, NULL);
             // Insert an empty menuitem so we're able to delay load the submenu. (dmex)
             PhInsertEMenuItem(menuItem, PhCreateEMenuItemEmpty(), ULONG_MAX);
             PhInsertEMenuItem(menu, menuItem, ULONG_MAX);
             //PhInsertEMenuItem(menu, PhpCreateToolsMenu(menuItem), ULONG_MAX);
 
-            menuItem = PhCreateEMenuItem(PH_EMENU_MAINMENU, PH_MENU_ITEM_LOCATION_USERS, L"&Users", NULL, NULL);
+            menuItem = PhCreateEMenuItem(PH_EMENU_MAINMENU, PH_MENU_ITEM_LOCATION_USERS, PH_I18N(L"&Users"), NULL, NULL);
             // Insert an empty menuitem so we're able to delay load the submenu. (dmex)
             PhInsertEMenuItem(menuItem, PhCreateEMenuItemEmpty(), ULONG_MAX);
             PhInsertEMenuItem(menu, menuItem, ULONG_MAX);
             //PhInsertEMenuItem(menu, PhpCreateUsersMenu(menuItem, TRUE), ULONG_MAX);
 
-            menuItem = PhCreateEMenuItem(PH_EMENU_MAINMENU, PH_MENU_ITEM_LOCATION_HELP, L"&Help", NULL, NULL);
+            menuItem = PhCreateEMenuItem(PH_EMENU_MAINMENU, PH_MENU_ITEM_LOCATION_HELP, PH_I18N(L"&Help"), NULL, NULL);
             // Insert an empty menuitem so we're able to delay load the submenu. (dmex)
             PhInsertEMenuItem(menuItem, PhCreateEMenuItemEmpty(), ULONG_MAX);
             PhInsertEMenuItem(menu, menuItem, ULONG_MAX);

--- a/SystemInformer/resource.h
+++ b/SystemInformer/resource.h
@@ -790,6 +790,8 @@
 #define ID_THREAD_FREEZE                10086
 #define ID_THREAD_THAW                  10087
 #define ID_VIEW_SYSTEMINFORMATION       10091
+#define ID_LANGUAGE_EN_US               60001
+#define ID_LANGUAGE_ZH_CN               60002
 #define ID_TRAYICONS_CPUHISTORY         10093
 #define ID_TRAYICONS_CPUUSAGE           10094
 #define ID_TRAYICONS_COMMITHISTORY      10096

--- a/SystemInformer/settings.c
+++ b/SystemInformer/settings.c
@@ -75,6 +75,7 @@ VOID PhAddDefaultSettings(
     PhpAddIntegerSetting(SETTING_ENABLE_SHUTDOWN_BOOT_MENU, L"1");
     PhpAddIntegerSetting(SETTING_ENABLE_SILENT_CRASH_NOTIFY, L"0");
     PhpAddIntegerSetting(SETTING_ENABLE_THEME_SUPPORT, L"0");
+    PhpAddStringSetting(SETTING_LANGUAGE, L"");
     PhpAddIntegerSetting(SETTING_THEME_MODE, L"0"); // PhThemeModeAutomatic
     PhpAddIntegerSetting(SETTING_ENABLE_THEME_ACRYLIC_SUPPORT, L"0");
     PhpAddIntegerSetting(SETTING_ENABLE_THEME_ACRYLIC_WINDOW_SUPPORT, L"0");

--- a/phlib/i18n.c
+++ b/phlib/i18n.c
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2022 Winsider Seminars & Solutions, Inc.  All rights reserved.
+ *
+ * This file is part of System Informer.
+ *
+ * Authors:
+ *
+ *     tianxing    2026
+ *
+ */
+
+#include <ph.h>
+#include <guisup.h>
+#include <settings.h>
+#include <phi18n.h>
+
+// Default language initialization
+static WCHAR PhCurrentLanguageCode[16] = L"en-US";
+
+/**
+ * Initializes the multi-language engine and detects system UI language
+ */
+PHLIBAPI
+VOID
+NTAPI
+PhInitializeI18n(
+    VOID
+    )
+{
+    const PPH_STRING languageSetting = PhGetStringSetting(L"Language");
+    if (!PhIsNullOrEmptyString(languageSetting))
+    {
+        wcsncpy_s(PhCurrentLanguageCode, sizeof(PhCurrentLanguageCode) / sizeof(WCHAR), languageSetting->Buffer, _TRUNCATE);
+        PhDereferenceObject(languageSetting);
+    }
+    else
+    {
+        LANGID langId = GetUserDefaultUILanguage();
+        if (PRIMARYLANGID(langId) == LANG_CHINESE)
+        {
+            wcsncpy_s(PhCurrentLanguageCode, sizeof(PhCurrentLanguageCode) / sizeof(WCHAR), L"zh-CN", _TRUNCATE);
+        }
+        else
+        {
+            wcsncpy_s(PhCurrentLanguageCode, sizeof(PhCurrentLanguageCode) / sizeof(WCHAR), L"en-US", _TRUNCATE);
+        }
+    }
+}
+
+// Built-in initial localization dictionary
+static PH_I18N_ENTRY PhChineseTranslations[] =
+{
+    { L"&System", L"系统" },
+    { L"&View", L"视图" },
+    { L"&Tools", L"工具" },
+    { L"&Users", L"用户" },
+    { L"&Help", L"帮助" },
+    { L"&Language", L"语言" },
+    { L"English", L"English" },
+    { L"简体中文", L"简体中文" }
+};
+
+PHLIBAPI
+PCWSTR
+NTAPI
+PhGetLocalizedString(
+    _In_ const PCWSTR String
+    )
+{
+    if (!String)
+        return String;
+
+    // Fallback directly to original English string if active language is en-US
+    if (PhEqualStringZ(PhCurrentLanguageCode, L"en-US", TRUE))
+    {
+        return String;
+    }
+
+    // Lookup in active translation table
+    for (ULONG i = 0; i < sizeof(PhChineseTranslations) / sizeof(PhChineseTranslations[0]); i++)
+    {
+        if (PhEqualStringZ(String, PhChineseTranslations[i].Key, FALSE))
+        {
+            return PhChineseTranslations[i].Value;
+        }
+    }
+
+    // Fallback to original string if no translation match is found
+    return String;
+}
+
+/**
+ * Sets current active language code
+ */
+PHLIBAPI
+VOID
+NTAPI
+PhSetCurrentLanguage(
+    _In_ const PCWSTR LanguageCode
+    )
+{
+    if (LanguageCode)
+    {
+        wcsncpy_s(PhCurrentLanguageCode, sizeof(PhCurrentLanguageCode) / sizeof(WCHAR), LanguageCode, _TRUNCATE);
+    }
+}
+
+/**
+ * Retrieves current active language code
+ */
+PHLIBAPI
+PCWSTR
+NTAPI
+PhGetCurrentLanguage(
+    VOID
+    )
+{
+    return PhCurrentLanguageCode;
+}

--- a/phlib/include/ph.h
+++ b/phlib/include/ph.h
@@ -17,5 +17,6 @@
 #include <phnative.h>
 #include <phnativeinl.h>
 #include <phutil.h>
+#include <phi18n.h>
 
 #endif

--- a/phlib/include/phi18n.h
+++ b/phlib/include/phi18n.h
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2022 Winsider Seminars & Solutions, Inc.  All rights reserved.
+ *
+ * This file is part of System Informer.
+ *
+ * Authors:
+ *
+ *     tianxing    2026
+ *
+ */
+
+#ifndef PH_PHI18N_H
+#define PH_PHI18N_H
+
+EXTERN_C_START
+
+typedef struct PH_I18N_ENTRY
+{
+    PCWSTR Key;
+    PCWSTR Value;
+} PH_I18N_ENTRY, *PPH_I18N_ENTRY;
+
+/**
+ * Initializes the multi-language engine and automatically detects the Windows system UI language
+ */
+PHLIBAPI
+VOID
+NTAPI
+PhInitializeI18n(
+    VOID
+    );
+
+/**
+ * Retrieves the localized version of the specified string
+ *
+ * \param String Input string to look up
+ * \return Localized string pointer or original string
+ */
+PHLIBAPI
+PCWSTR
+NTAPI
+PhGetLocalizedString(
+    _In_ PCWSTR String
+    );
+
+/**
+ * Dynamically sets the current active language code
+ *
+ * \param LanguageCode Target language code string
+ */
+PHLIBAPI
+VOID
+NTAPI
+PhSetCurrentLanguage(
+    _In_ PCWSTR LanguageCode
+    );
+
+/**
+ * Retrieves the current active language code
+ *
+ * \return Pointer to the current language code string
+ */
+PHLIBAPI
+PCWSTR
+NTAPI
+PhGetCurrentLanguage(
+    VOID
+    );
+
+#define PH_I18N(String) PhGetLocalizedString(String)
+
+EXTERN_C_END
+
+#endif

--- a/phlib/phlib.vcxproj
+++ b/phlib/phlib.vcxproj
@@ -238,8 +238,10 @@
     <ClCompile Include="verify.c" />
     <ClCompile Include="workqueue.c" />
     <ClCompile Include="wslsup.c" />
+    <ClCompile Include="i18n.c" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="include\phi18n.h" />
     <ClInclude Include="include\apiimport.h" />
     <ClInclude Include="include\appresolver.h" />
     <ClInclude Include="include\appresolverp.h" />


### PR DESCRIPTION
- Add i18n module supporting language initialization and system UI language detection
- Implement string localization interface with built-in translation dictionary
- Initialize multi-language engine during application startup
- Add language options in menu bar supporting switching between "English" and "Simplified Chinese"
- Update menu bar dynamically and persist language choice into settings on language switch
- Refactor menu creation logic to replace static text with localized strings
- Add "Language" configuration item in system settings for persistent selection
- Update project solution files to include new i18n source and header files