### PR TITLE
phnt: NtRaiseHardError is never noreturn

### DIFF
--- a/phnt/include/ntexapi.h
+++ b/phnt/include/ntexapi.h
@@ -8718,8 +8718,6 @@ typedef enum _HARDERROR_RESPONSE
  * \param[out] Response Receives the user's response to the error dialog.
  * \return NTSTATUS Successful or errant status.
  */
-_Analysis_noreturn_
-DECLSPEC_NORETURN
 _Kernel_entry_
 NTSYSCALLAPI
 NTSTATUS


### PR DESCRIPTION
NtRaiseHardError only sends a message over the error port and does not handle process exiting. Fixes miscompile on optimizing compilers.