### PR TITLE
phnt: Fix WinSta ABI declarations and add verified private exports

### DIFF
--- a/phnt/include/winsta.h
+++ b/phnt/include/winsta.h
@@ -80,6 +80,7 @@
 #define CLIENT_PRODUCT_ID_LENGTH 32
 #define MAX_COUNTER_EXTENSIONS 2
 #define WINSTATIONNAME_LENGTH 32
+#define WINSTATIONCOMMENT_LENGTH 60
 
 #define TERMSRV_TOTAL_SESSIONS 1
 #define TERMSRV_DISC_SESSIONS 2
@@ -130,6 +131,17 @@ typedef struct _SESSIONIDW
     WINSTATIONSTATECLASS State;
 } SESSIONIDW, *PSESSIONIDW;
 
+typedef struct _SESSIONIDA
+{
+    union
+    {
+        ULONG SessionId;
+        ULONG LogonId;
+    };
+    CHAR WinStationName[WINSTATIONNAME_LENGTH + 1];
+    WINSTATIONSTATECLASS State;
+} SESSIONIDA, *PSESSIONIDA;
+
 /**
  * The WINSTATIONINFOCLASS enumeration indicates the class of data for which to either query or set on the server.
  *
@@ -140,12 +152,12 @@ typedef struct _SESSIONIDW
 typedef enum _WINSTATIONINFOCLASS
 {
     WinStationCreateData,                   // q: WINSTATIONCREATE
-    WinStationConfiguration,                // qs: WINSTACONFIGWIRE + USERCONFIG
-    WinStationPdParams,                     // qs: PDPARAMSWIRE + PDPARAMS
+    WinStationConfiguration,                // q: WINSTATIONCONFIG; legacy RPC qs: WINSTACONFIGWIRE + USERCONFIG
+    WinStationPdParams,                     // q: PDPARAMS; legacy RPC qs: PDPARAMSWIRE + PDPARAMS
     WinStationWd,                           // q: WDCONFIG
     WinStationPd,                           // q: PDCONFIG2 + PDPARAMS
     WinStationPrinter,                      // qs: Not supported.
-    WinStationClient,                       // q: VARDATA_WIRE + WINSTATIONCLIENT
+    WinStationClient,                       // q: WINSTATIONCLIENT; legacy RPC: VARDATA_WIRE + WINSTATIONCLIENT
     WinStationModules,                      // q: UCHAR[]
     WinStationInformation,                  // q: WINSTATIONINFORMATION
     WinStationTrace,                        // s: TS_TRACE
@@ -179,7 +191,7 @@ typedef enum _WINSTATIONINFOCLASS
     WinStationReconnectedFromId,            // q: ULONG
     WinStationEffectsPolicy,                // q: ULONG
     WinStationType,                         // q: ULONG
-    WinStationInformationEx,                // q: VARDATA_WIRE + WINSTATIONINFORMATIONEX // 40
+    WinStationInformationEx,                // q: WINSTATIONINFORMATIONEX; legacy RPC adds VARDATA_WIRE // 40
     WinStationValidationInfo,               // q: UCHAR[]
     WinStationActivityId,                   // q: GUID
     MaxWinStationInfoClass
@@ -289,6 +301,14 @@ typedef struct _USERCONFIG
     WCHAR WFHomeDir[DIRECTORY_LENGTH + 1];
     WCHAR WFHomeDirDrive[4];
 } USERCONFIG, *PUSERCONFIG;
+
+// Native WinStationConfiguration buffer; no VARDATA_WIRE prefix.
+typedef struct _WINSTATIONCONFIG
+{
+    WCHAR Comment[WINSTATIONCOMMENT_LENGTH + 1];
+    USERCONFIG User;
+    CHAR OEMId[4];
+} WINSTATIONCONFIG, *PWINSTATIONCONFIG;
 
 typedef enum _SDCLASS
 {
@@ -471,6 +491,7 @@ typedef struct _WINSTATIONCLIENT
     ULONG fPasswordIsScPin : 1;
     ULONG fNoAudioPlayback : 1;
     ULONG fUsingSavedCreds : 1;
+    ULONG fRestrictedLogon : 1;
     WCHAR ClientName[CLIENTNAME_LENGTH + 1];
     WCHAR Domain[DOMAIN_LENGTH + 1];
     WCHAR UserName[USERNAME_LENGTH + 1];
@@ -943,9 +964,9 @@ typedef struct _TS_COUNTER
 #define WNOTIFY_ALL_SESSIONS 0x1
 // end_rev
 
-// In the functions below, memory returned can be freed using LocalFree. NULL can be specified for
-// server handles to indicate the local server. -1 can be specified for session IDs to indicate the
-// current session ID.
+// Close WinStationOpenServer* binding objects with WinStationCloseServer, not CloseHandle.
+// NULL selects the local server. Session ID -1 selects the current session where supported.
+// Use each API's matching free function for nested allocations.
 
 // rev
 /**
@@ -958,7 +979,7 @@ NTSYSAPI
 BOOLEAN
 NTAPI
 WinStationFreeMemory(
-    _In_ PVOID Buffer
+    _In_opt_ PVOID Buffer
     );
 
 // rev
@@ -1004,7 +1025,7 @@ NTSYSAPI
 BOOLEAN
 NTAPI
 WinStationCloseServer(
-    _In_ HANDLE ServerHandle
+    _In_opt_ HANDLE ServerHandle
     );
 
 // rev
@@ -1012,7 +1033,7 @@ NTSYSAPI
 BOOLEAN
 NTAPI
 WinStationServerPing(
-    _In_opt_ HANDLE ServerHandle
+    _In_opt_ HANDLE LicensingHandle // ServerLicensingOpenW context; NULL selects local
     );
 
 // rev
@@ -1022,7 +1043,7 @@ NTAPI
 WinStationGetTermSrvCountersValue(
     _In_opt_ HANDLE ServerHandle,
     _In_ ULONG Count,
-    _Inout_ PTS_COUNTER Counters // set counter IDs before calling
+    _Inout_updates_(Count) PTS_COUNTER Counters // set counter IDs before calling
     );
 
 // rev
@@ -1055,17 +1076,16 @@ WinStationWaitSystemEvent(
 
 // rev
 /**
- * The WinStationRegisterConsoleNotification routine shuts down (and optionally restarts) the specified Remote Desktop Session Host (RD Session Host) server.
+ * The WinStationRegisterConsoleNotification routine registers a window for session change notifications.
  *
  * \param ServerHandle Handle to an RD Session Host server, or WINSTATION_CURRENT_SERVER .
  * \param WindowHandle Handle of the window to receive session change notifications.
- * \param Flags Specifies whether to receive notifications for all sessions (WNOTIFY_ALL_SESSIONS) or only for the console session.
- * \return BOOLEAN Nonzero if the function succeeds, or zero otherwise. To get extended error information, call GetLastError.
- * \remarks To shut down or restart the system, the calling process must have the SE_SHUTDOWN_NAME privilege enabled.
+ * \param Flags Specifies all sessions (WNOTIFY_ALL_SESSIONS) or the current session (WNOTIFY_THIS_SESSION).
+ * \return BOOL Nonzero if the function succeeds, or zero otherwise. To get extended error information, call GetLastError.
  * \sa https://learn.microsoft.com/en-us/windows/win32/api/wtsapi32/nf-wtsapi32-wtsregistersessionnotificationex
  */
 NTSYSAPI
-BOOLEAN
+BOOL
 NTAPI
 WinStationRegisterConsoleNotification(
     _In_opt_ HANDLE ServerHandle,
@@ -1075,7 +1095,7 @@ WinStationRegisterConsoleNotification(
 
 // rev
 NTSYSAPI
-BOOLEAN
+BOOL
 NTAPI
 WinStationUnRegisterConsoleNotification(
     _In_opt_ HANDLE ServerHandle,
@@ -1088,7 +1108,7 @@ BOOLEAN
 NTAPI
 WinStationEnumerateW(
     _In_opt_ HANDLE ServerHandle,
-    _Out_ PSESSIONIDW *SessionIds,
+    _Outptr_result_buffer_(*Count) PSESSIONIDW* SessionIds, // WinStationFreeMemory
     _Out_ PULONG Count
     );
 
@@ -1099,11 +1119,11 @@ WinStationEnumerateW(
  * \param SessionId A Remote Desktop Services session identifier.
  * To indicate the session in which the calling application is running (or the current session) specify WINSTATION_CURRENT_SESSION.
  * Only specify WINSTATION_CURRENT_SESSION when obtaining session information on the local server.
- * If WINSTATION_CURRENT_SESSION is specified when querying session information on a remote server, the returned session information will be inconsistent. Do not use the returned data.
- * \param WinStationInformationClass A value from the TOKEN_INFORMATION_CLASS enumerated type identifying the type of information to be retrieved.
- * \param WinStationInformation Pointer to a caller-allocated buffer that receives the requested information about the token.
- * \param WinStationInformationLength Length, in bytes, of the caller-allocated TokenInformation buffer.
- * \param ReturnLength Pointer to a caller-allocated variable that receives the actual length, in bytes, of the information returned in the TokenInformation buffer.
+ * WINSTATION_CURRENT_SESSION is rejected for a remote server.
+ * \param WinStationInformationClass A WINSTATIONINFOCLASS value identifying the requested session information.
+ * \param WinStationInformation Pointer to the output buffer for session information.
+ * \param WinStationInformationLength Length, in bytes, of the caller-allocated WinStationInformation buffer.
+ * \param ReturnLength Receives the class-dependent output or required byte count; it may exceed the buffer capacity.
  * \return BOOLEAN Nonzero if the function succeeds, or zero otherwise. To get extended error information, call GetLastError.
  * \sa https://learn.microsoft.com/en-us/previous-versions/aa383827(v=vs.85)
  */
@@ -1120,6 +1140,9 @@ WinStationQueryInformationW(
     );
 
 // rev
+// In x64 10.0.26100.6899 / x86 10.0.26100.8972, only local/current WinStationNtSecurity reaches RPC.
+// All paths return FALSE in these versions.
+// Other classes, including WinStationConfiguration, fail with ERROR_INVALID_FUNCTION.
 NTSYSAPI
 BOOLEAN
 NTAPI
@@ -1137,8 +1160,9 @@ BOOLEAN
 NTAPI
 WinStationQueryCurrentSessionInformation(
     _In_ WINSTATIONINFOCLASS WinStationInformationClass,
-    _In_reads_bytes_(WinStationInformationLength) PVOID WinStationInformation,
-    _In_ ULONG WinStationInformationLength
+    _Out_writes_bytes_(WinStationInformationLength) PVOID WinStationInformation,
+    _In_ ULONG WinStationInformationLength,
+    _Out_ PULONG ReturnLength
     );
 
 NTSYSAPI
@@ -1280,8 +1304,8 @@ WinStationGetProcessSid(
     _In_opt_ HANDLE ServerHandle,
     _In_ ULONG ProcessId,
     _In_ FILETIME ProcessStartTime,
-    _Out_ PVOID ProcessUserSid,
-    _Inout_ PULONG dwSidSize
+    _Out_writes_bytes_(*SidSize) PSID ProcessUserSid,
+    _Inout_ PULONG SidSize
     );
 
 //
@@ -1319,7 +1343,7 @@ NTAPI
 WinStationVirtualOpen(
     _In_opt_ HANDLE ServerHandle,
     _In_ ULONG SessionId,
-    _In_ PCSTR Name
+    _In_reads_(8) PCSTR Name // Reads 8 bytes; the local copy is terminated at byte 7
     );
 
 // rev
@@ -1344,11 +1368,31 @@ WinStationIsCurrentSessionRemoteable(
 EXTERN_C DECLSPEC_SELECTANY CONST GUID PROPERTY_TYPE_GET_MONITOR_CONFIG = { 0x865D5285, 0xF70A, 0x4ECF, { 0x8B, 0x28, 0x51, 0x2F, 0xE0, 0xAA, 0x2D, 0x53 } };
 EXTERN_C DECLSPEC_SELECTANY CONST GUID PROPERTY_TYPE_CORRELATIONID_GUID = { 0x9A363F8E, 0x1902, 0x40DA, { 0xA2, 0xCC, 0x56, 0x4F, 0x09, 0x40, 0xAD, 0xE3 } };
 
-typedef struct _TS_PROPERTY_INFORMATION
+// rev (RPC property value discriminant and union)
+#define TS_PROPERTY_TYPE_ULONG 1
+#define TS_PROPERTY_TYPE_STRING 2
+#define TS_PROPERTY_TYPE_BINARY 3
+#define TS_PROPERTY_TYPE_GUID 4
+
+typedef struct _TS_PROPERTY_VALUE
 {
-    ULONG Length;
-    PVOID Buffer;
-} TS_PROPERTY_INFORMATION, *PTS_PROPERTY_INFORMATION;
+    USHORT Type; // TS_PROPERTY_TYPE_*
+    union
+    {
+        ULONG Ulong;
+        struct
+        {
+            ULONG Length;
+            PWSTR Buffer;
+        } String;
+        struct
+        {
+            ULONG Length;
+            PBYTE Buffer;
+        } Binary;
+        GUID Guid;
+    } Value;
+} TS_PROPERTY_VALUE, *PTS_PROPERTY_VALUE;
 
 // rev
 NTSYSAPI
@@ -1357,7 +1401,7 @@ NTAPI
 WinStationGetConnectionProperty(
     _In_ ULONG SessionId,
     _In_ PCGUID PropertyType,
-    _Out_ PTS_PROPERTY_INFORMATION PropertyBuffer
+    _Outptr_ PTS_PROPERTY_VALUE* PropertyValue // WinStationFreePropertyValue
     );
 
 // rev
@@ -1365,7 +1409,7 @@ NTSYSAPI
 BOOLEAN
 NTAPI
 WinStationFreePropertyValue(
-    _In_ PVOID PropertyBuffer
+    _In_ PTS_PROPERTY_VALUE PropertyValue
     );
 
 // rev
@@ -1383,8 +1427,8 @@ NTSYSAPI
 BOOLEAN
 NTAPI
 WinStationSetAutologonPassword(
-    _In_ PCSTR KeyName,
-    _In_ PCSTR Password
+    _In_ PCWSTR KeyName,
+    _In_ PCWSTR Password
     );
 
 // private
@@ -1470,18 +1514,9 @@ NTAPI
 WinStationGetAllUserSessions(
     _In_opt_ HANDLE ServerHandle,
     _In_ PSID Sid,
-    _Out_ PVOID* Processes, // LocalFree
-    _Out_ PULONG NumberOfProcesses
+    _Outptr_result_buffer_(*Count) PTS_USER_SESSION* Sessions, // WinStationFreeMemory
+    _Out_ PULONG Count
     );
-
-// rev
-typedef struct _TS_SESSION_VIRTUAL_ADDRESS
-{
-  USHORT AddressFamily;
-  USHORT AddressLength;
-  BYTE Address[20];
-} TS_SESSION_VIRTUAL_ADDRESS, *PTS_SESSION_VIRTUAL_ADDRESS;
-typedef USHORT ADDRESS_FAMILY;
 
 // rev
 NTSYSAPI
@@ -1490,8 +1525,8 @@ NTAPI
 WinStationQuerySessionVirtualIP(
     _In_opt_ HANDLE ServerHandle,
     _In_ ULONG SessionId,
-    _In_ ADDRESS_FAMILY Family,
-    _Out_ TS_SESSION_VIRTUAL_ADDRESS* SessionVirtualIP
+    _In_ USHORT Family, // AF_INET or AF_INET6
+    _Out_ PWINSTATIONREMOTEADDRESS SessionVirtualIP
     );
 
 // rev
@@ -1501,8 +1536,8 @@ NTAPI
 WinStationGetDeviceId(
     _In_opt_ HANDLE ServerHandle,
     _In_ ULONG SessionId,
-    _Out_ PCHAR* Buffer, // CHAR DeviceId[MAX_PATH + 1];
-    _In_ SIZE_T BufferLength
+    _Out_writes_bytes_(BufferLength * 2) PVOID Buffer,
+    _In_ ULONG BufferLength // Capacity in 2-byte units; payload is protocol-specific
     );
 
 // rev
@@ -1520,25 +1555,25 @@ WinStationGetLoggedOnCount(
  * can be optimized for displaying in a remote session to identify the region of a window that is the actual content.
  * In the remote session, this content will be encoded, sent to the client, then decoded and displayed.
  *
- * \param[out] RenderHintID The address of a value that identifies the rendering hint affected by this call.
+ * \param[in,out] RenderHintID The address of a value that identifies the rendering hint affected by this call.
  * If a new hint is being created, this value must contain zero.
  * This function will return a unique rendering hint identifier which is used for subsequent calls, such as clearing the hint.
  * \param[in] WindowHandle The handle of window linked to lifetime of the rendering hint. This window is used in situations where a hint target is removed without the hint being explicitly cleared.
  * \param[in] RenderHintType Specifies the type of hint represented by this call.
  * \param[in] HintDataLength The size in bytes, of the HintData buffer.
  * \param[in] HintData Additional data for the hint. The format of this data is dependent upon the value passed in the renderHintType parameter.
- * \return BOOLEAN Nonzero if the function succeeds, or zero otherwise.
+ * \return HRESULT status; S_OK also indicates that the hint was ignored for a local console session.
  * \sa https://learn.microsoft.com/en-us/windows/win32/api/wtshintapi/nf-wtshintapi-wtssetrenderhint
  */
 NTSYSAPI
-BOOLEAN
+HRESULT
 NTAPI
 WinStationSetRenderHint(
-    _In_opt_ PULONG64 RenderHintID,
+    _Inout_ PULONG64 RenderHintID,
     _In_ HWND WindowHandle,
     _In_ ULONG RenderHintType,
     _In_ ULONG HintDataLength,
-    _In_ PBYTE HintData
+    _In_reads_bytes_opt_(HintDataLength) PBYTE HintData
     );
 
 // rev
@@ -1546,14 +1581,413 @@ WinStationSetRenderHint(
  * The WinStationActiveSessionExists routine returns active sessions on the system without enumerating through the list of sessions.
  * It also does not obtain any extra information from Local Session Manager.
  *
- * \return BOOLEAN Nonzero if an active session exists.
+ * \param ActiveSessionExists Receives whether an active session exists.
+ * \return BOOLEAN Nonzero on success; the session state is returned through ActiveSessionExists.
  * \sa https://learn.microsoft.com/en-us/windows/win32/api/wtsapi32/nf-wtsapi32-wtsactivesessionexists
  */
 NTSYSAPI
 BOOLEAN
 NTAPI
 WinStationActiveSessionExists(
+    _Out_ PBOOL ActiveSessionExists
+    );
+
+// rev (x64/x86 winsta.dll and Windows SDK WinSta.lib)
+// Link with WinSta.lib. BOOLEAN results use AL; notification BOOL results use EAX.
+// ULONG functions below return Win32 error codes; HRESULT functions return HRESULTs.
+
+// ANSI server and session operations
+
+NTSYSAPI
+HANDLE
+NTAPI
+WinStationOpenServerA(
+    _In_opt_ PCSTR ServerName
+    );
+
+NTSYSAPI
+HANDLE
+NTAPI
+WinStationOpenServerExA(
+    _In_opt_ PCSTR ServerName
+    );
+
+NTSYSAPI
+BOOLEAN
+NTAPI
+WinStationEnumerateA(
+    _In_opt_ HANDLE ServerHandle,
+    _Outptr_result_buffer_(*Count) PSESSIONIDA* SessionIds, // WinStationFreeMemory
+    _Out_ PULONG Count
+    );
+
+NTSYSAPI
+BOOLEAN
+NTAPI
+WinStationSendMessageA(
+    _In_opt_ HANDLE ServerHandle,
+    _In_ ULONG SessionId,
+    _In_ PCSTR Title,
+    _In_ ULONG TitleLength,
+    _In_ PCSTR Message,
+    _In_ ULONG MessageLength,
+    _In_ ULONG Style,
+    _In_ ULONG Timeout,
+    _Out_ PULONG Response,
+    _In_ BOOLEAN DoNotWait
+    );
+
+// Current session
+
+NTSYSAPI
+BOOLEAN
+NTAPI
+WinStationGetCurrentSessionCapabilities(
+    _In_ ULONG Level, // Must be 1
+    _Out_ PULONG Capabilities
+    );
+
+NTSYSAPI
+BOOLEAN
+NTAPI
+WinStationGetCurrentSessionConnectionProperty(
+    _In_ PCGUID PropertyType,
+    _Outptr_ PTS_PROPERTY_VALUE* PropertyValue // WinStationFreePropertyValue
+    );
+
+NTSYSAPI
+BOOLEAN
+NTAPI
+WinStationGetCurrentSessionTerminalName(
+    _Out_writes_(WINSTATIONNAME_LENGTH) PWSTR TerminalName
+    );
+
+typedef enum _SESSION_FILTER
+{
+    SF_SERVICES_SESSION_POPUP = 0 // Logged-on sessions; MS-TSTS RpcGetSessionIds.
+} SESSION_FILTER;
+
+NTSYSAPI
+BOOLEAN
+NTAPI
+WinStationGetSessionIds(
+    _In_ SESSION_FILTER Filter,
+    _Out_writes_to_(*Count, *Count) PULONG SessionIds,
+    _Inout_ PULONG Count
+    );
+
+// Child sessions
+
+NTSYSAPI
+BOOLEAN
+NTAPI
+WinStationEnableChildSessions(
+    _In_ BOOLEAN Enable
+    );
+
+NTSYSAPI
+BOOLEAN
+NTAPI
+WinStationIsChildSessionsEnabled(
+    _Out_ PBOOLEAN Enabled
+    );
+
+NTSYSAPI
+BOOLEAN
+NTAPI
+WinStationGetChildSessionId(
+    _Out_ PULONG SessionId
+    );
+
+NTSYSAPI
+BOOLEAN
+NTAPI
+WinStationGetParentSessionId(
+    _In_ ULONG SessionId,
+    _Out_ PULONG ParentSessionId
+    );
+
+NTSYSAPI
+HRESULT
+NTAPI
+WinStationCreateChildSessionTransport(
+    _Out_writes_(TransportNameLength) PWSTR TransportName,
+    _In_range_(1, 256) ULONG TransportNameLength
+    );
+
+// Window notifications: Ex variants additionally select the notification event mask.
+
+NTSYSAPI
+BOOL
+NTAPI
+WinStationRegisterSessionNotification(
+    _In_opt_ HANDLE ServerHandle,
+    _In_ HWND WindowHandle,
+    _In_ ULONG Flags
+    );
+
+NTSYSAPI
+BOOL
+NTAPI
+WinStationRegisterSessionNotificationEx(
+    _In_opt_ HANDLE ServerHandle,
+    _In_ HWND WindowHandle,
+    _In_ ULONG Flags,
+    _In_ ULONG EventMask
+    );
+
+NTSYSAPI
+BOOL
+NTAPI
+WinStationRegisterConsoleNotificationEx(
+    _In_opt_ HANDLE ServerHandle,
+    _In_ HWND WindowHandle,
+    _In_ ULONG Flags,
+    _In_ ULONG EventMask
+    );
+
+NTSYSAPI
+BOOL
+NTAPI
+WinStationRegisterConsoleNotificationEx2(
+    _In_opt_ HANDLE ServerHandle,
+    _In_ HWND WindowHandle,
+    _In_ ULONG Flags,
+    _In_ ULONG EventMask
+    );
+
+NTSYSAPI
+BOOL
+NTAPI
+WinStationUnRegisterSessionNotification(
+    _In_opt_ HANDLE ServerHandle,
+    _In_ HWND WindowHandle
+    );
+
+NTSYSAPI
+BOOL
+NTAPI
+WinStationFreeSessionNotification(
+    _In_opt_ HANDLE ServerHandle,
+    _In_ HWND WindowHandle
+    );
+
+NTSYSAPI
+BOOL
+NTAPI
+WinStationFreeConsoleNotification(
+    _In_opt_ HANDLE ServerHandle,
+    _In_ HWND WindowHandle
+    );
+
+// Event notifications return an opaque registration, not a kernel handle.
+// Release it with WinStationUnRegisterNotificationEvent, not CloseHandle.
+
+NTSYSAPI
+BOOL
+NTAPI
+WinStationRegisterNotificationEvent(
+    _In_ HANDLE EventHandle,
+    _In_ ULONG SessionId,
+    _In_ ULONG EventMask, // Event-registration mask; not WEVENT_*
+    _Outptr_ PVOID* Registration
+    );
+
+NTSYSAPI
+BOOL
+NTAPI
+WinStationRegisterCurrentSessionNotificationEvent(
+    _In_ HANDLE EventHandle,
+    _In_ ULONG EventMask, // Event-registration mask; not WEVENT_*
+    _Outptr_ PVOID* Registration
+    );
+
+NTSYSAPI
+BOOL
+NTAPI
+WinStationUnRegisterNotificationEvent(
+    _In_ PVOID Registration
+    );
+
+// Session state and shutdown
+
+NTSYSAPI
+BOOLEAN
+NTAPI
+WinStationConnectAndLockDesktop(
+    _Reserved_ HANDLE ServerHandle, // Must be NULL
+    _In_ ULONG SessionId
+    );
+
+NTSYSAPI
+BOOLEAN
+NTAPI
+WinStationShadowAccessCheck(
+    _In_ ULONG SessionId,
+    _Out_ PBOOLEAN Allowed
+    );
+
+NTSYSAPI
+BOOLEAN
+NTAPI
+WinStationShadowStop2(
     VOID
+    );
+
+NTSYSAPI
+ULONG
+NTAPI
+WinStationConsumeCacheSession(
+    VOID
+    );
+
+NTSYSAPI
+ULONG
+NTAPI
+WinStationIsBoundToCacheTerminal(
+    _Out_ PBOOLEAN IsBound
+    );
+
+NTSYSAPI
+ULONG
+NTAPI
+WinStationIsSessionPermitted(
+    VOID
+    );
+
+NTSYSAPI
+ULONG
+NTAPI
+WinStationSystemShutdownStarted(
+    _In_ ULONG Unknown0
+    );
+
+NTSYSAPI
+ULONG
+NTAPI
+WinStationSystemShutdownWait(
+    _In_ ULONG Timeout,
+    _Out_opt_ PULONG Unknown0
+    );
+
+// Initial application and logon UI
+
+NTSYSAPI
+BOOLEAN
+NTAPI
+WinStationGetInitialApplication(
+    _In_ ULONG SessionId,
+    _Outptr_ PWSTR* Unknown0, // WinStationFreeMemory
+    _Outptr_ PWSTR* Unknown1, // WinStationFreeMemory
+    _Out_ PCHAR Unknown2,
+    _Out_ PCHAR Unknown3
+    );
+
+NTSYSAPI
+ULONG
+NTAPI
+WinStationRedirectErrorMessage(
+    _In_ ULONG Unknown0,
+    _In_ ULONG Unknown1
+    );
+
+NTSYSAPI
+HRESULT
+NTAPI
+WinStationRedirectLogonBeginPainting(
+    VOID
+    );
+
+NTSYSAPI
+HRESULT
+NTAPI
+WinStationRedirectLogonStatus(
+    _In_ PCWSTR Status,
+    _Out_ PULONG Unknown0
+    );
+
+NTSYSAPI
+HRESULT
+NTAPI
+WinStationRedirectLogonMessage(
+    _In_ PCWSTR Unknown0,
+    _In_ PCWSTR Unknown1,
+    _In_ ULONG Unknown2,
+    _Out_ PULONG Unknown3
+    );
+
+NTSYSAPI
+HRESULT
+NTAPI
+WinStationRedirectLogonError(
+    _In_ ULONG Unknown0,
+    _In_ ULONG Unknown1,
+    _In_ PCWSTR Unknown2,
+    _In_ PCWSTR Unknown3,
+    _In_ ULONG Unknown4,
+    _Out_ PULONG Unknown5
+    );
+
+NTSYSAPI
+BOOLEAN
+NTAPI
+WinStationReportLoggedOnCompleted(
+    VOID
+    );
+
+// Allocated certificate and credential data; release with the matching function.
+
+typedef struct _TS_USER_CERTIFICATES
+{
+    ULONG Count;
+    ULONG Length;
+    PBYTE Buffer;
+} TS_USER_CERTIFICATES, *PTS_USER_CERTIFICATES;
+
+NTSYSAPI
+BOOLEAN
+NTAPI
+WinStationGetUserCertificates(
+    _Outptr_ PTS_USER_CERTIFICATES* Certificates
+    );
+
+NTSYSAPI
+BOOLEAN
+NTAPI
+WinStationFreeUserCertificates(
+    _In_opt_ PTS_USER_CERTIFICATES Certificates
+    );
+
+typedef struct _TS_USER_CREDENTIALS
+{
+    ULONG Unknown0;
+    ULONG Unknown1;
+    ULONG Length;
+    PVOID Buffer;
+} TS_USER_CREDENTIALS, *PTS_USER_CREDENTIALS;
+
+NTSYSAPI
+ULONG
+NTAPI
+WinStationGetUserCredentials(
+    _Outptr_ PTS_USER_CREDENTIALS* Credentials
+    );
+
+NTSYSAPI
+ULONG
+NTAPI
+WinStationFreeUserCredentials(
+    _In_ PTS_USER_CREDENTIALS Credentials
+    );
+
+NTSYSAPI
+HRESULT
+NTAPI
+WinStationGetUserProfile(
+    _In_ HANDLE Unknown0,
+    _Outptr_ PWSTR* Unknown1, // WinStationFreeMemory
+    _Outptr_ PWSTR* Unknown2, // WinStationFreeMemory
+    _Outptr_ PWSTR* Unknown3  // WinStationFreeMemory
     );
 
 #endif


### PR DESCRIPTION
Several existing `winsta.h` declarations cannot safely describe the exported functions. The current-session
query omits an argument, the active-session query omits its output pointer, the virtual-IP record is smaller
than the implementation writes, and connection properties use an incompatible layout and pointer depth.
This change corrects those contracts and adds 43 private exports whose native argument types can be recovered.

The proposed phnt change is limited to `phnt/include/winsta.h`, based on commit
`e67552217b000ffe3642fb68795c3c77fc52d317`. NDK carries the corresponding declarations, tests, and
[API analysis](https://github.com/KNSoft/KNSoft.NDK/blob/5d64508394b0ac2f6cac090140938fbe05f7abff/Source/Include/KNSoft/NDK/Win32/WinSta/Analysis.md). The NDK directory/project changes and these
documents are not part of the phnt patch.

## Evidence and sample identity

The static review covers the supplied x64 and x86 IDA databases, including disassembly, callers/helpers,
allocation/free paths, and RPC format strings. Decompiled prototypes alone are not evidence of a public ABI.

| ID | Architecture | File version | SHA-256 | Use |
| --- | --- | --- | --- | --- |
| A | x64 | `10.0.26100.6899` | `6fb63648dee54c11b91d5778aba7b2325aed9419559e877b64fd7117c27d2bcf` | Original x64 IDB input; VM private DLL |
| B | x86 | `10.0.26100.8972` | `ffa6abb538d243266d376c7a0b460bb0634dc6be6b3101db89e6612b588e7996` | Original x86 IDB input; VM private DLL |
| C | x64 | `10.0.26100.8972` | `e44c55a20f1a2c38713988401b92146118324010ab75acf1df6fc2012b10a9af` | Additional VM private DLL |
| D | x64 | `10.0.28000.2605` | `82c39df19849db1d8120215db91b0c473d08065c504225acb86b5499f36f93cb` | Guest native DLL |
| E | x86 | `10.0.28000.2605` | `b664a5e0715dded9a60b4e3d3e9bb13be8fb6dd1cf4199c4b97a040d732bf7d8` | Guest native DLL |

IDB identities come from `ida_nalt.retrieve_input_file_sha256()`, not from hashing the current file at the
recorded input path. Sample A was recovered from the
[Microsoft symbol server](https://msdl.microsoft.com/download/symbols/winsta.dll/1C17E0A063000/winsta.dll)
and its hash matches the IDB. File versions above come from the actual DLL resources; the unmanifested
runtime probe can display a compatibility-adjusted `6.2` prefix.

All 88 resulting function declarations were checked against the x86 decorated argument sizes in Windows SDK
`10.0.28000.0` `WinSta.lib`. Stack cleanup and import symbols establish argument byte counts, not pointer
depth, output width, signedness, or ownership. Those conclusions use the additional evidence below.

## Independent PDB and import-library cross-check

The PDBs were downloaded separately from Microsoft's symbol server using the original PE CodeView records,
then read through DIA without registering a COM server or applying types to IDA.

| Architecture | PDB GUID | Age | Public symbols | Global structure/enum records |
| --- | --- | --- | --- | --- |
| x64 | `A62967D2-4DAA-7932-3B80-E7DACB6FB4DF` | `1` | `1995` | `0 / 0` |
| x86 | `4F554DA1-F4B6-4742-52D4-278A52BD313F` | `1` | `2248` | `0 / 0` |

The matching files are available as [x64 PDB](https://msdl.microsoft.com/download/symbols/winsta.pdb/A62967D24DAA79323B80E7DACB6FB4DF1/winsta.pdb)
and [x86 PDB](https://msdl.microsoft.com/download/symbols/winsta.pdb/4F554DA1F4B6474252D4278A52BD313F1/winsta.pdb).

Both PDBs report `isStripped == TRUE`. All 88 reviewed export entry points on each architecture match
original PDB public-symbol RVAs, including shared entry points for aliases. C++ decorated helper names
retain useful parameter/return types; the PDBs do not supply complete structure layouts or prototypes for
every C export. IDA local types are not presented as original PDB type evidence.

For example, the original x64 public symbol
`?_tsrpcRegisterForSessionNotifications@@YAHPEAXPEAUHWND__@@KK@Z` decodes to an `int` result, a pointer,
`HWND`, and two `unsigned long` arguments. The x86 helper's decoration independently agrees. The
`Legacy_WinStationGetProcessSid` decoration preserves a by-value `_FILETIME`; `GetCurrentSessionConfigData`
and `GetCurrentSessionClientData` preserve typed output-buffer, byte-capacity and return-length arguments.

Fresh SDK x86, x64 and ARM64 library listings contain all 88 symbols. x86 decorated sizes agree with the
native stack cleanup and final declarations. ARM64EC uses the x64 library. None of these checks alone
establishes an opaque payload's semantics.

## Existing declarations: changes and supporting evidence

| Declaration or definition | Correction | Evidence and limits |
| --- | --- | --- |
| `WinStationQueryCurrentSessionInformation` | Add fourth `PULONG ReturnLength`; mark the buffer as output. | Both clients validate and clear the fourth argument, then pass it to query helpers. x86 returns with `ret 10h`; SDK symbol is `@16`. VM checks cover invalid class, exact/undersized buffers and output guards. |
| `WinStationActiveSessionExists` | Add required `PBOOL`; retain `BOOLEAN` as the function result. | Both clients validate the pointer and pass it to RPC. x86 returns with `ret 4`. NDR describes a four-byte `FC_LONG` output. Samples B through E successfully write four bytes without touching guards. Sample A raises an RPC exception; see below. |
| `WinStationRegisterConsoleNotification`, `WinStationUnRegisterConsoleNotification` | Change return type from `BOOLEAN` to `BOOL`; correct copied shutdown documentation and flag descriptions. | Registration aliases the session wrapper and forwards to the four-argument helper. Internal C++ symbols encode an `int` result; the return path constructs a full `EAX` boolean. Unregistration uses `not` / `shr 31` / `mov eax`, on both architectures. Own-window registration and release succeeded in the VM. |
| `WinStationSetRenderHint` | Return `HRESULT`; require an input/output 64-bit hint ID; annotate optional data by byte length. | The remote helper reads the ID, generates/writes one when zero, validates the window/type/data and returns HRESULTs directly, including `E_INVALIDARG`. The local path returns `S_OK`. Remote rendering was not exercised. |
| `WinStationGetDeviceId` | Replace `PCHAR*` with a direct `PVOID` output buffer and `SIZE_T` with `ULONG`. | Both clients pass the third argument unchanged to `RpcQuerySessionData` class `4`, with byte capacity calculated by doubling the fourth argument using 32-bit arithmetic. Neither dereferences a caller pointer-to-pointer. VM rejection preserves guards; no successful device payload was obtained. Two-byte capacity units do not prove UTF-16 content. |
| `WinStationSetAutologonPassword` | Change both strings from `PCSTR` to `PCWSTR`. | The RPC format describes both as `FC_C_WSTRING`; native argument forwarding agrees in both clients. Autologon state was not changed for testing. |
| `WinStationGetConnectionProperty`, `TS_PROPERTY_INFORMATION` | Replace the incompatible length/pointer record with `TS_PROPERTY_VALUE`; return it through a pointer-to-pointer. | NDR parameter attributes `0x2013` describe an allocated output with pointer dereference. The referent has a `USHORT` discriminant and four union arms. Native/free-helper offsets independently agree: size `24/20`, union offset `8/4`, nested pointer `16/8` on x64/x86. No successful property query payload was available. |
| `WinStationFreePropertyValue` | Type the argument as the allocated property object. | Both implementations inspect its 16-bit type; types `2` and `3` free the nested allocation before the outer one. VM probes and repository tests free valid locally constructed objects for all four types. Null is rejected. |
| `WinStationQuerySessionVirtualIP`, `TS_SESSION_VIRTUAL_ADDRESS` | Use existing `WINSTATIONREMOTEADDRESS`; remove the incorrect 24-byte record and redundant `ADDRESS_FAMILY` typedef. | Both clients copy the address by family and write the IPv6 scope DWORD at offset `28`. The required extent is `32` bytes. `USHORT Family` retains the original ABI width. VM RPC failure prevented success-path validation. |
| `WinStationGetAllUserSessions` | Use `PTS_USER_SESSION*` and session-oriented output names. | Both clients allocate `20 * Count`, write a leading version DWORD of `1`, and copy four further DWORDs per entry. The existing structure has that layout. VM enumeration returned zero entries, so it does not independently establish field meanings. Existing `TS_USER_SESSION` members, including `SESSIONTYPE State`, are preserved. |
| `WinStationGetProcessSid` | Use `PSID` and a byte-capacity SAL annotation; clarify `SidSize`. | The implementation passes caller storage and size to `GetSidFromProcessId` or copies a SID in the legacy path. `FILETIME` remains eight bytes passed by value, including on x86. No argument count or representation is changed. |
| `WinStationGetTermSrvCountersValue` | Annotate the input/output array with `Count`. | Both paths consume counter IDs and use a `24`-byte record stride. VM queries for counter IDs `1` through `12` match the result/value offsets. |
| `WinStationEnumerateW` | Annotate an allocated array of `*Count` entries and its release API. | Allocation/copy code produces `76`-byte entries with state at offset `72`; VM enumeration and release succeeded. |
| `WinStationFreeMemory`, `WinStationCloseServer` | Mark accepted null inputs optional. | Both implementations explicitly handle null. `WinStationFreeMemory` only calls `LocalFree` for nonnull input. `WinStationCloseServer` skips destruction for null after flushing notifications associated with that binding. Null acceptance does not mean the latter has no other effects. |
| Allocation/server/session guidance | Replace blanket `LocalFree` and universal session `-1` guidance with API-specific contracts. | Process/session/property/credential release functions traverse nested allocations. `WinStationOpenServer*` returns binding objects with destructors; licensing ping uses a separate context. `WinStationQueryInformationW` rejects remote-server/current-session combinations before querying. |
| `WINSTATIONINFOCLASS` comments | Identify native query buffers while retaining legacy RPC query/set contracts. | Native helpers omit wire prefixes; legacy protocol definitions retain them. Configuration and PD-parameter comments still say `qs` for legacy RPC. No enum value is changed. |
| `WinStationQueryInformationW` documentation | Correct token/session copy errors and describe class-dependent `ReturnLength`. | Dispatch helpers use session classes; several paths report required size or supplied capacity rather than copied bytes. VM query/guard results agree. The declaration's ABI is unchanged. |
| `WinStationSetInformationW` comment | State the observed version-specific limitation. | In both IDBs only local/current class `13` reaches `RpcPopSecurityDialog`; every exit returns zero in `AL`. Classes `1` and `2` return `ERROR_INVALID_FUNCTION` in all five VM sample combinations. This does not remove the legacy protocol's setting contract. |
| `WINSTATIONCLIENT.fRestrictedLogon` | Add the next bit after `fUsingSavedCreds`. | The published MS-TSTS `WINSTATIONCLIENT` definition supplies this exact field/order. Size and following field offsets remain unchanged and match the native `2296`-byte buffer. Runtime size checks do not independently prove a flag's meaning. |

Two further existing declarations require more precise caller contracts:

| Declaration | Correction | Evidence |
| --- | --- | --- |
| `WinStationVirtualOpen` | Use `_In_reads_(8)` for `Name` and document local truncation. | x64 performs `mov rax, [r8]` before checking the copied first byte; x86 loads `[ecx]` and `[ecx+4]`. Both zero local byte `7`. An ordinary short string does not necessarily provide the eight readable bytes these instructions require. Parameter type and argument count remain unchanged. |
| `WinStationServerPing` | Rename the handle parameter to `LicensingHandle` and document its origin; narrow the general binding guidance. | x86 calls the PDB-named `RpcLicensingServerPing` with the supplied handle unchanged; x64 uses operation `7` of the same licensing interface. Its NDR handle descriptor is `FC_BIND_CONTEXT` (`0x30`). The null path calls `LcRpcBindLocal`, which caches `ServerLicensingOpenW(NULL)`; that function returns the context produced by `RpcLicensingOpenServer`, after freeing the transport binding. A `WinStationOpenServer*` object is not this context. Native `HANDLE` width is unchanged. |

These two corrections follow instruction-level evidence in both architectures. They add no new runtime
test or claim of a successful channel/licensing operation.

The following excerpts show why a boolean-looking function is not enough to choose its type. Instructions
are taken from the two different return paths; labels and unrelated instructions are omitted.

```asm
; WinStationActiveSessionExists, x64: only the byte result is assigned.
mov     al, bl

; WinStationUnRegisterConsoleNotification, x86: full BOOL result.
not     esi
shr     esi, 1Fh
mov     eax, esi
```

For `WinStationActiveSessionExists`, the RPC output descriptor has parameter attributes `0x2150`
(`out`, base type, simple reference, server allocation) and base type `0x08` (`FC_LONG`). This establishes
the pointee's four-byte width independently of the export's byte return. A `PBOOLEAN` would permit a
three-byte overwrite; the former no-argument declaration also mismatches x86 stack cleanup.

The virtual-IP correction similarly addresses a concrete overwrite: the original record has `24` bytes,
while the IPv6 path writes four bytes beginning at offset `28`. The replacement uses the already defined
`WINSTATIONREMOTEADDRESS`; it does not introduce new packing or guess the address from a function name.

### Protocol corroboration

- [MS-TSTS `WINSTATIONCONFIG`](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-tsts/379fe706-cf87-417e-b1f2-e8536013132d): `Comment[61]`, `USERCONFIG`, and four OEM bytes. Native size is `2664`; `User.Password` is at offset `210`.
- [MS-TSTS `WINSTATIONCLIENT`](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-tsts/673d8ac0-f557-48cb-98a6-49925160d729): client flag order, including `fRestrictedLogon`.
- [Legacy query](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-tsts/1bba9ff2-71d3-49a3-bb26-2e5f6fcab3ee) and [legacy set](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-tsts/2a5ee131-a1dd-44c7-9880-98df708061ea): wire-buffer contracts, including configuration and PD-parameter setters. They are not proof that the current native export forwards a setter.
- [MS-TSTS `RpcQuerySessionData`](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-tsts/8661c3aa-bc47-41b9-9662-5762ee052c2f): byte-buffer RPC contract used by the device query.
- [MS-TSTS `rcmpublic.idl`](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-tsts/7b70d367-5d92-4783-8bb7-ce1820ca8069): certificate count, byte length and byte buffer.
- [MS-TSTS `SESSION_FILTER`](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-tsts/35269584-7c5e-4410-8195-1aa49559274e): the defined filter value `SF_SERVICES_SESSION_POPUP == 0`.

## Added declarations

Every row below was checked in both native clients and against the SDK import library. The x86 column is
the total stack argument size, not a substitute for the type evidence. Runtime coverage is described
separately; listing an export here does not imply its success path was exercised.

| Function | Return | x86 bytes | Type/contract evidence |
| --- | --- | --- | --- |
| `WinStationOpenServerA` | `HANDLE` | `4` | ANSI-to-wide conversion and the existing wide-server open path; pointer-sized binding result. |
| `WinStationOpenServerExA` | `HANDLE` | `4` | ANSI-to-wide conversion and the extended wide-server open path; pointer-sized binding result. |
| `WinStationEnumerateA` | `BOOLEAN` | `12` | Converts wide enumeration to allocated `44`-byte `SESSIONIDA` records; state at `40`; DWORD count output. |
| `WinStationSendMessageA` | `BOOLEAN` | `40` | ANSI conversion uses explicit title/message lengths, forwards DWORD style/timeout/response and a byte wait flag. |
| `WinStationGetCurrentSessionCapabilities` | `BOOLEAN` | `8` | Unconditionally clears the required DWORD output before service/level checks; level `1` reaches RPC. |
| `WinStationGetCurrentSessionConnectionProperty` | `BOOLEAN` | `8` | GUID input and allocated discriminated property output; same NDR/value layout as the explicit-session query. |
| `WinStationGetCurrentSessionTerminalName` | `BOOLEAN` | `4` | Writes the caller buffer via `StringCchCopyW` with capacity `32` WCHARs, including the terminator. |
| `WinStationGetSessionIds` | `BOOLEAN` | `12` | Four-byte native filter, in/out DWORD count and caller DWORD array; NDR `FC_ENUM16` filter and counted result. |
| `WinStationEnableChildSessions` | `BOOLEAN` | `4` | Consumes a byte boolean; native forwarding and RPC boolean type agree. |
| `WinStationIsChildSessionsEnabled` | `BOOLEAN` | `4` | Validates caller storage and writes a byte boolean; VM canaries confirm width. |
| `WinStationGetChildSessionId` | `BOOLEAN` | `4` | Required DWORD output; RPC base type and native argument forwarding agree. |
| `WinStationGetParentSessionId` | `BOOLEAN` | `8` | DWORD input session ID and required DWORD parent output; RPC descriptors agree. |
| `WinStationCreateChildSessionTransport` | `HRESULT` | `8` | Caller wide-string buffer; NDR character capacity range `1..256`; HRESULT returned directly. |
| `WinStationRegisterSessionNotification` | `BOOL` | `12` | Three-argument wrapper passes mask `0xFFFFFFFF` to the Ex function; full `EAX` result. |
| `WinStationRegisterSessionNotificationEx` | `BOOL` | `16` | Binding/window handles and DWORD flags/mask flow to the typed notification helper; full `EAX` result. |
| `WinStationRegisterConsoleNotificationEx` | `BOOL` | `16` | Shares the four-argument session-notification implementation and its result contract. |
| `WinStationRegisterConsoleNotificationEx2` | `BOOL` | `16` | Shares the same export entry point and four-argument helper as the other Ex registration names in both samples. |
| `WinStationUnRegisterSessionNotification` | `BOOL` | `8` | Binding/window arguments feed `DeleteWindowNotification`; converts HRESULT to full `BOOL`. |
| `WinStationFreeSessionNotification` | `BOOL` | `8` | Binding/window arguments feed the matching notification deletion path; full `BOOL`. |
| `WinStationFreeConsoleNotification` | `BOOL` | `8` | Shares the notification-release implementation; same two handle arguments and full result. |
| `WinStationRegisterNotificationEvent` | `BOOL` | `16` | Duplicates the event handle; DWORD session/mask inputs; writes an allocated opaque registration through the last pointer. |
| `WinStationRegisterCurrentSessionNotificationEvent` | `BOOL` | `12` | Current-session wrapper for event registration; handle, DWORD mask and registration pointer-to-pointer. |
| `WinStationUnRegisterNotificationEvent` | `BOOL` | `4` | Dereferences and destroys the opaque registration object; it is not a kernel handle and cannot be null. |
| `WinStationConnectAndLockDesktop` | `BOOLEAN` | `8` | Rejects nonnull server and session `-1`; explicit DWORD session ID reaches the connection helper. |
| `WinStationShadowAccessCheck` | `BOOLEAN` | `8` | DWORD session input and one-byte access output; RPC/native stores establish pointee width. |
| `WinStationShadowStop2` | `BOOLEAN` | `0` | No native parameters; uses current-session state and returns byte status. |
| `WinStationConsumeCacheSession` | `ULONG` | `0` | No native parameters; converts the RPC HRESULT to a Win32 error returned in `EAX`. |
| `WinStationIsBoundToCacheTerminal` | `ULONG` | `4` | Writes one byte through caller pointer; function result is a Win32 error, not a boolean. |
| `WinStationIsSessionPermitted` | `ULONG` | `0` | No native parameters; forwards the RPC Win32 result directly, with a local-success shortcut and a `1722`-to-zero case. |
| `WinStationSystemShutdownStarted` | `ULONG` | `4` | One DWORD forwarded to RPC; its meaning remains `Unknown0`; full Win32 error result. |
| `WinStationSystemShutdownWait` | `ULONG` | `8` | Millisecond timeout flows to the wait operation; optional DWORD output receives completion data of unknown meaning. |
| `WinStationGetInitialApplication` | `BOOLEAN` | `20` | DWORD session ID, two allocated wide-string outputs and two one-byte outputs; NDR types/pointer direction agree. |
| `WinStationRedirectErrorMessage` | `ULONG` | `8` | Two DWORDs forwarded to the error-message RPC; semantics remain unknown; Win32 error result. |
| `WinStationRedirectLogonBeginPainting` | `HRESULT` | `0` | No native parameters; remote-only RPC path returns HRESULT, local path returns `S_OK`. |
| `WinStationRedirectLogonStatus` | `HRESULT` | `8` | NDR wide-string input and DWORD output; HRESULT result; local shortcut can leave output untouched. |
| `WinStationRedirectLogonMessage` | `HRESULT` | `16` | Two wide strings, DWORD input and DWORD output established by NDR and native forwarding; unnamed meanings retained. |
| `WinStationRedirectLogonError` | `HRESULT` | `24` | Three DWORD inputs, two wide strings and a DWORD output; native order agrees with RPC descriptors. |
| `WinStationReportLoggedOnCompleted` | `BOOLEAN` | `0` | No native parameters; obtains current session internally and returns byte status. |
| `WinStationGetUserCertificates` | `BOOLEAN` | `4` | Allocated count/byte-length/buffer wrapper; native size `16/12`; RPC IDL confirms field meanings. |
| `WinStationFreeUserCertificates` | `BOOLEAN` | `4` | Reads/frees the nested buffer then wrapper; explicit null-accepting path; byte status. |
| `WinStationGetUserCredentials` | `ULONG` | `4` | Allocated three-DWORD/pointer wrapper, size `24/16`; payload byte length controls copy/decryption; first two meanings remain unknown. |
| `WinStationFreeUserCredentials` | `ULONG` | `4` | Uses the third DWORD as byte length, clears payload, frees nested/outer allocations; returns a Win32 error. |
| `WinStationGetUserProfile` | `HRESULT` | `16` | Pointer-sized handle input (`FC_UINT3264`) and three allocated wide-string outputs. Required handle subtype/access rights remain unknown. |

`TS_PROPERTY_TYPE_*` values come from the NDR union arms and release code, not inferred payload names.
`WINSTATIONCOMMENT_LENGTH == 60` comes from the published configuration record. `SESSIONIDA` field widths
come from the conversion loop. The certificate/credential layouts are independently constrained by their
allocation sizes and matching release functions.

Event-registration masks are not `WEVENT_*`. Both implementations translate input bits
`1, 2, 4, 8, 0x10, 0x20, 0x100` to RPC bits `0x100, 0x200, 2, 4, 8, 0x10, 0x60` respectively.
The header avoids assigning `WEVENT_*` semantics; the analysis documents the mapping using the
[protocol's RPC notification constants](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-tsts/c00907ea-a492-415b-bc19-fbcb36934710).

## Whole-header coverage

The inventory contains **88 functions, 66 structure/union/enum definitions, 16 standalone type aliases,
97 public macros and two GUID constants**. The phnt include guard is excluded. Changed declarations have
the detailed evidence above; the remaining inventory is recorded here so retained legacy definitions
are not confused with newly established behavior.

### Original 45 function declarations

All rows include x64/x86 disassembly and decompilation review. Return-register assignments were checked
alongside the call paths; a zero-extended byte on one path was not treated as proof of `BOOL`.

| Function | Contract cross-check |
| --- | --- |
| `WinStationFreeMemory` | Nonnull input reaches `LocalFree`; null returns byte true. |
| `WinStationOpenServerW` | Tail-call to `_tsrpcOpenServer`; original helper symbols and constructor return an opaque pointer. |
| `WinStationOpenServerExW` | Allocates/constructs `CPublicBinding`; returns its pointer or null. |
| `WinStationCloseServer` | Flushes notifications, destroys a nonnull `CPublicBinding`, then returns byte true. |
| `WinStationServerPing` | Licensing-context NDR and `RpcLicensingServerPing`; see the corrected handle contract above. |
| `WinStationGetTermSrvCountersValue` | DWORD count, counted `TS_COUNTER` storage and byte status; legacy helper symbol agrees. |
| `WinStationShutdownSystem` | Forwards handle and DWORD flags to the PDB-typed byte-returning legacy helper. |
| `WinStationWaitSystemEvent` | DWORD mask input/output; native mask conversion and byte return; legacy helper decoration agrees. |
| `WinStationRegisterConsoleNotification` | Alias of the session wrapper, passing `0xFFFFFFFF` to the PDB-typed `int` helper. |
| `WinStationUnRegisterConsoleNotification` | Same entry as session unregistration; `DeleteWindowNotification(..., 1)` and full `EAX` result. |
| `WinStationEnumerateW` | Typed allocated `SESSIONIDW**` and DWORD count in original helper symbol; native conversion agrees. |
| `WinStationQueryInformationW` | Six arguments; native class dispatch and legacy enum/buffer/length helper symbols agree. |
| `WinStationSetInformationW` | Five x86 argument slots retained despite unused buffer/length in the current implementation; byte false return. |
| `WinStationQueryCurrentSessionInformation` | Four arguments and typed three-argument query helpers; fourth DWORD output is cleared. |
| `WinStationNameFromLogonIdW` | DWORD ID to caller wide buffer; current-session path and PDB-typed legacy helper agree. |
| `LogonIdFromWinStationNameW` | Wide-name comparison and DWORD ID output; legacy helper decoration agrees. |
| `WinStationSendMessageW` | Two byte-counted wide inputs, DWORD style/timeout/response, and byte wait flag; legacy decoration agrees. |
| `WinStationConnectW` | Two DWORD IDs, optional wide password and byte wait flag; typed legacy helper agrees. |
| `WinStationDisconnect` | DWORD ID and byte wait flag; native wrapper and typed legacy helper agree. |
| `WinStationReset` | DWORD ID and byte wait flag; native wrapper and typed legacy helper agree. |
| `WinStationShadow` | Wide server name, DWORD ID, byte virtual key and 16-bit modifier value forwarded to RPC. |
| `WinStationShadowStop` | Third argument is unused by these implementations; retain inherited `BOOLEAN` and SDK `@12` contract. |
| `WinStationEnumerateProcesses` | Two native slots and an allocated opaque output in the legacy helper. The current x64 local path is unsupported; retain opaque output. |
| `WinStationGetAllProcesses` | Level-zero conversion, DWORD count and allocated record array; original legacy helper confirms pointer depth. |
| `WinStationFreeGAPMemory` | Level, array pointer and DWORD count; nested record/SID/name release; byte status. |
| `WinStationTerminateProcess` | DWORD process ID and exit status; local `NtOpenProcess`/`NtTerminateProcess` path and legacy decoration agree. |
| `WinStationGetProcessSid` | By-value eight-byte `FILETIME`, caller SID buffer and in/out DWORD length; PDB and native/legacy forwarding agree. |
| `WinStationSwitchToServicesSession` | No arguments; current binding supplies RPC context; byte status. |
| `WinStationRevertFromServicesSession` | No arguments; paired RPC operation; byte status. |
| `_WinStationWaitForConnect` | No arguments; waits for LSM then invokes current-session RPC; byte status. |
| `WinStationVirtualOpen` | Three arguments; unconditional eight-byte name load and local byte-7 terminator; pointer result. |
| `WinStationVirtualOpenEx` | Four arguments; null/empty name check, DWORD flags and pointer result. |
| `WinStationIsCurrentSessionRemoteable` | Clears one byte through the required output pointer; RPC and byte result agree. |
| `WinStationGetConnectionProperty` | DWORD ID, GUID input and allocated discriminated-value output; see NDR/layout evidence above. |
| `WinStationFreePropertyValue` | 16-bit discriminator and nested-free offsets; byte result. |
| `WinStationIsSessionRemoteable` | Handle, DWORD session ID and one-byte output; current-session shortcut or internal remote helper. |
| `WinStationSetAutologonPassword` | Two NDR `FC_C_WSTRING` inputs and byte wrapper status. |
| `WinStationGetAllSessionsEx` | Level, allocated result and DWORD count; typed helper and fallback conversion agree. |
| `WinStationFreeEXECENVDATAEX` | Pointer/count, level-dispatched nested releases; keep `VOID`, not the incidental `LocalFree` result. |
| `WinStationGetAllUserSessions` | SID conversion, allocated 20-byte records and DWORD count; supplied server argument is unused. |
| `WinStationQuerySessionVirtualIP` | 16-bit family input; family-specific output stores through byte 31. |
| `WinStationGetDeviceId` | Direct caller buffer; 32-bit capacity doubled before RPC. |
| `WinStationGetLoggedOnCount` | Two required DWORD outputs passed to the logged-on-count RPC; byte result. |
| `WinStationSetRenderHint` | Remote helper returns HRESULT and consumes a 64-bit in/out ID; local shortcut returns zero. |
| `WinStationActiveSessionExists` | One required four-byte output; byte wrapper result; NDR `FC_LONG` and SDK `@4`. |

### Structures, unions and enums

The protocol comparison covers field order, base type, array extent, bitfield width and enum value.
Member spelling, equivalent Windows typedefs, explicit first-enumerator zero, trailing commas and IDL
annotations are normalized only for comparison; inherited source names are retained. `APPLICATIONNAME`
is `WCHAR[MAX_BR_NAME]`, confirming the existing `USERCONFIG.PublishedName` array.

The older protocol calls information classes `33..36` unused and ends at `40`; those naming/version
differences do not justify removing inherited names or the native `41`/`42` cases. A copied record is
evidence of layout, not necessarily evidence of every field's meaning.

| Definition | Evidence / retained limit |
| --- | --- |
| `VARDATA_WIRE` | [Protocol definition](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-tsts/cc15eeb5-f981-48d1-93f6-d4f9bfdb07ca); layout/values retained. |
| `WINSTATIONSTATECLASS` | [Protocol definition](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-tsts/ce70794f-2138-43e8-bf6c-2c147887d6a2); layout/values retained. |
| `SESSIONIDW` | Native enumeration: 76-byte stride, name offset 4, state offset 72; published `SESSIONID` has equivalent members. |
| `SESSIONIDA` | Native A/W conversion: 44-byte stride, name capacity 33, state offset 40. |
| `WINSTATIONINFOCLASS` | [Legacy enum](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-tsts/ce70794f-2138-43e8-bf6c-2c147887d6a2) and native dispatch; historical unused names/version tail retained as explained above. |
| `WINSTATIONCREATE` | [Protocol definition](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-tsts/dcd01340-5084-4089-8173-ad3a5831e087); layout/values retained. |
| `WINSTACONFIGWIRE` | [Protocol definition](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-tsts/ae5355e7-c6cc-48ab-b82a-d1de8b3cd6d6); layout/values retained. |
| `CALLBACKCLASS` | [Protocol definition](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-tsts/4fa6b4b0-cc9c-46c8-8c20-68013a645e92); layout/values retained. |
| `SHADOWCLASS` | [Protocol definition](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-tsts/4099e9b2-21ae-4a79-8798-c627107d028f); layout/values retained. |
| `USERCONFIG` | [Protocol definition](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-tsts/dba750b8-cb35-4e88-9811-e2a1f8a10701); layout/values retained. |
| `WINSTATIONCONFIG` | [Protocol definition](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-tsts/379fe706-cf87-417e-b1f2-e8536013132d) plus native size/offset or conversion/free checks described above. |
| `SDCLASS` | [Protocol definition](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-tsts/7de560c9-ca6b-4741-a448-c67de0e52e0e); layout/values retained. |
| `NETWORKCONFIG` | [Protocol definition](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-tsts/a962dcf9-04ae-461a-acf1-4b50e677c265); layout/values retained. |
| `FLOWCONTROLCLASS` | [Protocol definition](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-tsts/e5ba41c8-f4e0-4c69-a411-715571d5f389); layout/values retained. |
| `RECEIVEFLOWCONTROLCLASS` | [Protocol definition](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-tsts/ce70794f-2138-43e8-bf6c-2c147887d6a2); layout/values retained. |
| `TRANSMITFLOWCONTROLCLASS` | [Protocol definition](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-tsts/ce70794f-2138-43e8-bf6c-2c147887d6a2); layout/values retained. |
| `ASYNCCONNECTCLASS` | [Protocol definition](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-tsts/4e0d193c-1b74-4ba0-98cc-33255405b3a5); layout/values retained. |
| `FLOWCONTROLCONFIG` | [Protocol definition](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-tsts/aba2eab5-c9b8-48aa-befc-ae8b32a3efd7); layout/values retained. |
| `CONNECTCONFIG` | [Protocol definition](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-tsts/8f14c17b-af56-4430-bcab-9231d1334b29); layout/values retained. |
| `ASYNCCONFIG` | [Protocol definition](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-tsts/f6c52c7c-8861-4ce6-88f1-8c84e4f2026a); layout/values retained. |
| `NASICONFIG` | [Protocol definition](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-tsts/bd57a02d-e083-4a22-946a-581d939dd6dc); layout/values retained. |
| `OEMTDCONFIG` | [Protocol definition](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-tsts/35230147-7fe0-47d8-93d4-1ace099fa8e0); layout/values retained. |
| `PDPARAMS` | [Protocol definition](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-tsts/ff0e2998-fb8b-4dff-ab64-8427fad556eb) plus native size/offset or conversion/free checks described above. |
| `WDCONFIG` | [Protocol definition](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-tsts/d1bf099b-eb54-4ed9-a723-0b1062dbc128); layout/values retained. |
| `PDCONFIG2` | [Protocol definition](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-tsts/74204022-eb7c-4454-b3d0-24f642c892a4) plus native size/offset or conversion/free checks described above. |
| `WINSTATIONCLIENT` | [Protocol definition](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-tsts/673d8ac0-f557-48cb-98a6-49925160d729) plus native size/offset or conversion/free checks described above. |
| `TSHARE_COUNTERS` | [Protocol definition](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-tsts/9981de84-885c-4ff8-a870-9912a8a5ff12); layout/values retained. |
| `PROTOCOLCOUNTERS` | [Protocol definition](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-tsts/c5d7f335-bfd9-444d-87a5-b0d028a52b5e) plus native size/offset or conversion/free checks described above. |
| `THINWIRECACHE` | [Protocol definition](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-tsts/3adaf1a0-f632-4440-aeca-103d9e4097ea); layout/values retained. |
| `RESERVED_CACHE` | [Protocol definition](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-tsts/9c0c0474-ac36-4315-b0ba-8fca36b5d6e5); layout/values retained. |
| `TSHARE_CACHE` | [Protocol definition](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-tsts/07167f99-bd89-4338-b3c7-7aafcc75334f); layout/values retained. |
| `CACHE_STATISTICS` | [Protocol definition](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-tsts/81203ca2-e58b-4681-affa-924e59671b5c) plus native size/offset or conversion/free checks described above. |
| `PROTOCOLSTATUS` | [Protocol definition](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-tsts/c9066753-acbd-4678-9a72-8fb1b080bd09) plus native size/offset or conversion/free checks described above. |
| `WINSTATIONINFORMATION` | [Protocol definition](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-tsts/ce70794f-2138-43e8-bf6c-2c147887d6a2) plus native size/offset or conversion/free checks described above. |
| `TS_TRACE` | [Protocol definition](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-tsts/ad349575-5369-4830-a174-1920a7af8d5f); layout/values retained. |
| `BEEPINPUT` | [Protocol definition](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-tsts/2faf4c5b-3a79-491a-9d1a-145f46a797d1); layout/values retained. |
| `WINSTATIONUSERTOKEN` | [Protocol definition](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-tsts/07f9831c-6331-43e5-ba27-d3d58772eb4c); layout/values retained. |
| `WINSTATIONVIDEODATA` | [Protocol definition](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-tsts/5f95f657-89d2-472d-b4ab-b0595618dbd1); layout/values retained. |
| `CDCLASS` | [Protocol definition](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-tsts/ad6aac89-0055-4cbf-9868-25cb944fe294); layout/values retained. |
| `CDCONFIG` | [Protocol definition](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-tsts/f88900e1-c159-4f02-b3ae-84f05eec212f); layout/values retained. |
| `WINSTATIONCLIENTDATA` | [Protocol definition](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-tsts/d96b68a3-c0ba-47dd-bd21-9a11d9eae598); layout/values retained. |
| `LOADFACTORTYPE` | [Protocol definition](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-tsts/2d4b1921-a38d-4dea-996c-a4470a0fe9db); layout/values retained. |
| `WINSTATIONLOADINDICATORDATA` | [Protocol definition](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-tsts/ce70794f-2138-43e8-bf6c-2c147887d6a2); layout/values retained. |
| `SHADOWSTATECLASS` | [Protocol definition](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-tsts/c55fbd8f-d7e3-4efe-9ca6-d0985dab9602); layout/values retained. |
| `WINSTATIONSHADOW` | [Protocol definition](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-tsts/5ffd248b-6932-4937-b604-4ca4456e8028); layout/values retained. |
| `WINSTATIONPRODID` | [Protocol definition](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-tsts/42e13db8-6eb3-49d3-a667-62500e568db5); layout/values retained. |
| `WINSTATIONREMOTEADDRESS` | Native address-query and virtual-IP copies; family at 0, port at 4, IPv6 address at 12, scope at 28. |
| `WINSTATIONEXECSRVSYSTEMPIPE` | Inherited 48-WCHAR layout; no producer in the analyzed query paths. Retained without new semantic claims. |
| `WINSTATIONINFORMATIONEX_LEVEL1` | Native information conversion: 1216 bytes; times, names and protocol-status offsets checked. |
| `WINSTATIONINFORMATIONEX_LEVEL2` | No producer found in these clients; retained unchanged, without claiming level-2 runtime validation. |
| `WINSTATIONINFORMATIONEX_LEVEL` | Level-1 member confirmed by native stores; level-2 member retained as inherited. |
| `WINSTATIONINFORMATIONEX` | Native level at 0 and payload at 8; observed level-1 output extent 1224. The union still includes inherited level 2. |
| `TS_PROCESS_INFORMATION_NT4` | Inherited legacy trailer. Current x64 local enumeration does not produce it; no new field semantics asserted. |
| `TS_SYS_PROCESS_INFORMATION` | Native process conversion and field stores; 184/136 bytes. Historical spare fields remain unchanged. |
| `TS_ALL_PROCESSES_INFO` | Native conversion/free paths: pointer, DWORD SID size, SID pointer; 24/12-byte stride. |
| `TS_COUNTER_HEADER` | [Protocol definition](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-tsts/e08317cb-a693-40d3-9a5f-61e14cfdb431) plus native size/offset or conversion/free checks described above. |
| `TS_COUNTER` | [Protocol definition](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-tsts/a0173488-c483-4340-ab1a-aab2d21ea323) plus native size/offset or conversion/free checks described above. |
| `TS_PROPERTY_VALUE` | NDR discriminant/arms plus native free offsets; 24/20 bytes. Detailed correction above. |
| `EXECENVDATAEX_LEVEL1` | [Protocol definition](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-tsts/b4295b0e-c641-40ab-bbdb-ea44323b0804) plus native size/offset or conversion/free checks described above. |
| `EXECENVDATAEX_PAYLOAD` | Single level-1 union; native allocation/free dispatch and published `ExecEnvDataEx` arm agree. |
| `EXECENVDATAEX` | [Protocol definition](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-tsts/0a3f7e7b-03f8-4f62-a65f-c2d670bb3173) plus native size/offset or conversion/free checks described above. |
| `SESSIONTYPE` | [Protocol definition](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-tsts/12510151-f01d-4984-a1bb-64ec4298c31c); association with `TS_USER_SESSION.State` remains inherited. |
| `TS_USER_SESSION` | 20-byte native output and version prefix established; inherited field/enum meanings retained. |
| `SESSION_FILTER` | [Protocol definition](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-tsts/35269584-7c5e-4410-8195-1aa49559274e); layout/values retained. |
| `TS_USER_CERTIFICATES` | RPC certificate metadata and native allocation/free paths; 16/12 bytes. |
| `TS_USER_CREDENTIALS` | Native allocation/copy/clear/free paths; 24/16 bytes. First two DWORD meanings remain unknown. |

### Aliases, macros and GUIDs

The 16 aliases are `TS_TIME_ZONE_INFORMATION`, `WINSTATIONNAME`, `DEVICENAME`, `MODEMNAME`,
`NASISPECIFICNAME`, `NASIUSERNAME`, `NASIPASSWORD`, `NASISESIONNAME`, `NASIFILESERVER`, `WDNAME`,
`WDPREFIX`, `CDNAME`, `DLLNAME`, `PDNAME`, `CLIENTDATANAME` and `PCLIENTDATANAME`.
They retain their existing base types and extents. The time-zone alias is checked through the client
record; the string aliases are checked against the published legacy declarations. The inherited spelling
`NASISESIONNAME` is preserved.

All 97 macros were inventoried. Of these, 65 have same-name counterparts in the
[published legacy header](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-tsts/ce70794f-2138-43e8-bf6c-2c147887d6a2).
Differences in comments, parentheses and hexadecimal zero padding do not change their values.
`LOGONID_CURRENT` retains the inherited signed `-1`; the protocol spells it with an `ULONG` cast.
The native session-ID comparisons use the same 32-bit all-ones pattern. No cast change is needed.

| Macro group | Check |
| --- | --- |
| Current-server aliases and current/any-session selectors | Null and `-1` handling checked per native API; no new universal promise for `-2`. |
| Access masks and composite access expressions | Legacy definitions compared; authorization policy lives on the server. Values retained. |
| Name/password/directory/client/transport length constants, `MAX_BR_NAME`, `MAX_COUNTER_EXTENSIONS`, `MAX_THINWIRECACHE` | Legacy definitions and corresponding array extents compared; inherited unused constants retained. |
| `TERMSRV_*` counter IDs | IDs `1..12`, native counted-array path and previous VM counter results; names retained. |
| `PROTOCOL_*`, NT4 process magic and legacy size constants | Legacy definitions/conversion paths reviewed; legacy sizes are not substituted for native x64 record sizes. |
| `WSD_*`, `WEVENT_*`, `KBD*` | Legacy definitions and native forwarding/conversion reviewed; ignored modern mask bits are not renumbered. |
| `WNOTIFY_*`, `WINSTATION_PROCESS_LEVEL`, `TS_PROPERTY_TYPE_*` | Native flag/level checks and NDR union arms; property values `1..4` also constrained by the free path. |

The two inherited `PROPERTY_TYPE_*` GUID constants are preserved. Neither appears in the analyzed
client image, and the APIs forward caller-supplied GUIDs. That absence supplies no evidence for changing
their numeric values or assigning a new payload contract.

## Validation

### Compile, layout and linkage

- Full NDK solution, `Debug`: x64, x86, ARM64 and ARM64EC.
- All 88 declarations referenced in separate C and C++ translation units and linked against SDK
  `10.0.28000.0` `WinSta.lib`, for all four architectures: eight NDK builds and eight phnt builds.
- phnt probes include `phnt_windows.h`, `phnt.h`, and `winsta.h` within C linkage; compiler warnings are errors.
- Compile-time assertions cover enumeration, configuration/client, process/session, counter, virtual-IP,
  property and credential sizes and offsets. ARM64EC follows the repository's x64 import-library convention.
- The full System Informer x64 build is blocked before compilation by this checkout's missing
  `CustomBuildTool.exe`. The independent phnt compile/link checks pass; they are not reported as a full
  System Informer build.

ARM64 and ARM64EC results establish compiler layout and linkage only. Their DLL implementations were not
disassembled or executed.

### VM execution

Probes ran on the Windows `28000.2605` Hyper-V guest as `S-1-5-18` (`SYSTEM`), integrity RID `16384`, session
`0`, desktop `Default`. Private DLLs were loaded from a test directory; guest system DLLs were not replaced.
This is a service-session test context, not a remote interactive session.

| Client sample | Broad probe result |
| --- | --- |
| A: x64 `26100.6899`, matching IDB | One caught `RPC_X_BAD_STUB_DATA` exception from `WinStationActiveSessionExists`; other probes completed. |
| B: x86 `26100.8972` | No harness-detected error. |
| C: x64 `26100.8972` | No harness-detected error. |
| D: native x64 `28000.2605` | No harness-detected error. |
| E: native x86 `28000.2605` | No harness-detected error. |

An expected API rejection counts as a checked failure path, not successful feature operation. Guarded
buffers, raw return-register capture and x86 stack checks were used to distinguish byte results, DWORD
outputs, required sizes, pointer depth and overwrites. No guard damage or x86 stack imbalance was observed.

The checked operations include:

- General information classes `0..42`; targeted current-session classes `1`, `6`, `8`, `39`; exact and
  undersized capacities, required lengths and guard preservation.
- Configuration/PD setters with class `1`/`2`, null buffer and zero length. Both IDB control flows reject
  these classes without reading the buffer or reaching RPC; all five clients return byte `FALSE` and error `1`.
- ANSI/wide session enumeration, extended session enumeration, process enumeration with the probe's own
  process identified, matching frees, user-session enumeration and counters `1..12`.
- One-byte state outputs versus the four-byte active-session output; four valid property variants and
  their local release paths; own-event and own-window notification registration/release.
- Profile handle probes, virtual-IP/device queries, and credential/property queries. Their failed outputs
  constrain error behavior but do not establish an unavailable payload's contents.

Sample A's `WinStationActiveSessionExists` raises exception `0x000006F7` (`RPC_X_BAD_STUB_DATA`) with the
output canary untouched. The cause is not established; running this older client against a newer server
does not by itself prove a version mismatch is responsible. Its successful output path remains untested.
The retained `PBOOL` declaration instead has independent NDR evidence and successful four-byte writes in
samples B through E. The function's byte return is independently visible in both IDBs.

The repository's `WinSta` unit test ran against guest-native x64 and x86 DLLs: **25 passed, 0 failed, 0 skipped
on each architecture**. It uses local allocations/releases, a query rejected before RPC, and read-only state
queries. It does not change logon, child-session, shutdown, rendering, or service configuration.

The guest was restored to its pre-run checkpoint and powered off. The temporary checkpoint was removed;
the original disk attachments and SYSTEM hive were verified restored, test files were absent, and no VHD
remained mounted. No guest accounts or credentials were created. No private WinSta API probe ran on the
physical host.

## Limits and intentionally retained uncertainty

- `TS_USER_SESSION.State` and its `SESSIONTYPE` type are retained. Copying a DWORD does not disprove the
  inherited enum. There is no new claim that every legacy field meaning or constant was recovered from
  these clients; many are copied unchanged or have no producing path.
- `WinStationGetUserProfile` retains `HANDLE Unknown0`. A valid token reached `E_NOINTERFACE`; invalid
  handles and process-handle probes produced handle/object-type errors. No successful profile result
  established a required token subtype or access mask.
- No successful virtual-IP, device-ID, monitor/correlation property, certificate, or credential payload
  was available in this service context. Their accepted types rely on native/NDR layout and release paths.
- Child-session mutation, autologon, shutdown, desktop locking, shadowing and remote logon/rendering were
  not invoked to manufacture coverage. Declarations for those operations rely on the static evidence.
- Existing property GUID constants are preserved. The client forwards GUIDs and does not contain those
  two values, so their absence is not evidence that they are wrong.
- Unknown DWORD/string fields remain `UnknownN`. Exports with only a stub, constant return, ambiguous
  aggregate ABI or unresolved pointer contract were not added. In particular, no single-pointer signature
  was inferred for `_WinStationWaitForConnectEx` from x64 alone; x86 consumes `16` argument bytes.
- Correcting the property and virtual-IP definitions necessarily breaks source code built around those
  incorrect private layouts. Keeping the undersized/incorrect types as aliases would preserve unsafe
  usage. Export names and linkage are unchanged.

Assisted by Codex.
